### PR TITLE
Rework issue templates: leaner, diagnostics-first bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
       required: true
     attributes:
       label: What happened?
-      description: A clear and concise description of the problem. Tell us what you did, what happened, and what you expected to happen instead.
+      description: A clear and concise description of the problem. Tell us what you did, what happened, and what you expected to happen instead. If it relates to a specific music provider or player, please name it here.
 
   - type: textarea
     id: reproduce
@@ -82,15 +82,6 @@ body:
 
         Please **attach the file** — do not paste its contents. If you really can't provide either, explain why.
       placeholder: Drag & drop your diagnostics report (or log file) here.
-
-  - type: input
-    id: providers
-    validations:
-      required: false
-    attributes:
-      label: Affected provider(s)
-      description: Which music or player providers are involved? This helps us route your issue to the right maintainer.
-      placeholder: e.g. Spotify, Sonos, AirPlay
 
   - type: textarea
     id: additional

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,202 +1,101 @@
-name: Report a Bug in Music Assistant
-description: Report an issue with Music Assistant.
+name: 🐛 Bug report
+description: Report a bug or problem with the Music Assistant server.
 labels: ["triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        This issue form is for reporting bugs only!
-        If you are using AI to assist you with this report then please read the [AI Policy][ai]
-        Read this for what you MUST include [Troubleshooting][ft]
-        For questions read our [FAQ section][fq] or visit our community on [Discord][cf].
-        If you have a feature or enhancement request, please enter them in our discussions section [feature request][fr]
+        Thanks for taking the time to report a bug!
 
-        [fq]: https://github.com/orgs/music-assistant/discussions/categories/q-a
-        [cf]: https://discord.com/channels/753947050995089438/753947050995089442
-        [fr]: https://github.com/orgs/music-assistant/discussions/categories/feature-requests-and-ideas
-        [ft]: https://music-assistant.io/faq/troubleshooting/
-        [ai]: https://github.com/music-assistant/.github/blob/main/AI_POLICY.md
+        This form is for **bugs in the Music Assistant server** (playback, providers, players, the core).
+        - Questions & how-to → [Q&A discussions](https://github.com/music-assistant/support/discussions/categories/q-a) or [Discord](https://discord.gg/kaVm8hGpne)
+        - Feature requests → [Feature requests & ideas](https://github.com/music-assistant/support/discussions/categories/feature-requests-and-ideas)
+        - A frontend/UI-only glitch → use the **Frontend/UI bug report** form instead
 
-  - type: input
-    id: version_MA
-    validations:
-      required: true
-    attributes:
-      label: What server version of Music Assistant has the issue?
-      placeholder: 2.8.0
-      description: >
-        Can be found in: MA SETTINGS>> ABOUT
-        For example: 2.9.0b10
-
-  - type: dropdown
-    validations:
-      required: true
-    attributes:
-      label: How is the MA server installed?
-      description: |
-        Can be found in: [Settings >> About](https://my.home-assistant.io/redirect/info/).
-
-        [![Open your Home Assistant instance and show your Home Assistant version information.](https://my.home-assistant.io/badges/info.svg)](https://my.home-assistant.io/redirect/info/)
-      options:
-        - Home Assistant OS Addon
-        - Docker Container
-        - Other - Please do not select this or file a report as support is only available for the above two options
+        Please fill this out in English and keep it short — the diagnostics report below covers most of what we need.
 
   - type: checkboxes
-    validations:
-      required: true
     attributes:
-      label: "Mandatory: Carefully read the Troubleshooting FAQ and confirm that"
-      description: |
-        If you tick a box that you haven't done then clearly state that and explain why in the report
+      label: Before you begin
+      description: Please confirm the following. If a box doesn't apply, explain why further down.
       options:
-        - label: "I have examined the logs and tried to resolve this issue"
+        - label: I have searched the [open and closed issues](https://github.com/music-assistant/support/issues?q=is%3Aissue) and this hasn't been reported yet.
           required: true
-        - label: "I have fixed any errors or warnings in the logs that relate to tags"
+        - label: I have read the [troubleshooting guide](https://www.music-assistant.io/faq/troubleshooting/) and it did not solve my problem.
           required: true
-        - label: "I am not running MA across a VPN, VLAN, subnet, behind a firewall, or using local SSL or have any other complex network setup"
+        - label: I am running a [supported installation](https://www.music-assistant.io/installation/) (Home Assistant add-on or Docker container).
           required: true
-        - label: "I am not using or have disabled tools such as AdGuard, Pi-hole or pfSense and retested"
-          required: true
-        - label: "I have checked my network setup to ensure mDNS/multicast is not being blocked"
-          required: true
-        - label: I have reviewed the [Open](https://github.com/music-assistant/support/issues) and [Closed](https://github.com/music-assistant/support/issues?q=is%3Aissue%20state%3Aclosed) Issues and [Discussions](https://github.com/orgs/music-assistant/discussions)
-          required: true
-        - label: "I have reviewed the applicable [player](https://www.music-assistant.io/player-support/) or [music provider](https://www.music-assistant.io/music-providers/) documentation"
-          required: true
-        - label: "I have reviewed the [MA Status Page](https://github.com/orgs/music-assistant/discussions/709)"
-          required: true
-        - label: "I have tried restarting MA and rebooting the host"
-          required: true
-  - type: checkboxes
-    attributes:
-      label: "As Applicable: Carefully read the Troubleshooting FAQ and confirm that"
-      description: |
-        If you don't tick a box and it is applicable, then clearly state that and explain why in the report
-      options:        
-        - label: "If using HA, I have confirmed the internal URL is set correctly"
-          required: false
-        - label: "I have tried a wired connection for issues related to interrupted or poor playback quality"
-          required: false
-        - label: "If the problem relates to a device then I have checked the device settings"
-          required: false
-        - label: "If it is a frontend issue, I have tried a different widely used browser"
-          required: false
-        - label: "For voice problems, I have sought help elsewhere before returning here"
-          required: false
-        - label: "For playback problems, I have recycled power to the physical device"
-          required: false
 
   - type: textarea
+    id: what_happened
     validations:
       required: true
     attributes:
-      label: The problem
-      description: |
-        Please give a clear and concise description of the issue you are experiencing here,
-        to communicate to the maintainers. Tell us what you were trying to do and what happened. Detail what you have tried from the troubleshooting page in the docs that hasn't helped.
+      label: What happened?
+      description: A clear and concise description of the problem. Tell us what you did, what happened, and what you expected to happen instead.
 
   - type: textarea
+    id: reproduce
     validations:
       required: true
     attributes:
       label: How to reproduce
-      description: |
-        Describe the least amount of steps possible to reproduce your error
-
-  - type: textarea
-    validations:
-      required: true
-    attributes:
-      label: Music Providers
-      description: |
-        List the music providers that you have tried which result in the problem. ALSO list the music providers you have tried that don't show the problem. Do not just list the providers you have installed.
-
-  - type: textarea
-    validations:
-      required: true
-    attributes:
-      label: Player Providers
-      description: |
-        List the player providers that you have tried which result in the problem. ALSO list the player providers you have tried that don't show the problem. Also indicate if you are trying to play to grouped players. Do not just list the providers you have installed.
-
-  - type: textarea
-    validations:
-      required: true
-    id: logs
-    attributes:
-      label: Full log output
-      placeholder: DO NOT PASTE the log here. ATTACH IT. Your issue will not be reviewed if this is not done as requested.
-      description: |
-        Please DOWNLOAD then DRAG and DROP the full log output from MA SETTINGS>> SYSTEM>> SERVER LOGGING into the field below. Do NOT use Verbose logging unless asked to do so.
-
-  - type: textarea
-    validations:
-      required: true
-    attributes:
-      label: Additional information
-      placeholder: For Audiobookshelf include broken book ASINs here
-      description: |
-        Supply additional information requested which is not captured above, specifically the information requested in the troubleshooting page of the docs. Include how the playback is being instigated if that makes a difference (ie. via the UI or via HA service call), what you have tried from the troubleshooting FAQ and detail what is working so it is clear you have narrowed down the problem. Additionally, if you aren't running HAOS or have an unusual network setup provide details about that.
-
-  - type: markdown
-    attributes:
-      value: |
-        ## Environment
+      description: The minimal steps needed to trigger the problem.
+      placeholder: |
+        1. Go to '...'
+        2. Play '...'
+        3. See error
 
   - type: input
-    id: version_HA
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: Music Assistant version
+      description: Found in **Settings → About**.
+      placeholder: e.g. 2.9.6 or 2.10.0b5
+
+  - type: dropdown
+    id: install_type
+    validations:
+      required: true
+    attributes:
+      label: How do you run Music Assistant?
+      description: Only the Home Assistant add-on and Docker container installs are supported.
+      options:
+        - Home Assistant add-on
+        - Docker container
+        - Other (unsupported)
+
+  - type: textarea
+    id: diagnostics
+    validations:
+      required: true
+    attributes:
+      label: Diagnostics report or log file
+      description: |
+        Please attach a **diagnostics report** — it contains everything we need (versions, platform, providers and their error states, and an optional log excerpt) and is privacy-sanitized, so it is safe to share publicly.
+
+        - **Music Assistant 2.10 or newer:** go to **Settings → Download diagnostics** and drag the `music-assistant-diagnostics-<date>.json` file into the box below.
+        - **Music Assistant 2.9.6 or newer** (no button yet): while logged in as admin, browse to `http://<your-ma-host>:8095/diagnostics?include_log_tail=true` (when you open MA through Home Assistant, just add `/diagnostics?include_log_tail=true` to the address instead), save the file and drag it in below.
+        - **Older than 2.9.6:** attach your full server log instead, from **Settings → System → Server Logging**.
+
+        Please **attach the file** — do not paste its contents. If you really can't provide either, explain why.
+      placeholder: Drag & drop your diagnostics report (or log file) here.
+
+  - type: input
+    id: providers
     validations:
       required: false
     attributes:
-      label: What version of Home Assistant Core (if used) are your running
-      placeholder: HA version
-      description: |
-        Can be found in: [HA Settings -> About](https://my.home-assistant.io/redirect/info/).
-        For example: 2026.2.0
-        [![Open your Home Assistant instance and show your Home Assistant version information.](https://my.home-assistant.io/badges/info.svg)](https://my.home-assistant.io/redirect/info/)
+      label: Affected provider(s)
+      description: Which music or player providers are involved? This helps us route your issue to the right maintainer.
+      placeholder: e.g. Spotify, Sonos, AirPlay
 
-  - type: dropdown
+  - type: textarea
+    id: additional
     validations:
-      required: true
+      required: false
     attributes:
-      label: What type of installation are you running?
-      description: |
-        Can be found in: [HA Settings -> About](https://my.home-assistant.io/redirect/info/).
-
-        [![Open your Home Assistant instance and show your Home Assistant version information.](https://my.home-assistant.io/badges/info.svg)](https://my.home-assistant.io/redirect/info/)
-      options:
-        - Home Assistant OS
-        - Home Assistant Container
-        - Other - Please do not select this as support is only available for the above two options
-
-  - type: dropdown
-    validations:
-      required: true
-    attributes:
-      label: On what type of hardware are you running?
-      description: |
-        Can be found in: [HA Settings -> System -> Hardware](https://my.home-assistant.io/redirect/hardware/).
-
-        [![Open your Home Assistant instance and show your hardware information.](https://my.home-assistant.io/badges/hardware.svg)](https://my.home-assistant.io/redirect/hardware/)
-      options:
-        - Raspberry Pi
-        - ODROID
-        - ASUS Tinkerboard
-        - Generic x86-64 (e.g. Intel NUC)
-        - Windows
-        - macOS
-        - Linux
-        - Proxmox
-        - Alternative
-
-  - type: checkboxes
-    validations:
-      required: true
-    attributes:
-      label: Have you included ALL of the information specified in the Troubleshooting FAQ or explained why you cannot
-      description: |
-        Failing to provide all the requested information slows down the resolution process and creates unnecessary work for those trying to help. We are a small team, we need you to help us to help you by submitting succinct but comprehensive reports
-      options:
-        - label: "Yes"
-          required: true
+      label: Anything else?
+      description: Screenshots, an unusual network setup, whether playback is triggered from the UI or a Home Assistant action, or anything else that might help.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,9 +76,8 @@ body:
       description: |
         Please attach a **diagnostics report** — it contains everything we need (versions, platform, providers and their error states, and an optional log excerpt) and is privacy-sanitized, so it is safe to share publicly.
 
-        - **Music Assistant 2.10 or newer:** go to **Settings → Download diagnostics** and drag the `music-assistant-diagnostics-<date>.json` file into the box below.
-        - **Music Assistant 2.9.6 or newer** (no button yet): while logged in as admin, browse to `http://<your-ma-host>:8095/diagnostics?include_log_tail=true` (when you open MA through Home Assistant, just add `/diagnostics?include_log_tail=true` to the address instead), save the file and drag it in below.
-        - **Older than 2.9.6:** attach your full server log instead, from **Settings → System → Server Logging**.
+        - Go to **Settings → Download diagnostics**, then drag the downloaded `music-assistant-diagnostics-<date>.json` file into the box below.
+        - **Don't see that button?** You're on an older version — attach your full server log instead, from **Settings → System → Server Logging**.
 
         Please **attach the file** — do not paste its contents. If you really can't provide either, explain why.
       placeholder: Drag & drop your diagnostics report (or log file) here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,23 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Music Assistant Q&A section.
+  - name: 📖 Documentation & troubleshooting
+    url: https://www.music-assistant.io/faq/troubleshooting/
+    about: Start here! Most problems are solved by the troubleshooting guide.
+  - name: 💬 Discord community & support
+    url: https://discord.gg/kaVm8hGpne
+    about: Chat with the community and get help from other users.
+  - name: ❓ Questions & how-to (Q&A)
     url: https://github.com/music-assistant/support/discussions/categories/q-a
-    about: Please ask and answer questions here.
-  - name: Music Assistant community on Discord.
-    url: https://discord.com/channels/753947050995089438/753947050995089442
-    about: For questions and sharing with other users.
-  - name: Music Assistant new features section.
+    about: Ask how-to questions and search previous answers.
+  - name: 💡 Feature requests & ideas
     url: https://github.com/music-assistant/support/discussions/categories/feature-requests-and-ideas
-    about: If you have a feature or enhancement request.
+    about: Suggest and vote on new features and enhancements.
+  - name: 📱 Music Assistant mobile app (Android / iOS)
+    url: https://github.com/music-assistant/mobile-app/issues/new/choose
+    about: For MA's own (beta) mobile app only — NOT the Home Assistant Companion app and NOT the web interface.
+  - name: 🖥️ Music Assistant desktop app
+    url: https://github.com/music-assistant/desktop-app/issues/new/choose
+    about: For the Music Assistant companion desktop app.
+  - name: 🏠 Home Assistant integration
+    url: https://github.com/home-assistant/core/issues/new?template=bug_report.yml
+    about: For controlling MA from Home Assistant (entities/services). Pick "Music Assistant" as the integration. NOT for MA server bugs.

--- a/.github/ISSUE_TEMPLATE/frontend_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/frontend_bug_report.yml
@@ -1,0 +1,70 @@
+name: 🖥️ Frontend/UI bug report
+description: Report a visual or user-interface bug in the Music Assistant web app.
+labels: ["triage", "frontend"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a frontend issue!
+
+        This form is **only** for visual/UI bugs in the Music Assistant web interface — layout glitches, broken buttons, styling, display errors, etc.
+        - Playback, provider, player or server problems → use the **Bug report** form instead (it asks for a diagnostics report).
+        - Mobile app or desktop app issues → use their own repositories.
+        - Questions → [Q&A](https://github.com/music-assistant/support/discussions/categories/q-a) or [Discord](https://discord.gg/kaVm8hGpne).
+
+        A screenshot or screen recording is the most useful thing you can give us here.
+
+  - type: input
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: Music Assistant version
+      description: Found in **Settings → About**.
+      placeholder: e.g. 2.9.6 or 2.10.0b5
+
+  - type: input
+    id: browser_os
+    validations:
+      required: true
+    attributes:
+      label: Browser and operating system
+      description: Which browser (and version) and OS/device are you using?
+      placeholder: e.g. Chrome 125 on Windows 11, or Safari on iPad
+
+  - type: textarea
+    id: what_happened
+    validations:
+      required: true
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the visual/UI problem and what you expected to see instead.
+
+  - type: textarea
+    id: reproduce
+    validations:
+      required: true
+    attributes:
+      label: How to reproduce
+      description: The minimal steps needed to see the problem.
+      placeholder: |
+        1. Open '...'
+        2. Click '...'
+        3. Notice '...'
+
+  - type: textarea
+    id: screenshot
+    validations:
+      required: true
+    attributes:
+      label: Screenshot or recording
+      description: Drag & drop a screenshot or short screen recording that shows the problem.
+      placeholder: Drag & drop your screenshot or recording here.
+
+  - type: textarea
+    id: additional
+    validations:
+      required: false
+    attributes:
+      label: Anything else?
+      description: Anything else that might help — browser console errors, whether it happens on other devices, etc.

--- a/.github/ISSUE_TEMPLATE/translation_contribute.yml
+++ b/.github/ISSUE_TEMPLATE/translation_contribute.yml
@@ -1,5 +1,5 @@
-name: "Translation Request Music Assistant."
-description: "Contribute to Music Assistant with a translation."
+name: 🌍 Translation contribution
+description: Offer to help translate Music Assistant into a new language.
 labels: ["triage", "translation"]
 assignees:
   - jozefKruszynski
@@ -7,8 +7,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        This issue form is for contributions to translations only!
-        More information on the process can be found in the discussions [see here][lc]
+        This form is for offering to contribute a translation.
+        Please read how the process works in [this discussion][lc] first.
 
         [lc]: https://github.com/orgs/music-assistant/discussions/1216
   - type: dropdown
@@ -17,17 +17,17 @@ body:
     attributes:
       label: Which project is the translation for?
       options:
-        - MA Frontend
-        - MA Mobile App
+        - Frontend (web app)
+        - Mobile app
   - type: input
     id: new_language
     validations:
       required: true
     attributes:
       label: New language
-      placeholder: klingon
+      placeholder: Klingon
       description: >
-        New language to contribute with
+        The language you'd like to contribute.
   - type: textarea
     id: additional_remarks
     validations:
@@ -35,4 +35,4 @@ body:
     attributes:
       label: Additional remarks
       description: |
-        Optional
+        Anything else you'd like to add (optional).


### PR DESCRIPTION
## Problem

Our bug report form had grown into an interrogation: 15 mandatory checkboxes, six required free-text sections and a stack of Home Assistant/hardware questions. It was intimidating to fill in, most of it duplicated information we can read from a diagnostics report, and it still produced low-signal reports. The template chooser in front of it was thin and didn't steer people toward the right place, so reports for the mobile app, desktop app and the Home Assistant integration all landed here.

Now that the server produces a downloadable, privacy-sanitized **diagnostics report** (versions, platform, providers and their error states, aggregated errors and an optional log excerpt), the form can lean on that instead of asking for everything by hand.

## Changes

- **Reworked the bug report form** to be short and diagnostics-first: what happened / how to reproduce, MA version, install type, and a single required **diagnostics report** upload. The hint covers every version — Settings → Download diagnostics (2.10+), the `/diagnostics` URL (2.9.6+, also over HA ingress), or the full server log for older versions. Replaced the 15-checkbox wall with one compact 3-item confirmation.
- **Added a dedicated Frontend/UI bug report form** — a lightweight, screenshot-focused form for visual/interface bugs in the web app, so they don't have to go through the full server bug form.
- **Expanded the template chooser (`config.yml`)** with clear links that keep non-bug reports out of the tracker: troubleshooting docs, Discord, Q&A, feature requests, the mobile app repo (with a note that it's MA's own beta app, not the HA Companion app or the web UI), the desktop app repo, and the Home Assistant integration (redirected to home-assistant/core). Also fixed the Discord link, which pointed at a members-only channel.
- **Refreshed the translation contribution form** wording (no functional changes).

The triage bot's validation is being updated to match the new section names in a separate change.