### PR TITLE
Fix triage test suite: commit log fixture excluded by .gitignore

### DIFF
--- a/.github/scripts/tests/fixtures/sample.log
+++ b/.github/scripts/tests/fixtures/sample.log
@@ -1,0 +1,29 @@
+2024-05-01 12:00:00 INFO (MainThread) [music_assistant] Starting Music Assistant 2.8.1 (schema 1)
+2024-05-01 12:00:00 INFO (MainThread) [music_assistant] Running from /home/frank/.mass on Linux
+2024-05-01 12:00:01 WARNING (MainThread) [music_assistant] Starting in SAFE MODE after a previous crash
+2024-05-01 12:00:02 DEBUG (MainThread) [aiohttp] Authorization: Bearer sk-abcdef0123456789ABCDEF
+2024-05-01 12:00:02 DEBUG (MainThread) [config] api_key=super-secret-value-1234 loaded
+2024-05-01 12:00:02 DEBUG (MainThread) [config] token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payloadpart.signature
+2024-05-01 12:00:03 INFO (MainThread) [net] contacting api at 8.8.8.8 from 192.168.1.50 (mac aa:bb:cc:dd:ee:ff)
+2024-05-01 12:00:03 INFO (MainThread) [account] registered to frank@example.com
+2024-05-01 12:00:05 ERROR (MainThread) [music_assistant.providers] Error setting up provider sonos
+2024-05-01 12:00:06 ERROR (MainThread) [music_assistant.providers] Failed to set up spotify provider
+2024-05-01 12:00:07 ERROR (MainThread) [music_assistant] Unhandled exception in event loop
+Traceback (most recent call last):
+  File "/home/frank/.mass/app.py", line 42, in run
+    do_thing()
+  File "/home/frank/.mass/thing.py", line 7, in do_thing
+    raise ValueError("bad state 12345")
+ValueError: bad state 12345
+2024-05-01 12:00:08 ERROR (MainThread) [music_assistant] Unhandled exception in event loop
+Traceback (most recent call last):
+  File "/home/frank/.mass/app.py", line 42, in run
+    do_thing()
+  File "/home/frank/.mass/thing.py", line 7, in do_thing
+    raise ValueError("bad state 67890")
+ValueError: bad state 67890
+2024-05-01 12:00:09 ERROR (MainThread) [music_assistant] Timer failed
+Traceback (most recent call last):
+  File "/home/frank/.mass/timer.py", line 3, in tick
+    conn.send()
+ConnectionResetError: [Errno 104] Connection reset by peer

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 *.log
 *.tmp
 .cache/
+
+# Keep triage test log fixtures (excluded by the *.log rule above)
+!/.github/scripts/tests/fixtures/*.log


### PR DESCRIPTION
## Problem

The triage bot's offline test suite references `.github/scripts/tests/fixtures/sample.log`, but the repo-root `.gitignore` rule `*.log` silently excluded it — so it was never committed alongside the bot. On a **clean checkout** the raw-log tests can't find the fixture and error out (**109 pass, 8 error**) instead of the intended full green.

## Changes

- Add the `sample.log` test fixture (a synthetic log with planted fake secrets, used by the log-redaction tests).
- Add a targeted `.gitignore` negation (`!/.github/scripts/tests/fixtures/*.log`) so triage test log fixtures are tracked while the general `*.log` rule stays in place.

Result: the full offline suite is green (**117 passed**) on a clean checkout.