### PR TITLE
Improve triage reply when a screenshot is pasted instead of diagnostics

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -71,10 +71,11 @@ def build_result(
     result.missing_sections = template.missing_sections(body, kind)
     result.log_wall_detected = template.detect_log_wall(body)
     result.reported_version = template.extract_version(body)
+    result.has_media_attachment = has_media_attachment(body)
 
     if kind == "frontend":
         # UI bug: the required "attachment" is a screenshot/recording.
-        result.missing_attachment = not has_media_attachment(body)
+        result.missing_attachment = not result.has_media_attachment
         return result
 
     # --- main server bug form ------------------------------------------------

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -201,10 +201,18 @@ def build_body(result: TriageResult) -> str:
                 f"To help us look into this, could you fill in the following "
                 f"section(s) of the report: {pretty}?\n"
             )
-        parts.append(
-            "It would also really help if you could attach a **diagnostics "
-            "report or log file**. " + _DIAGNOSTICS_HOWTO
-        )
+        if result.has_media_attachment:
+            # Reporter pasted a screenshot/image instead of the actual file.
+            parts.append(config.SCREENSHOT_ATTACHMENT_NOTE + " " + _DIAGNOSTICS_HOWTO)
+        else:
+            lead = (
+                "It would also really help if you could attach"
+                if result.missing_sections
+                else "Could you attach"
+            )
+            parts.append(
+                f"{lead} a **diagnostics report or log file**? " + _DIAGNOSTICS_HOWTO
+            )
         # Even without a file we can still nudge on an outdated version, etc.
         if result.findings:
             parts.append("")

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -284,3 +284,13 @@ FRONTEND_MISSING_MESSAGE = (
     "a **screenshot or short screen recording** that shows the problem, plus the "
     "steps to reproduce it? That's by far the most useful thing for frontend bugs."
 )
+
+# Main form: reporter pasted a screenshot/image into the diagnostics field
+# instead of attaching the actual diagnostics report or log file.
+SCREENSHOT_ATTACHMENT_NOTE = (
+    "👀 It looks like you pasted a **screenshot** in the *Diagnostics report or "
+    "log file* section. I can't read logs from an image — and a partial "
+    "screenshot usually doesn't include enough to go on. Could you attach the "
+    "actual **diagnostics report** (a `.json` file) or your **full log file** "
+    "instead?"
+)

--- a/.github/scripts/ma_triage/models.py
+++ b/.github/scripts/ma_triage/models.py
@@ -135,6 +135,9 @@ class TriageResult:
     # The attachment the form asked for is missing (diagnostics/log for the main
     # form, a screenshot/recording for the frontend form).
     missing_attachment: bool = False
+    # A screenshot/image was attached (used to spot reporters who paste a
+    # screenshot of a log into the main form's diagnostics field).
+    has_media_attachment: bool = False
     missing_sections: list[str] = field(default_factory=list)
     log_wall_detected: bool = False
 

--- a/.github/scripts/tests/test_comment.py
+++ b/.github/scripts/tests/test_comment.py
@@ -35,6 +35,28 @@ def test_build_body_invalid():
     assert "couldn't read it" in body or "regenerate" in body
 
 
+def test_build_body_screenshot_instead_of_diagnostics():
+    # Main form, all sections filled, but a screenshot was pasted in the
+    # diagnostics field instead of the actual file (issue #5815 pattern).
+    result = TriageResult(
+        form_kind="main",
+        missing_attachment=True,
+        has_media_attachment=True,
+        missing_sections=[],
+    )
+    body = comment.build_body(result)
+    assert "screenshot" in body.lower()
+    assert "Download diagnostics" in body  # still points to the how-to
+
+
+def test_build_body_no_attachment_no_screenshot():
+    # No attachment at all → generic ask, and no misleading screenshot note.
+    result = TriageResult(form_kind="main", missing_attachment=True)
+    body = comment.build_body(result)
+    assert "diagnostics report or log file" in body
+    assert "screenshot" not in body.lower()
+
+
 def test_build_body_frontend_missing():
     result = TriageResult(
         form_kind="frontend", missing_attachment=True, missing_sections=[]


### PR DESCRIPTION
## Problem

Reporters sometimes fill in the bug form correctly but paste a **screenshot** of a (often partial) log into the *Diagnostics report or log file* field instead of attaching the actual diagnostics report or log file (e.g. #5815). The triage bot already correctly declines to treat the image as valid input and asks for the file — but with a generic message that doesn't tell the reporter what they did wrong.

## Changes

- Detect when the main bug form has an image/screenshot attached but no usable diagnostics report or log file, and reply with a specific, friendly note explaining that logs can't be read from an image and asking for the actual `.json` diagnostics report or full log file.
- Keep the generic ask for the case where nothing was attached at all.
- Track `has_media_attachment` on the triage result; add tests for both the screenshot and the no-attachment cases.

Runs behind the existing dry-run/AI flags; no behavior change when a valid file is attached.