### PR TITLE
Add docs-grounded answers & similar-issue detection to the triage bot

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -26,6 +26,7 @@ never interpolated into a shell command.
 ├── workflows/
 │   ├── triage.yml            # issues opened/edited/reopened + new comments
 │   ├── triage_scheduled.yml  # daily reminder / auto-close sweep
+│   ├── docs_embeddings.yml   # nightly RAG index build (docs + posts)
 │   └── copilot_dispatch.yml  # hand a bug to the Copilot coding agent
 └── scripts/
     ├── ma_triage/            # the bot (see module docstrings)
@@ -39,7 +40,10 @@ The bot branches on the issue form (detected from labels):
 - **frontend bug** (`triage`, `frontend`): checks a screenshot/recording is
   attached and required fields are filled — stays silent when the report is
   complete;
-- **translation** (`triage`, `translation`): skipped entirely.
+- **translation**: translation contributions are moving to a GitHub **Discussion**
+  (via a contact link in the issue chooser) rather than an issue form, so no
+  issue carries a `translation` label anymore. The label-based skip guard is kept
+  as a harmless safety net.
 
 ### Tier 0 — deterministic (always on)
 From the diagnostics file the bot derives, with no AI:
@@ -73,6 +77,38 @@ A maintainer applies the `triage/dispatch-copilot` label (or runs the dispatch
 workflow manually) to hand the bug to the Copilot coding agent on the server
 repo. See **Copilot dispatch token** below.
 
+### Docs-grounded answers & similar reports (Phase 2, optional)
+When `TRIAGE_AI_ENABLED=true` (and `TRIAGE_RAG_ENABLED` is not `false`), the bot
+adds a **retrieval-augmented** layer on top of the tiers above, modelled on
+`zwave-js-bot`:
+
+- **Docs Q&A.** The incoming issue is embedded once and matched against an index
+  of the public docs (`music-assistant/music-assistant.io`, chunked by heading).
+  Retrieval is hybrid and entirely local — dense cosine **plus** BM25 over the
+  breadcrumbs+body, fused with Reciprocal Rank Fusion — so exact tokens (provider
+  domains, error codes) are not lost. The top chunks and the issue go to a single
+  judge call that returns `{answers_question, confidence, answer, cited_sections}`.
+- **Similar past reports.** The issue embedding is compared (dense cosine) to an
+  index of past issues + discussions to surface likely duplicates / prior answers.
+  If the index is missing, this degrades to a plain GitHub issue search.
+  Translation-category discussions are excluded from this index (they aren't
+  docs-answerable and would only add noise). Live triage of discussions
+  themselves is out of scope for this phase.
+- **Confidence tiers.** `HIGH` (≥ `TRIAGE_ANSWER_HI`) posts a doc-grounded answer
+  with cited links; `MEDIUM` (≥ `TRIAGE_ANSWER_LO`) posts doc links only;
+  `LOW` stays silent (deterministic triage and duplicate links may still post).
+  An answer matching a previously down-voted (`suppress.json`) fingerprint is
+  demoted a tier.
+- **Cost.** Per issue: **1 embedding + ≤1 judge chat**, only when AI is enabled.
+  Indexing runs nightly, cached by content SHA (unchanged chunks are never
+  re-embedded) and skips on rate-limit. All output is rendered as extra sections
+  in the same sticky comment, and everything echoed is sanitized.
+
+The two indexes (`docs.json`, `posts.json`) and the down-vote fingerprints
+(`suppress.json`) are stored as JSON on an orphan **`triage-index`** branch
+(keeping `main` clean) and read at runtime. When they are absent the whole layer
+degrades gracefully and Tier-0/Tier-1 behaviour is unchanged.
+
 ## Response-state lifecycle
 
 | Trigger | Effect |
@@ -104,6 +140,30 @@ Maintainer override labels: `triage/hold` (pause automation), `triage/skip`
 | `TRIAGE_COPILOT_AUTO` | `false` | Allow auto-recommending Tier-2 dispatch. |
 | `TRIAGE_COPILOT_AUTO_DAILY_CAP` | `3` | Max auto dispatches/day. |
 | `TRIAGE_COPILOT_AUTO_MIN_CONFIDENCE` | `0.75` | Min AI confidence to auto-dispatch. |
+| `TRIAGE_RAG_ENABLED` | `true` | Sub-flag for the Phase-2 RAG layer (still requires `TRIAGE_AI_ENABLED`). |
+| `TRIAGE_EMBED_MODEL` | `openai/text-embedding-3-small` | Embeddings model (GitHub Models). |
+| `TRIAGE_EMBED_DIM` | `512` | Embedding dimensionality (keeps indexes small). |
+| `TRIAGE_ANSWER_MODEL` | `openai/gpt-4o` | Judge/answer chat model. |
+| `TRIAGE_ANSWER_HI` | `0.75` | Min confidence for a full doc-grounded answer. |
+| `TRIAGE_ANSWER_LO` | `0.45` | Min confidence for doc links only. |
+| `TRIAGE_DOCS_REPO` | `music-assistant/music-assistant.io` | Public docs source. |
+| `TRIAGE_INDEX_BRANCH` | `triage-index` | Orphan branch holding the JSON indexes. |
+| `TRIAGE_INDEX_MAX_POSTS` | `500` | Cap on posts embedded into the similar-posts index. |
+
+### RAG indexes (`triage-index` branch)
+The `docs_embeddings.yml` workflow builds `docs.json` / `posts.json` and commits
+them to the orphan `triage-index` branch. It runs nightly, on manual
+`workflow_dispatch`, and on a `repository_dispatch` (`docs-changed`) the docs repo
+can send. Build them on demand with:
+
+```bash
+python -m ma_triage index all     # or: docs | posts
+```
+
+The index-build workflow (and the small `index-append` job in `triage.yml` that
+appends each new issue) has `contents: write` + `models: read` but **no**
+`issues:` permission — the job that can write repo contents can never comment,
+and vice-versa. Both honour `TRIAGE_DRY_RUN` (dry-run previews the commit).
 
 ### Repo secret
 | Secret | Needed for | Notes |
@@ -126,17 +186,23 @@ dispatching, and skips cleanly otherwise.
 
 ## Security model
 
-- Triggers are `issues`, `issue_comment` and `schedule` only — **no
+- Triggers are `issues`, `issue_comment`, `schedule`, `workflow_dispatch` and
+  `repository_dispatch` (the last two only for the RAG index build) — **no
   `pull_request_target`**.
 - Issue content flows through `env:` → `os.environ`; it is never placed in a
   shell command line.
 - Attachment downloads are **host-allowlisted** (`user-attachments` / repo
   `files`) and **byte-capped** while streaming; JSON is parsed with size/depth
   guards; nothing from a file is ever executed.
-- Everything echoed back from a diagnostics file is escaped: `@mentions` and
-  `#refs` are neutralised, HTML/markers are escaped, code spans/fences can't be
-  broken out of, and strings are length-capped.
-- Least-privilege permissions per workflow; one concurrent run per issue.
+- The docs corpus comes from the **public** docs repo (read with the default
+  token, no secret); doc text is comparatively trusted but is still sanitized
+  before it is echoed into a comment.
+- Everything echoed back from a diagnostics file (or a doc / model answer) is
+  escaped: `@mentions` and `#refs` are neutralised, HTML/markers are escaped,
+  code spans/fences can't be broken out of, and strings are length-capped.
+- Least-privilege permissions **per job**: the commenting jobs get `issues:
+  write` but never `contents: write`; the index-writing jobs get `contents:
+  write` + `models: read` but never `issues:` access. One concurrent run per issue.
 
 ## Local development / testing
 

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -21,7 +21,7 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
-from . import ai, analyze, comment, config, copilot, lifecycle, logscan, template
+from . import ai, analyze, comment, config, copilot, embeddings, lifecycle, logscan, rag, template
 from .attachments import (
     download_capped,
     download_log_windowed,
@@ -57,10 +57,13 @@ def build_result(
     *,
     token: str,
     labels: set[str] | list[str] | None = None,
+    number: int = 0,
 ) -> TriageResult:
     """Run the full read-only analysis pipeline and return a TriageResult.
 
     ``labels`` are the issue's current labels, used to pick the form kind.
+    ``number`` is the issue number (used only to exclude the post itself from
+    related-post detection).
     """
     kind = template.form_kind(labels)
     if kind == "translation":
@@ -133,6 +136,10 @@ def build_result(
     result.findings = findings
     result.labels_to_add = labels_to_add
     result.maintainers_to_ping = maintainers
+
+    # Phase 2 RAG layer (docs-grounded answer + related posts). Returns None when
+    # disabled or on any failure, so Tier-0/Tier-1 output is unchanged.
+    result.rag = rag.answer(gh, title=title, body=body, number=number, token=token)
     return result
 
 
@@ -209,7 +216,7 @@ def apply_triage(
     if labels:
         gh.add_labels(number, labels)
 
-    if result.should_comment:
+    if result.should_comment or (result.rag is not None and result.rag.has_output):
         state = {
             "v": 1,
             "last_run": _now_iso(),
@@ -221,6 +228,13 @@ def apply_triage(
         if result.diagnostics is not None:
             state["version"] = result.diagnostics.system.version
             state["source"] = result.diagnostics.source
+        if result.rag is not None:
+            state["rag"] = {
+                "tier": result.rag.tier,
+                "cited": [c.id for c in result.rag.cited_chunks],
+                "related": [p.number for p in result.rag.related_posts],
+                "suppressed": result.rag.suppressed,
+            }
         if "dispatch" in prior_state:  # preserve any earlier Copilot dispatch record
             state["dispatch"] = prior_state["dispatch"]
 
@@ -256,7 +270,7 @@ def cmd_triage(gh: GitHubClient, token: str) -> int:
         return 0
 
     summary(f"## Triage of #{number}\n")
-    result = build_result(gh, title, body, token=token, labels=labels)
+    result = build_result(gh, title, body, token=token, labels=labels, number=number)
     if result.skip:
         summary(f"#{number}: skipped ({result.form_kind} form — not triaged).")
         return 0
@@ -319,7 +333,7 @@ def cmd_dispatch(gh: GitHubClient, token: str) -> int:
     labels = lifecycle.issue_labels(issue)
 
     summary(f"## Copilot dispatch for #{number}\n")
-    result = build_result(gh, title, body, token=token, labels=labels)
+    result = build_result(gh, title, body, token=token, labels=labels, number=number)
     if not result.is_actionable:
         summary(f"#{number}: no valid diagnostics; not dispatching.")
         return 0
@@ -347,10 +361,128 @@ def cmd_dispatch(gh: GitHubClient, token: str) -> int:
     return 0
 
 
+# --------------------------------------------------------------------------- #
+# RAG index build (Phase 2)
+# --------------------------------------------------------------------------- #
+def _build_docs_index(gh: GitHubClient, token: str) -> None:
+    prev = embeddings.load_index(gh, config.DOCS_INDEX_PATH)
+    index, changed = embeddings.build_docs_index(gh, token=token, previous=prev)
+    if index is None:
+        summary("- docs: build skipped (embeddings unavailable / rate limited)")
+        return
+    count = len(index.get("chunks", []))
+    if not changed:
+        summary(f"- docs: unchanged ({count} chunks); no commit")
+        return
+    embeddings.save_index(
+        gh, config.DOCS_INDEX_PATH, index, message=f"Update docs index ({count} chunks)"
+    )
+    summary(f"- docs: {count} chunks indexed")
+
+
+def _collect_posts(gh: GitHubClient) -> list[dict[str, Any]]:
+    posts: list[dict[str, Any]] = []
+    for issue in gh.list_recent_issues(limit=config.INDEX_MAX_POSTS):
+        posts.append(
+            {
+                "kind": "issue",
+                "number": issue.get("number"),
+                "title": issue.get("title") or "",
+                "body": issue.get("body") or "",
+                "url": issue.get("html_url") or "",
+                "state": issue.get("state"),
+                "updated_at": issue.get("updated_at"),
+            }
+        )
+    for disc in gh.list_discussions(limit=config.INDEX_MAX_POSTS):
+        category = ((disc.get("category") or {}).get("name") or "").lower()
+        if category in config.DISCUSSION_EXCLUDE_CATEGORIES:
+            # e.g. translation-category discussions: not useful as related posts.
+            continue
+        posts.append(
+            {
+                "kind": "discussion",
+                "number": disc.get("number"),
+                "title": disc.get("title") or "",
+                "body": disc.get("body") or "",
+                "url": disc.get("url") or "",
+                "state": "closed" if disc.get("closed") else "open",
+                "updated_at": disc.get("updatedAt"),
+            }
+        )
+    posts.sort(key=lambda p: p.get("updated_at") or "", reverse=True)
+    return posts
+
+
+def _build_posts_index(gh: GitHubClient, token: str) -> None:
+    prev = embeddings.load_index(gh, config.POSTS_INDEX_PATH)
+    posts = _collect_posts(gh)
+    index, changed = embeddings.build_posts_index(
+        gh, posts, token=token, previous=prev
+    )
+    if index is None:
+        summary("- posts: build skipped (embeddings unavailable / rate limited)")
+        return
+    count = len(index.get("posts", []))
+    if not changed:
+        summary(f"- posts: unchanged ({count} posts); no commit")
+        return
+    embeddings.save_index(
+        gh, config.POSTS_INDEX_PATH, index, message=f"Update posts index ({count} posts)"
+    )
+    summary(f"- posts: {count} posts indexed")
+
+
+def cmd_index(gh: GitHubClient, token: str, target: str = "all") -> int:
+    summary(f"## RAG index build ({target})\n")
+    if target not in ("docs", "posts", "all"):
+        log(f"unknown index target: {target} (use docs|posts|all)")
+        return 2
+    if target in ("docs", "all"):
+        _build_docs_index(gh, token)
+    if target in ("posts", "all"):
+        _build_posts_index(gh, token)
+    return 0
+
+
+def cmd_index_append(gh: GitHubClient, token: str) -> int:
+    """Embed a single new issue and upsert it into the posts index."""
+    number = int(_env("ISSUE_NUMBER"))
+    summary(f"## RAG posts-index append for #{number}\n")
+    issue = gh.get_issue(number)
+    if "pull_request" in issue:
+        summary(f"#{number}: is a pull request; skipping append.")
+        return 0
+    post = {
+        "kind": "issue",
+        "number": number,
+        "title": issue.get("title") or _env("ISSUE_TITLE"),
+        "body": issue.get("body") or _env("ISSUE_BODY"),
+        "url": issue.get("html_url") or "",
+        "state": issue.get("state"),
+        "updated_at": issue.get("updated_at"),
+    }
+    index, _changed = embeddings.append_post(gh, post, token=token)
+    if index is None:
+        summary(f"#{number}: append skipped (embeddings unavailable).")
+        return 0
+    embeddings.save_index(
+        gh,
+        config.POSTS_INDEX_PATH,
+        index,
+        message=f"Append issue #{number} to posts index",
+    )
+    summary(f"#{number}: appended ({len(index.get('posts', []))} posts total).")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
     if not argv:
-        log("usage: python -m ma_triage {triage|respond|sweep|dispatch}")
+        log(
+            "usage: python -m ma_triage "
+            "{triage|respond|sweep|dispatch|index|index-append}"
+        )
         return 2
     command = argv[0]
 
@@ -372,6 +504,11 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_sweep(gh)
     if command == "dispatch":
         return cmd_dispatch(gh, token)
+    if command == "index":
+        target = argv[1] if len(argv) > 1 else "all"
+        return cmd_index(gh, token, target)
+    if command == "index-append":
+        return cmd_index_append(gh, token)
     log(f"unknown command: {command}")
     return 2
 

--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -18,7 +18,7 @@ from typing import Any
 import requests
 
 from . import config
-from .models import AIResult, Diagnostics
+from .models import AIResult, Diagnostics, DocAnswer, DocHit
 from .sanitize import fenced, inline
 
 # Allowed values for the model's `category` field; anything else → "unknown".
@@ -171,4 +171,123 @@ def assess(
         return _coerce(data)
     except Exception as exc:  # noqa: BLE001 — never let AI break triage
         print(f"AI assessment skipped: {exc}")
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Doc-answer judge (Phase 2 RAG) — the single chat call per post
+# --------------------------------------------------------------------------- #
+# JSON schema for the judge's structured verdict.
+_ANSWER_SCHEMA: dict[str, Any] = {
+    "name": "docs_answer",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "answers_question": {"type": "boolean"},
+            "confidence": {"type": "number"},
+            "answer": {"type": "string"},
+            "cited_sections": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["answers_question", "confidence", "answer", "cited_sections"],
+    },
+}
+
+_ANSWER_SYSTEM_PROMPT = (
+    "You are a documentation assistant for the open-source project Music "
+    "Assistant. You are given a user's issue and a set of numbered documentation "
+    "sections retrieved from the official docs. Decide whether those sections "
+    "actually answer the user's question. Ground your answer ONLY in the "
+    "provided sections — never invent settings, versions, or steps that are not "
+    "present. Cite the sections you used by their exact [id]. If the sections do "
+    "not answer the question, set answers_question=false, keep confidence low, "
+    "and leave the answer brief. Reflect genuine uncertainty in `confidence` "
+    "(0-1). Keep the answer concise, friendly, and directly actionable."
+)
+
+
+def build_answer_messages(
+    title: str, body: str, doc_hits: list[DocHit]
+) -> list[dict[str, str]]:
+    """Assemble the (bounded, sanitized) judge messages from retrieved docs."""
+    sections: list[str] = []
+    for hit in doc_hits:
+        chunk = hit.chunk
+        # The id is our own internally-generated key ("<slug>#<anchor>") and the
+        # judge must echo it back verbatim to cite a section, so it is shown RAW
+        # — it must NOT go through inline(), which would insert a zero-width space
+        # after the '#' and make every citation fail the exact-match filter.
+        sections.append(
+            f"[{chunk.id}] {inline(chunk.label, max_len=200)}\n"
+            f"{fenced(chunk.text, max_len=1200)}"
+        )
+    user_content = (
+        f"ISSUE TITLE: {inline(title, max_len=300)}\n\n"
+        f"ISSUE BODY (excerpt):\n{fenced(body, max_len=2000)}\n\n"
+        f"DOCUMENTATION SECTIONS:\n" + "\n\n".join(sections)
+    )
+    if len(user_content) > config.MAX_AI_INPUT_CHARS:
+        user_content = user_content[: config.MAX_AI_INPUT_CHARS] + "\n…[truncated]"
+    return [
+        {"role": "system", "content": _ANSWER_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+
+def _coerce_answer(data: dict[str, Any], valid_ids: set[str]) -> DocAnswer:
+    try:
+        confidence = float(data.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    cited = data.get("cited_sections") or []
+    if not isinstance(cited, list):
+        cited = []
+    # Drop any hallucinated ids the model did not actually receive.
+    cited = [str(c) for c in cited if str(c) in valid_ids]
+    answer = str(data.get("answer", "")).strip()[: config.MAX_DOC_ANSWER_CHARS]
+    return DocAnswer(
+        answers_question=bool(data.get("answers_question", False)),
+        confidence=max(0.0, min(1.0, confidence)),
+        answer=answer,
+        cited_sections=cited,
+    )
+
+
+def judge_answer(
+    title: str, body: str, doc_hits: list[DocHit], *, token: str
+) -> DocAnswer | None:
+    """Ask the judge whether the retrieved docs answer the post. ``None`` on any
+    failure or when the RAG layer is disabled — so triage is never affected."""
+    if not (config.AI_ENABLED and config.RAG_ENABLED):
+        return None
+    if not doc_hits:
+        return None
+    messages = build_answer_messages(title or "", body or "", doc_hits)
+    payload = {
+        "model": config.ANSWER_MODEL,
+        "messages": messages,
+        "temperature": 0.1,
+        "response_format": {"type": "json_schema", "json_schema": _ANSWER_SCHEMA},
+    }
+    valid_ids = {hit.chunk.id for hit in doc_hits}
+    try:
+        resp = requests.post(
+            config.AI_ENDPOINT,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            json=payload,
+            timeout=60,
+        )
+        if resp.status_code >= 400:
+            print(f"Doc-answer judge skipped: HTTP {resp.status_code}: {resp.text[:200]}")
+            return None
+        content = resp.json()["choices"][0]["message"]["content"]
+        data = json.loads(content)
+        return _coerce_answer(data, valid_ids)
+    except Exception as exc:  # noqa: BLE001 — never let AI break triage
+        print(f"Doc-answer judge skipped: {exc}")
         return None

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -17,8 +17,8 @@ from typing import Any
 
 from . import config
 from .gh import GitHubClient
-from .models import Severity, TriageResult
-from .sanitize import inline
+from .models import RagResult, Severity, TriageResult
+from .sanitize import fenced, inline
 
 _SEVERITY_ICON = {
     Severity.CRITICAL: "🔴",
@@ -165,6 +165,54 @@ def _missing_sections_line(result: TriageResult) -> str:
     )
 
 
+def _doc_link(label: str, url: str) -> str:
+    """A sanitized markdown bullet link to a docs page.
+
+    Doc content is from the public docs repo (comparatively trusted) but is still
+    sanitized before echoing; the URL is derived from our own config + slug.
+    """
+    return f"- [{inline(label, max_len=160) or url}]({url})"
+
+
+def _rag_section(result: TriageResult) -> str:
+    """Render the optional docs-answer + related-posts sections.
+
+    Returns ``""`` when the RAG layer produced nothing (or is disabled), so the
+    comment is byte-identical to Phase 1 in that case.
+    """
+    rag: RagResult | None = result.rag
+    if rag is None or not rag.has_output:
+        return ""
+    parts: list[str] = []
+
+    if rag.tier == "high" and rag.doc_answer is not None:
+        parts.append(config.DOCS_ANSWER_HEADING)
+        # The answer is model-generated and grounded in the cited docs; sanitize
+        # it anyway so it can never ping users or break out of the comment.
+        parts.append(fenced(rag.doc_answer.answer, max_len=config.MAX_DOC_ANSWER_CHARS))
+        if rag.cited_chunks:
+            parts.append("\n**Sources:**")
+            for chunk in rag.cited_chunks:
+                parts.append(_doc_link(chunk.label, chunk.url))
+        parts.append("\n" + config.DOCS_ANSWER_DISCLAIMER)
+    elif rag.tier == "medium" and rag.doc_hits:
+        parts.append(config.DOCS_LINKS_HEADING)
+        parts.append("These documentation pages look related to your report:")
+        for hit in rag.doc_hits[: config.DOCS_LINKS_SHOWN]:
+            parts.append(_doc_link(hit.chunk.label, hit.chunk.url))
+        parts.append("\n" + config.DOCS_ANSWER_DISCLAIMER)
+
+    if rag.related_posts:
+        parts.append("\n" + config.RELATED_POSTS_HEADING)
+        parts.append(config.RELATED_POSTS_INTRO)
+        for post in rag.related_posts:
+            closed = " _(closed)_" if post.state == "closed" else ""
+            title = inline(post.title, max_len=140)
+            parts.append(f"- [#{post.number}: {title}]({post.url}){closed}")
+
+    return "\n".join(parts)
+
+
 def build_body(result: TriageResult) -> str:
     """Render the full sticky-comment body for a triage pass."""
     parts = [config.STICKY_MARKER, "", config.GREETING, ""]
@@ -224,6 +272,11 @@ def build_body(result: TriageResult) -> str:
             "A diagnostics report (or a log attached as a file) is much easier for "
             "us to work with than inline logs."
         )
+
+    rag_section = _rag_section(result)
+    if rag_section:
+        parts.append("")
+        parts.append(rag_section)
 
     if result.maintainers_to_ping:
         pings = " ".join(f"@{m}" for m in sorted(result.maintainers_to_ping))

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -18,7 +18,7 @@ from typing import Any
 from . import config
 from .gh import GitHubClient
 from .models import RagResult, Severity, TriageResult
-from .sanitize import fenced, inline
+from .sanitize import inline, link_label, markdown_safe
 
 _SEVERITY_ICON = {
     Severity.CRITICAL: "🔴",
@@ -171,7 +171,7 @@ def _doc_link(label: str, url: str) -> str:
     Doc content is from the public docs repo (comparatively trusted) but is still
     sanitized before echoing; the URL is derived from our own config + slug.
     """
-    return f"- [{inline(label, max_len=160) or url}]({url})"
+    return f"- [{link_label(label, max_len=160) or url}]({url})"
 
 
 def _rag_section(result: TriageResult) -> str:
@@ -189,7 +189,11 @@ def _rag_section(result: TriageResult) -> str:
         parts.append(config.DOCS_ANSWER_HEADING)
         # The answer is model-generated and grounded in the cited docs; sanitize
         # it anyway so it can never ping users or break out of the comment.
-        parts.append(fenced(rag.doc_answer.answer, max_len=config.MAX_DOC_ANSWER_CHARS))
+        parts.append(
+            markdown_safe(
+                rag.doc_answer.answer, max_len=config.MAX_DOC_ANSWER_CHARS
+            )
+        )
         if rag.cited_chunks:
             parts.append("\n**Sources:**")
             for chunk in rag.cited_chunks:
@@ -207,7 +211,7 @@ def _rag_section(result: TriageResult) -> str:
         parts.append(config.RELATED_POSTS_INTRO)
         for post in rag.related_posts:
             closed = " _(closed)_" if post.state == "closed" else ""
-            title = inline(post.title, max_len=140)
+            title = link_label(post.title, max_len=140)
             parts.append(f"- [#{post.number}: {title}]({post.url}){closed}")
 
     return "\n".join(parts)

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -222,6 +222,83 @@ COPILOT_AUTO_MIN_CONFIDENCE = float(
 )
 
 # --------------------------------------------------------------------------- #
+# RAG layer (Phase 2) — docs-grounded answers + similar-post detection
+# --------------------------------------------------------------------------- #
+# The RAG layer is *additionally* gated behind AI_ENABLED (see rag.py). This
+# sub-flag lets a maintainer turn off just the RAG features while keeping the
+# Tier-1 assessment. Effective enablement is ``AI_ENABLED and RAG_ENABLED``.
+RAG_ENABLED = _flag("TRIAGE_RAG_ENABLED", True)
+
+# Public docs repository (Astro/Starlight). Readable with the default
+# GITHUB_TOKEN — it is public, so no secret is required.
+DOCS_REPO = os.environ.get("TRIAGE_DOCS_REPO", "music-assistant/music-assistant.io")
+DOCS_CONTENT_ROOT = os.environ.get("TRIAGE_DOCS_CONTENT_ROOT", "src/content/docs")
+DOCS_SITE = os.environ.get("TRIAGE_DOCS_SITE", "https://www.music-assistant.io")
+DOCS_REF = os.environ.get("TRIAGE_DOCS_REF", "main")
+# Doc paths (relative to the content root) whose prefix excludes them from the
+# index — the dated blog posts are announcements, not troubleshooting material.
+DOCS_EXCLUDE_PREFIXES = tuple(
+    p.strip()
+    for p in os.environ.get("TRIAGE_DOCS_EXCLUDE", "blog/").split(",")
+    if p.strip()
+)
+# Discussion categories excluded from the similar-posts index (case-insensitive).
+# Translation contributions live in a Discussion category and are not useful as
+# "similar reports" for bug issues, so they are skipped by default. (Live
+# discussion triage is out of scope for this phase; discussions are only read
+# into the posts index for related-post links.)
+DISCUSSION_EXCLUDE_CATEGORIES = tuple(
+    c.strip().lower()
+    for c in os.environ.get(
+        "TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES", "translations,translation"
+    ).split(",")
+    if c.strip()
+)
+
+# Orphan branch in THIS repo that stores the JSON indexes (keeps ``main`` clean).
+INDEX_BRANCH = os.environ.get("TRIAGE_INDEX_BRANCH", "triage-index")
+DOCS_INDEX_PATH = "docs.json"
+POSTS_INDEX_PATH = "posts.json"
+SUPPRESS_INDEX_PATH = "suppress.json"
+
+# GitHub Models — embeddings + judge/answer chat (both OpenAI-compatible, served
+# from models.github.ai with the default token + ``models: read`` permission).
+EMBED_MODEL = os.environ.get("TRIAGE_EMBED_MODEL", "openai/text-embedding-3-small")
+# Reduced embedding dimensionality (OpenAI ``dimensions`` param) keeps the JSON
+# indexes small and the pure-Python cosine fast. Set to 0 to use the model default.
+EMBED_DIM = int(os.environ.get("TRIAGE_EMBED_DIM", "512"))
+EMBED_ENDPOINT = os.environ.get(
+    "TRIAGE_EMBED_ENDPOINT", "https://models.github.ai/inference/embeddings"
+)
+EMBED_BATCH = int(os.environ.get("TRIAGE_EMBED_BATCH", "64"))
+ANSWER_MODEL = os.environ.get("TRIAGE_ANSWER_MODEL", "openai/gpt-4o")
+
+# Confidence-tier thresholds for the doc-answer judge (0-1). See rag.tier().
+ANSWER_HI = float(os.environ.get("TRIAGE_ANSWER_HI", "0.75"))
+ANSWER_LO = float(os.environ.get("TRIAGE_ANSWER_LO", "0.45"))
+
+# Retrieval knobs.
+DOCS_TOP_K = int(os.environ.get("TRIAGE_DOCS_TOP_K", "6"))
+RELATED_POSTS = int(os.environ.get("TRIAGE_RELATED_POSTS", "3"))
+RELATED_MIN_SCORE = float(os.environ.get("TRIAGE_RELATED_MIN_SCORE", "0.35"))
+# Minimum dense cosine for the top doc hit to show links when the judge call
+# itself failed (retrieval-only MEDIUM fallback).
+DOCS_MIN_DENSE = float(os.environ.get("TRIAGE_DOCS_MIN_DENSE", "0.30"))
+# Max doc links rendered in a MEDIUM (links-only) comment section.
+DOCS_LINKS_SHOWN = int(os.environ.get("TRIAGE_DOCS_LINKS_SHOWN", "3"))
+# A cited-answer fingerprint with at least this many downvotes is suppressed.
+SUPPRESS_MIN_DOWNVOTES = int(os.environ.get("TRIAGE_SUPPRESS_MIN_DOWNVOTES", "1"))
+RRF_K = 60  # reciprocal-rank-fusion constant
+BM25_K1 = 1.5
+BM25_B = 0.75
+
+# Indexing caps / cost guards.
+INDEX_MAX_POSTS = int(os.environ.get("TRIAGE_INDEX_MAX_POSTS", "500"))
+DOCS_CHUNK_MAX_CHARS = int(os.environ.get("TRIAGE_DOCS_CHUNK_MAX_CHARS", "2000"))
+MAX_POST_EMBED_CHARS = 6000  # bound the text embedded per post / query
+MAX_DOC_ANSWER_CHARS = 1200  # cap the judge's answer echoed into the comment
+
+# --------------------------------------------------------------------------- #
 # User-facing copy
 # --------------------------------------------------------------------------- #
 DISCLOSURE_FOOTER = (
@@ -293,4 +370,22 @@ SCREENSHOT_ATTACHMENT_NOTE = (
     "screenshot usually doesn't include enough to go on. Could you attach the "
     "actual **diagnostics report** (a `.json` file) or your **full log file** "
     "instead?"
+)
+
+# --------------------------------------------------------------------------- #
+# RAG layer copy (docs-grounded answers + similar past reports)
+# --------------------------------------------------------------------------- #
+# Shown for a HIGH-confidence, docs-grounded answer (generated prose + links).
+DOCS_ANSWER_HEADING = "### 📚 This might be answered in the docs"
+# Shown for a MEDIUM-confidence result (relevant links only, no generated prose).
+DOCS_LINKS_HEADING = "### 📚 Docs that might help"
+DOCS_ANSWER_DISCLAIMER = (
+    "_This is an automated suggestion based on the documentation — it may not "
+    "perfectly match your setup, and a maintainer will still take a look. If it "
+    "helped, a 👍 on this comment helps me learn; a 👎 tells me I got it wrong._"
+)
+RELATED_POSTS_HEADING = "### 🔁 Similar past reports"
+RELATED_POSTS_INTRO = (
+    "These earlier issues or discussions look related and might already have an "
+    "answer (or indicate a duplicate):"
 )

--- a/.github/scripts/ma_triage/docs.py
+++ b/.github/scripts/ma_triage/docs.py
@@ -1,0 +1,245 @@
+"""Fetch and chunk the public Music Assistant documentation.
+
+The docs live in the **public** ``music-assistant/music-assistant.io`` repo
+(Astro/Starlight), as markdown under ``src/content/docs/**``. Because the repo is
+public, the default ``GITHUB_TOKEN`` can read it — no secret is required.
+
+Indexing strategy (mirrors the ``zwave-js-bot`` blueprint):
+
+* enumerate every ``*.md`` / ``*.mdx`` page via the Git Trees API,
+* strip YAML frontmatter and MDX ``import``/``export``/JSX noise,
+* **chunk by heading**, keeping a breadcrumb path and a stable cite URL per
+  chunk (e.g. ``https://www.music-assistant.io/faq/troubleshooting/#networking``),
+* oversized sections are split at paragraph boundaries so each chunk stays under
+  :data:`config.DOCS_CHUNK_MAX_CHARS`.
+
+This module is deliberately **network-light and pure where possible**:
+:func:`chunk_document` takes raw text and does no I/O, so it is trivially
+unit-testable; only :func:`doc_paths` / :func:`build_chunks` touch the network.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+from . import config
+from .gh import GitHubClient
+from .models import DocChunk
+
+_RE_FRONTMATTER = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_RE_FM_TITLE = re.compile(r"^title:\s*(.+?)\s*$", re.MULTILINE)
+_RE_HEADING = re.compile(r"^(#{1,6})\s+(.*?)\s*#*\s*$")
+_RE_MDX_IMPORT = re.compile(r"^\s*(?:import|export)\s.+$", re.MULTILINE)
+_RE_HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+_RE_JSX_TAG = re.compile(r"</?[A-Za-z][\w.]*(?:\s[^<>]*?)?/?>")
+_RE_CODE_FENCE = re.compile(r"^```")
+_RE_MULTINEWLINE = re.compile(r"\n{3,}")
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def slug_for(path: str) -> str:
+    """Map a docs repo path to its Starlight slug.
+
+    ``src/content/docs/faq/troubleshooting.md`` -> ``faq/troubleshooting``;
+    an ``index`` basename collapses to its parent (``foo/index.md`` -> ``foo``).
+    """
+    root = config.DOCS_CONTENT_ROOT.strip("/")
+    rel = path
+    if rel.startswith(root):
+        rel = rel[len(root):]
+    rel = rel.lstrip("/")
+    rel = re.sub(r"\.(md|mdx)$", "", rel, flags=re.IGNORECASE)
+    if rel.rsplit("/", 1)[-1].lower() == "index":
+        rel = rel.rsplit("/", 1)[0] if "/" in rel else ""
+    return rel.lower()
+
+
+def url_for(slug: str, anchor: str = "") -> str:
+    """Build the canonical site URL for a slug (+ optional heading anchor)."""
+    base = config.DOCS_SITE.rstrip("/")
+    path = f"{base}/{slug}/" if slug else f"{base}/"
+    return f"{path}#{anchor}" if anchor else path
+
+
+def anchor_for(heading: str) -> str:
+    """Slugify a heading the way GitHub/Starlight generate anchors."""
+    text = heading.strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    return re.sub(r"-{2,}", "-", text).strip("-")
+
+
+def parse_frontmatter(raw: str) -> tuple[str | None, str]:
+    """Return ``(title, body)`` stripping the YAML frontmatter block."""
+    match = _RE_FRONTMATTER.match(raw)
+    if not match:
+        return None, raw
+    front = match.group(1)
+    title_match = _RE_FM_TITLE.search(front)
+    title = None
+    if title_match:
+        title = title_match.group(1).strip().strip("\"'") or None
+    return title, raw[match.end():]
+
+
+def strip_mdx(body: str) -> str:
+    """Remove MDX imports/exports, HTML comments and stray JSX tags."""
+    body = _RE_HTML_COMMENT.sub("", body)
+    body = _RE_MDX_IMPORT.sub("", body)
+    body = _RE_JSX_TAG.sub("", body)
+    return body
+
+
+def _clean_text(text: str) -> str:
+    return _RE_MULTINEWLINE.sub("\n\n", text).strip()
+
+
+def _split_paragraphs(text: str, max_chars: int) -> list[str]:
+    """Pack a section body into <= ``max_chars`` pieces at paragraph breaks."""
+    text = _clean_text(text)
+    if len(text) <= max_chars:
+        return [text] if text else []
+    pieces: list[str] = []
+    current = ""
+    for para in text.split("\n\n"):
+        para = para.strip()
+        if not para:
+            continue
+        if current and len(current) + len(para) + 2 > max_chars:
+            pieces.append(current)
+            current = ""
+        if len(para) > max_chars:
+            # A single very long paragraph: hard-wrap it.
+            if current:
+                pieces.append(current)
+                current = ""
+            for i in range(0, len(para), max_chars):
+                pieces.append(para[i : i + max_chars])
+            continue
+        current = f"{current}\n\n{para}" if current else para
+    if current:
+        pieces.append(current)
+    return pieces
+
+
+def _first_h1(body: str) -> str | None:
+    for line in body.splitlines():
+        match = _RE_HEADING.match(line)
+        if match and len(match.group(1)) == 1:
+            return match.group(2).strip()
+    return None
+
+
+def chunk_document(path: str, raw: str) -> list[DocChunk]:
+    """Split one raw doc into heading-delimited :class:`DocChunk` objects.
+
+    Pure function (no I/O). Embeddings are left empty; the builder fills them in.
+    """
+    title, body = parse_frontmatter(raw)
+    body = strip_mdx(body)
+    slug = slug_for(path)
+    if not title:
+        title = _first_h1(body) or (slug.rsplit("/", 1)[-1] or slug).replace("-", " ").title()
+
+    # Walk the body, accumulating (heading-stack, body-lines) sections.
+    sections: list[tuple[list[tuple[int, str]], list[str]]] = []
+    stack: list[tuple[int, str]] = []
+    buffer: list[str] = []
+    in_fence = False
+
+    def _flush() -> None:
+        if buffer:
+            sections.append((list(stack), list(buffer)))
+
+    for line in body.splitlines():
+        if _RE_CODE_FENCE.match(line):
+            in_fence = not in_fence
+            buffer.append(line)
+            continue
+        heading = None if in_fence else _RE_HEADING.match(line)
+        if heading:
+            _flush()
+            buffer = []
+            level = len(heading.group(1))
+            text = heading.group(2).strip()
+            while stack and stack[-1][0] >= level:
+                stack.pop()
+            stack.append((level, text))
+        else:
+            buffer.append(line)
+    _flush()
+
+    chunks: list[DocChunk] = []
+    seen_ids: set[str] = set()
+    for heading_stack, lines in sections:
+        text = _clean_text("\n".join(lines))
+        if not text:
+            continue
+        heading = heading_stack[-1][1] if heading_stack else ""
+        anchor = anchor_for(heading) if heading else ""
+        breadcrumbs = [title] + [h for _, h in heading_stack]
+        label = " › ".join([c for c in breadcrumbs if c]) or (title or slug)
+        base_id = f"{slug}#{anchor}" if anchor else slug
+        for piece in _split_paragraphs(text, config.DOCS_CHUNK_MAX_CHARS):
+            chunk_id = base_id
+            suffix = 2
+            while chunk_id in seen_ids:
+                chunk_id = f"{base_id}-{suffix}"
+                suffix += 1
+            seen_ids.add(chunk_id)
+            chunks.append(
+                DocChunk(
+                    id=chunk_id,
+                    path=slug,
+                    url=url_for(slug, anchor),
+                    title=title,
+                    heading=heading,
+                    text=piece,
+                    breadcrumbs=breadcrumbs,
+                    # Hash the breadcrumb label together with the text, because the
+                    # embedder sees both — this way a title/breadcrumb-only edit
+                    # still invalidates the SHA cache and triggers a re-embed.
+                    sha=_sha(f"{label}\n{piece}"),
+                )
+            )
+    return chunks
+
+
+def doc_paths(gh: GitHubClient) -> list[str]:
+    """List every documentation page path in the docs repo."""
+    tree = gh.get_tree(config.DOCS_REPO, config.DOCS_REF)
+    root = config.DOCS_CONTENT_ROOT.strip("/")
+    exclude = config.DOCS_EXCLUDE_PREFIXES
+    paths: list[str] = []
+    for entry in tree:
+        if entry.get("type") != "blob":
+            continue
+        path = entry.get("path") or ""
+        if not path.startswith(root):
+            continue
+        if not re.search(r"\.(md|mdx)$", path, re.IGNORECASE):
+            continue
+        rel = path[len(root):].lstrip("/")
+        if any(rel.startswith(prefix) for prefix in exclude):
+            continue
+        paths.append(path)
+    return sorted(paths)
+
+
+def build_chunks(
+    gh: GitHubClient, paths: list[str] | None = None
+) -> list[DocChunk]:
+    """Fetch and chunk the whole docs corpus (embeddings still empty)."""
+    if paths is None:
+        paths = doc_paths(gh)
+    chunks: list[DocChunk] = []
+    for path in paths:
+        raw = gh.get_raw_file(config.DOCS_REPO, path, ref=config.DOCS_REF)
+        if not raw:
+            continue
+        chunks.extend(chunk_document(path, raw))
+    return chunks

--- a/.github/scripts/ma_triage/embeddings.py
+++ b/.github/scripts/ma_triage/embeddings.py
@@ -1,0 +1,346 @@
+"""GitHub Models embeddings client + JSON index read/write.
+
+The embeddings API is OpenAI-compatible and served from ``models.github.ai`` with
+the default ``GITHUB_TOKEN`` (``models: read`` permission) — no secret required.
+
+Everything here is **defensive and cost-aware**:
+
+* embeddings are requested in batches, with a reduced ``dimensions`` to keep the
+  indexes small; any HTTP / network failure returns ``None`` (**skip-on-limit**)
+  so a rate-limited run never writes a broken index,
+* index builds are **cached by content SHA** — an unchanged chunk is never
+  re-embedded — and the caller skips the commit entirely when nothing changed,
+* the indexes are plain JSON persisted on the orphan ``triage-index`` branch and
+  read back at runtime through :meth:`GitHubClient.get_raw_file`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
+from . import config, docs
+from .gh import GitHubClient, log
+from .models import DocChunk
+
+_SCHEMA = 1
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def post_sha(title: str, body: str) -> str:
+    return hashlib.sha256(f"{title}\n{body}".encode("utf-8")).hexdigest()[:16]
+
+
+# --------------------------------------------------------------------------- #
+# Embeddings client
+# --------------------------------------------------------------------------- #
+def _request_embeddings(inputs: list[str], token: str) -> list[list[float]]:
+    """One embeddings API call for a batch of inputs (raises on any error)."""
+    payload: dict[str, Any] = {"model": config.EMBED_MODEL, "input": inputs}
+    if config.EMBED_DIM > 0:
+        payload["dimensions"] = config.EMBED_DIM
+    resp = requests.post(
+        config.EMBED_ENDPOINT, headers=_headers(token), json=payload, timeout=60
+    )
+    if resp.status_code >= 400:
+        raise requests.HTTPError(f"HTTP {resp.status_code}: {resp.text[:200]}")
+    data = resp.json()["data"]
+    # The API preserves input order, but sort by index to be safe.
+    ordered = sorted(data, key=lambda d: d.get("index", 0))
+    return [list(item["embedding"]) for item in ordered]
+
+
+def embed_texts(texts: list[str], *, token: str) -> list[list[float]] | None:
+    """Embed a list of texts (batched). Returns ``None`` on any failure."""
+    if not texts:
+        return []
+    vectors: list[list[float]] = []
+    batch = max(1, config.EMBED_BATCH)
+    try:
+        for start in range(0, len(texts), batch):
+            chunk = texts[start : start + batch]
+            vectors.extend(_request_embeddings(chunk, token))
+    except Exception as exc:  # noqa: BLE001 — never let embeddings break triage
+        log(f"Embeddings skipped: {exc}")
+        return None
+    if len(vectors) != len(texts):
+        log("Embeddings response count mismatch; skipping")
+        return None
+    return vectors
+
+
+def embed_text(text: str, *, token: str) -> list[float] | None:
+    """Embed a single text; ``None`` on failure."""
+    result = embed_texts([text[: config.MAX_POST_EMBED_CHARS]], token=token)
+    if not result:
+        return None
+    return result[0]
+
+
+def _chunk_embed_input(chunk: DocChunk) -> str:
+    """Text fed to the embedder: breadcrumb label boosts semantic signal."""
+    return f"{chunk.label}\n{chunk.text}"[: config.MAX_POST_EMBED_CHARS]
+
+
+# --------------------------------------------------------------------------- #
+# Index (de)serialisation
+# --------------------------------------------------------------------------- #
+def _dumps(index: dict[str, Any]) -> str:
+    return json.dumps(index, separators=(",", ":"), sort_keys=True)
+
+
+def load_index(gh: GitHubClient, path: str) -> dict[str, Any] | None:
+    """Read + parse a JSON index from the index branch; ``None`` if absent/bad."""
+    raw = gh.get_raw_file(gh.repo, path, ref=config.INDEX_BRANCH)
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        log(f"Index {path} is not valid JSON: {exc}")
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def load_docs_chunks(gh: GitHubClient) -> list[DocChunk]:
+    """Load ``docs.json`` into :class:`DocChunk` objects (with embeddings)."""
+    index = load_index(gh, config.DOCS_INDEX_PATH)
+    if not index:
+        return []
+    if index.get("model") != config.EMBED_MODEL or index.get("dim") != config.EMBED_DIM:
+        log("Docs index model/dim mismatch; ignoring index")
+        return []
+    chunks: list[DocChunk] = []
+    for raw in index.get("chunks", []) or []:
+        if not isinstance(raw, dict) or not raw.get("embedding"):
+            continue
+        chunks.append(
+            DocChunk(
+                id=str(raw.get("id", "")),
+                path=str(raw.get("path", "")),
+                url=str(raw.get("url", "")),
+                title=str(raw.get("title", "")),
+                heading=str(raw.get("heading", "")),
+                text=str(raw.get("text", "")),
+                breadcrumbs=list(raw.get("breadcrumbs", []) or []),
+                sha=str(raw.get("sha", "")),
+                embedding=[float(x) for x in raw.get("embedding", [])],
+            )
+        )
+    return chunks
+
+
+def load_posts(gh: GitHubClient) -> list[dict[str, Any]]:
+    """Load ``posts.json`` records (each with an ``embedding``)."""
+    index = load_index(gh, config.POSTS_INDEX_PATH)
+    if not index:
+        return []
+    if index.get("model") != config.EMBED_MODEL or index.get("dim") != config.EMBED_DIM:
+        return []
+    posts = index.get("posts")
+    return [p for p in posts if isinstance(p, dict) and p.get("embedding")] if isinstance(posts, list) else []
+
+
+def load_suppress(gh: GitHubClient) -> list[dict[str, Any]]:
+    """Load the downvoted-answer fingerprints from ``suppress.json``."""
+    index = load_index(gh, config.SUPPRESS_INDEX_PATH)
+    if not index:
+        return []
+    fps = index.get("fingerprints")
+    return [f for f in fps if isinstance(f, dict)] if isinstance(fps, list) else []
+
+
+def _chunk_to_dict(chunk: DocChunk) -> dict[str, Any]:
+    return {
+        "id": chunk.id,
+        "path": chunk.path,
+        "url": chunk.url,
+        "title": chunk.title,
+        "heading": chunk.heading,
+        "text": chunk.text,
+        "breadcrumbs": chunk.breadcrumbs,
+        "sha": chunk.sha,
+        "embedding": chunk.embedding,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Index builders (used by the `index` subcommand)
+# --------------------------------------------------------------------------- #
+def build_docs_index(
+    gh: GitHubClient,
+    *,
+    token: str,
+    chunks: list[DocChunk] | None = None,
+    previous: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, bool]:
+    """Build the docs index, reusing cached embeddings by content SHA.
+
+    Returns ``(index, changed)``. ``index`` is ``None`` when embedding failed
+    (rate limit / network) so the caller keeps the previous index untouched.
+    ``changed`` is ``False`` when the corpus is byte-for-byte identical to
+    ``previous`` (nothing to re-embed, no added/removed chunks) — the caller then
+    skips the commit.
+    """
+    if chunks is None:
+        chunks = docs.build_chunks(gh)
+
+    prev_by_id: dict[str, dict[str, Any]] = {}
+    if (
+        previous
+        and previous.get("model") == config.EMBED_MODEL
+        and previous.get("dim") == config.EMBED_DIM
+    ):
+        for raw in previous.get("chunks", []) or []:
+            if isinstance(raw, dict) and raw.get("id"):
+                prev_by_id[raw["id"]] = raw
+
+    to_embed: list[int] = []
+    for i, chunk in enumerate(chunks):
+        cached = prev_by_id.get(chunk.id)
+        if cached and cached.get("sha") == chunk.sha and cached.get("embedding"):
+            chunk.embedding = [float(x) for x in cached["embedding"]]
+        else:
+            to_embed.append(i)
+
+    if to_embed:
+        vectors = embed_texts(
+            [_chunk_embed_input(chunks[i]) for i in to_embed], token=token
+        )
+        if vectors is None:
+            return None, False
+        for i, vector in zip(to_embed, vectors):
+            chunks[i].embedding = vector
+
+    new_ids = {c.id for c in chunks}
+    changed = bool(to_embed) or new_ids != set(prev_by_id)
+
+    index = {
+        "schema": _SCHEMA,
+        "model": config.EMBED_MODEL,
+        "dim": config.EMBED_DIM,
+        "built_at": _now_iso(),
+        "chunks": [_chunk_to_dict(c) for c in chunks],
+    }
+    return index, changed
+
+
+def _post_record(post: dict[str, Any], embedding: list[float]) -> dict[str, Any]:
+    return {
+        "kind": post.get("kind", "issue"),
+        "number": int(post.get("number", 0)),
+        "title": str(post.get("title", "")),
+        "url": str(post.get("url", "")),
+        "state": post.get("state"),
+        "updated_at": post.get("updated_at"),
+        "sha": post_sha(str(post.get("title", "")), str(post.get("body", ""))),
+        "embedding": embedding,
+    }
+
+
+def _empty_posts_index() -> dict[str, Any]:
+    return {
+        "schema": _SCHEMA,
+        "model": config.EMBED_MODEL,
+        "dim": config.EMBED_DIM,
+        "built_at": _now_iso(),
+        "posts": [],
+    }
+
+
+def build_posts_index(
+    gh: GitHubClient,
+    posts: list[dict[str, Any]],
+    *,
+    token: str,
+    previous: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, bool]:
+    """Build the posts index from ``{kind,number,title,body,url,state,...}`` dicts."""
+    prev_by_key: dict[tuple[str, int], dict[str, Any]] = {}
+    if (
+        previous
+        and previous.get("model") == config.EMBED_MODEL
+        and previous.get("dim") == config.EMBED_DIM
+    ):
+        for raw in previous.get("posts", []) or []:
+            if isinstance(raw, dict) and raw.get("number") is not None:
+                prev_by_key[(raw.get("kind", "issue"), int(raw["number"]))] = raw
+
+    records: list[dict[str, Any]] = []
+    to_embed: list[dict[str, Any]] = []
+    embed_targets: list[str] = []
+    for post in posts[: config.INDEX_MAX_POSTS]:
+        key = (post.get("kind", "issue"), int(post.get("number", 0)))
+        sha = post_sha(str(post.get("title", "")), str(post.get("body", "")))
+        cached = prev_by_key.get(key)
+        if cached and cached.get("sha") == sha and cached.get("embedding"):
+            records.append(cached)
+        else:
+            to_embed.append(post)
+            embed_targets.append(
+                f"{post.get('title', '')}\n\n{post.get('body', '')}"
+            )
+
+    if to_embed:
+        vectors = embed_texts(embed_targets, token=token)
+        if vectors is None:
+            return None, False
+        for post, vector in zip(to_embed, vectors):
+            records.append(_post_record(post, vector))
+
+    changed = bool(to_embed) or {
+        (r.get("kind", "issue"), int(r.get("number", 0))) for r in records
+    } != set(prev_by_key)
+
+    records.sort(key=lambda r: int(r.get("number", 0)), reverse=True)
+    index = _empty_posts_index()
+    index["posts"] = records
+    return index, changed
+
+
+def append_post(
+    gh: GitHubClient, post: dict[str, Any], *, token: str
+) -> tuple[dict[str, Any] | None, bool]:
+    """Embed a single new post and upsert it into the posts index."""
+    previous = load_index(gh, config.POSTS_INDEX_PATH) or _empty_posts_index()
+    vector = embed_text(
+        f"{post.get('title', '')}\n\n{post.get('body', '')}", token=token
+    )
+    if vector is None:
+        return None, False
+    record = _post_record(post, vector)
+    key = (record["kind"], record["number"])
+    kept = [
+        p
+        for p in previous.get("posts", []) or []
+        if isinstance(p, dict)
+        and (p.get("kind", "issue"), int(p.get("number", 0))) != key
+    ]
+    kept.append(record)
+    kept.sort(key=lambda r: int(r.get("number", 0)), reverse=True)
+    kept = kept[: config.INDEX_MAX_POSTS]
+    index = _empty_posts_index()
+    index["posts"] = kept
+    return index, True
+
+
+def save_index(
+    gh: GitHubClient, path: str, index: dict[str, Any], *, message: str
+) -> Any:
+    """Persist a JSON index to the orphan index branch (dry-run aware)."""
+    return gh.commit_files(config.INDEX_BRANCH, {path: _dumps(index)}, message)

--- a/.github/scripts/ma_triage/gh.py
+++ b/.github/scripts/ma_triage/gh.py
@@ -210,6 +210,102 @@ class GitHubClient:
             log(f"Could not fetch {url}: {exc}")
         return None
 
+    def get_tree(
+        self, repo: str, ref: str = "main", *, recursive: bool = True
+    ) -> list[dict[str, Any]]:
+        """List a repo's git tree (used to enumerate the docs corpus).
+
+        ``ref`` may be a branch name or tree SHA. Returns the ``tree`` array of
+        ``{path, type, sha, ...}`` entries, or ``[]`` on any error.
+        """
+        params = {"recursive": "1"} if recursive else {}
+        try:
+            data = self._rest("GET", f"/repos/{repo}/git/trees/{ref}", params=params)
+        except Exception as exc:  # noqa: BLE001
+            log(f"Could not fetch tree {repo}@{ref}: {exc}")
+            return []
+        if isinstance(data, dict):
+            tree = data.get("tree")
+            if isinstance(tree, list):
+                return tree
+        return []
+
+    def get_ref_sha(self, branch: str, *, repo: str | None = None) -> str | None:
+        """Return the commit SHA a branch points at, or ``None`` if it is absent."""
+        repo = repo or self.repo
+        try:
+            data = self._rest("GET", f"/repos/{repo}/git/ref/heads/{branch}")
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                return None
+            raise
+        if isinstance(data, dict):
+            return (data.get("object") or {}).get("sha")
+        return None
+
+    def list_recent_issues(
+        self, *, state: str = "all", limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """Recent issues (newest-updated first), excluding pull requests."""
+        out: list[dict[str, Any]] = []
+        page = 1
+        while len(out) < limit:
+            batch = self._rest(
+                "GET",
+                f"/repos/{self.repo}/issues",
+                params={
+                    "state": state,
+                    "per_page": 100,
+                    "page": page,
+                    "sort": "updated",
+                    "direction": "desc",
+                },
+            )
+            if not batch:
+                break
+            for issue in batch:
+                if "pull_request" in issue:
+                    continue
+                out.append(issue)
+                if len(out) >= limit:
+                    break
+            if len(batch) < 100:
+                break
+            page += 1
+        return out
+
+    def list_discussions(self, *, limit: int = 500) -> list[dict[str, Any]]:
+        """Recent discussions via GraphQL (empty list if disabled/unavailable)."""
+        owner, name = self.repo.split("/", 1)
+        query = """
+        query($o:String!,$n:String!,$c:String){
+          repository(owner:$o,name:$n){
+            discussions(first:100, after:$c,
+              orderBy:{field:UPDATED_AT, direction:DESC}){
+              pageInfo{ hasNextPage endCursor }
+              nodes{ number title body url updatedAt closed category { name } }
+            }
+          }
+        }
+        """
+        out: list[dict[str, Any]] = []
+        cursor: str | None = None
+        while len(out) < limit:
+            try:
+                data = self.graphql(query, {"o": owner, "n": name, "c": cursor})
+            except Exception as exc:  # noqa: BLE001
+                log(f"Discussion listing failed: {exc}")
+                break
+            repo = (data.get("data") or {}).get("repository") or {}
+            disc = repo.get("discussions") or {}
+            nodes = disc.get("nodes") or []
+            out.extend(n for n in nodes if isinstance(n, dict))
+            page_info = disc.get("pageInfo") or {}
+            if not page_info.get("hasNextPage") or not nodes:
+                break
+            cursor = page_info.get("endCursor")
+        return out[:limit]
+
     # ------------------------------------------------------------------ #
     # Mutating helpers (no-op + log when dry-run)
     # ------------------------------------------------------------------ #
@@ -307,4 +403,65 @@ class GitHubClient:
         return self._mutate(
             f"minimize comment {node_id}",
             lambda: self.graphql(query, {"id": node_id, "classifier": classifier}),
+        )
+
+    def commit_files(
+        self,
+        branch: str,
+        files: dict[str, str],
+        message: str,
+        *,
+        repo: str | None = None,
+    ) -> Any:
+        """Commit text files to ``branch`` via the Git Data API (dry-run aware).
+
+        Creates the branch as a root (orphan) commit if it does not yet exist.
+        Used to persist the RAG indexes on the ``triage-index`` branch without
+        touching ``main``. Returns the new commit SHA, or ``None`` in dry-run.
+        """
+        repo = repo or self.repo
+        if not files:
+            return None
+
+        def _do() -> Any:
+            base_sha = self.get_ref_sha(branch, repo=repo)
+            base_tree: str | None = None
+            parents: list[str] = []
+            if base_sha:
+                commit = self._rest(
+                    "GET", f"/repos/{repo}/git/commits/{base_sha}"
+                )
+                base_tree = (commit.get("tree") or {}).get("sha")
+                parents = [base_sha]
+            tree_items = [
+                {"path": path, "mode": "100644", "type": "blob", "content": content}
+                for path, content in files.items()
+            ]
+            tree_body: dict[str, Any] = {"tree": tree_items}
+            if base_tree:
+                tree_body["base_tree"] = base_tree
+            new_tree = self._rest("POST", f"/repos/{repo}/git/trees", json=tree_body)
+            new_tree_sha = new_tree["sha"]
+            commit_obj = self._rest(
+                "POST",
+                f"/repos/{repo}/git/commits",
+                json={"message": message, "tree": new_tree_sha, "parents": parents},
+            )
+            new_commit_sha = commit_obj["sha"]
+            if base_sha:
+                self._rest(
+                    "PATCH",
+                    f"/repos/{repo}/git/refs/heads/{branch}",
+                    json={"sha": new_commit_sha, "force": True},
+                )
+            else:
+                self._rest(
+                    "POST",
+                    f"/repos/{repo}/git/refs",
+                    json={"ref": f"refs/heads/{branch}", "sha": new_commit_sha},
+                )
+            return new_commit_sha
+
+        return self._mutate(
+            f"commit {sorted(files)} to {repo}@{branch}", _do
         )

--- a/.github/scripts/ma_triage/models.py
+++ b/.github/scripts/ma_triage/models.py
@@ -120,6 +120,88 @@ class AIResult:
     user_message: str | None = None
 
 
+# --------------------------------------------------------------------------- #
+# RAG layer (Phase 2)
+# --------------------------------------------------------------------------- #
+@dataclass
+class DocChunk:
+    """A single heading-delimited chunk of a documentation page."""
+
+    id: str  # stable "<path>#<heading-anchor>"
+    path: str  # docs slug, e.g. "faq/troubleshooting"
+    url: str  # full cite URL incl. heading anchor
+    title: str  # page title (frontmatter or first H1)
+    heading: str  # this chunk's heading ("" for the page intro)
+    text: str
+    breadcrumbs: list[str] = field(default_factory=list)
+    sha: str = ""  # sha256 of ``text`` — lets the builder skip re-embedding
+    embedding: list[float] = field(default_factory=list)
+
+    @property
+    def label(self) -> str:
+        """Human-readable citation label for the comment."""
+        crumbs = [c for c in self.breadcrumbs if c]
+        return " › ".join(crumbs) if crumbs else (self.title or self.path)
+
+
+@dataclass
+class DocHit:
+    """A retrieved doc chunk with its fused relevance score."""
+
+    chunk: DocChunk
+    score: float
+
+
+@dataclass
+class DocAnswer:
+    """The judge model's verdict about whether the docs answer the question."""
+
+    answers_question: bool
+    confidence: float  # 0-1
+    answer: str
+    cited_sections: list[str] = field(default_factory=list)  # DocChunk ids
+
+
+@dataclass
+class RelatedPost:
+    """A similar past issue or discussion surfaced from the posts index."""
+
+    kind: str  # "issue" | "discussion"
+    number: int
+    title: str
+    url: str
+    score: float = 0.0
+    state: str | None = None  # "open" | "closed"
+
+
+@dataclass
+class RagResult:
+    """Everything the RAG layer decided for one post.
+
+    ``tier`` is one of ``"high" | "medium" | "low"``; only ``high``/``medium``
+    render anything in the comment (``low`` stays silent). This whole object is
+    ``None`` on ``TriageResult`` whenever the RAG layer is disabled or fails, so
+    Phase-1 behaviour is completely unchanged in that case.
+    """
+
+    tier: str = "low"
+    doc_answer: DocAnswer | None = None
+    cited_chunks: list[DocChunk] = field(default_factory=list)
+    doc_hits: list[DocHit] = field(default_factory=list)
+    related_posts: list[RelatedPost] = field(default_factory=list)
+    suppressed: bool = False
+
+    @property
+    def has_docs_output(self) -> bool:
+        return self.tier in ("high", "medium") and bool(
+            self.cited_chunks or self.doc_hits
+        )
+
+    @property
+    def has_output(self) -> bool:
+        return self.has_docs_output or bool(self.related_posts)
+
+
 @dataclass
 class TriageResult:
     """Everything the bot decided about an issue in one pass."""
@@ -150,6 +232,9 @@ class TriageResult:
     maintainers_to_ping: set[str] = field(default_factory=set)
     ai: AIResult | None = None
     diagnostics: Diagnostics | None = None
+    # RAG layer output (Phase 2). ``None`` whenever the RAG layer is disabled or
+    # failed, which keeps the rendered comment byte-identical to Phase 1.
+    rag: RagResult | None = None
 
     @property
     def is_actionable(self) -> bool:

--- a/.github/scripts/ma_triage/prompts/answer.prompt.yml
+++ b/.github/scripts/ma_triage/prompts/answer.prompt.yml
@@ -1,0 +1,61 @@
+# GitHub Models prompt file for the Music Assistant triage bot's doc-answer
+# judge (Phase 2 RAG layer). This is the source-of-truth copy of the judge
+# prompt + output schema; `ma_triage/ai.py` mirrors it at runtime so the bot has
+# no YAML runtime dependency. It can also be run/evaluated with the `gh models`
+# tooling. Keep the two in sync.
+name: MA triage docs answer judge
+description: >-
+  Given a Music Assistant issue and documentation sections retrieved by hybrid
+  search, decide whether the docs answer the question and produce a grounded,
+  cited answer with a confidence score.
+model: openai/gpt-4o
+modelParameters:
+  temperature: 0.1
+responseFormat: json_schema
+jsonSchema:
+  name: docs_answer
+  strict: true
+  schema:
+    type: object
+    additionalProperties: false
+    properties:
+      answers_question:
+        type: boolean
+        description: Whether the provided documentation sections answer the question.
+      confidence:
+        type: number
+        description: Confidence in the answer, from 0 to 1.
+      answer:
+        type: string
+        description: A concise, friendly answer grounded ONLY in the provided sections.
+      cited_sections:
+        type: array
+        description: The exact [id] values of the sections used to answer.
+        items:
+          type: string
+    required:
+      - answers_question
+      - confidence
+      - answer
+      - cited_sections
+messages:
+  - role: system
+    content: >-
+      You are a documentation assistant for the open-source project Music
+      Assistant. You are given a user's issue and a set of numbered documentation
+      sections retrieved from the official docs. Decide whether those sections
+      actually answer the user's question. Ground your answer ONLY in the
+      provided sections — never invent settings, versions, or steps that are not
+      present. Cite the sections you used by their exact [id]. If the sections do
+      not answer the question, set answers_question=false, keep confidence low,
+      and leave the answer brief. Reflect genuine uncertainty in `confidence`
+      (0-1). Keep the answer concise, friendly, and directly actionable.
+  - role: user
+    content: |-
+      ISSUE TITLE: {{title}}
+
+      ISSUE BODY (excerpt):
+      {{body}}
+
+      DOCUMENTATION SECTIONS:
+      {{sections}}

--- a/.github/scripts/ma_triage/rag.py
+++ b/.github/scripts/ma_triage/rag.py
@@ -1,0 +1,149 @@
+"""RAG orchestration — ties docs / embeddings / retrieval / similar / judge.
+
+One entry point, :func:`answer`, runs the whole docs-grounded-answer +
+related-posts pipeline for a single post and returns a :class:`RagResult`
+(or ``None``). It is wrapped so **any** failure degrades to ``None`` and leaves
+the deterministic Tier-0/Tier-1 triage completely untouched.
+
+Pipeline (≤ 1 embedding + ≤ 1 judge chat per post):
+
+1. embed the post once,
+2. hybrid-retrieve doc chunks (dense + BM25 + RRF),
+3. ask the judge whether the docs answer it,
+4. route to a confidence tier (HIGH / MEDIUM / LOW),
+5. find related past posts (dense, or search fallback),
+6. demote the tier if the answer matches a downvoted (suppressed) fingerprint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from . import ai, config, embeddings, similar
+from .gh import GitHubClient, log
+from .models import DocAnswer, DocChunk, DocHit, RagResult
+from .retrieval import cosine, retrieve_docs
+
+
+def tier_for(confidence: float) -> str:
+    """Map a judge confidence to ``high`` / ``medium`` / ``low``."""
+    if confidence >= config.ANSWER_HI:
+        return "high"
+    if confidence >= config.ANSWER_LO:
+        return "medium"
+    return "low"
+
+
+def demote(tier: str) -> str:
+    return {"high": "medium", "medium": "low"}.get(tier, "low")
+
+
+def fingerprint(cited_sections: list[str]) -> str:
+    """Stable fingerprint of an answer = hash of its sorted cited section ids."""
+    joined = "|".join(sorted(cited_sections))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+
+def is_suppressed(fp: str, suppress: list[dict]) -> bool:
+    """True if ``fp`` has accumulated enough downvotes to be suppressed."""
+    if not fp:
+        return False
+    for entry in suppress:
+        if entry.get("hash") == fp:
+            try:
+                votes = int(entry.get("downvotes", 0))
+            except (TypeError, ValueError):
+                votes = 0
+            return votes >= config.SUPPRESS_MIN_DOWNVOTES
+    return False
+
+
+def _resolve_cited(answer: DocAnswer, doc_hits: list[DocHit]) -> list[DocChunk]:
+    by_id = {hit.chunk.id: hit.chunk for hit in doc_hits}
+    chunks = [by_id[cid] for cid in answer.cited_sections if cid in by_id]
+    if chunks:
+        return chunks
+    # The judge answered but cited nothing usable — fall back to the top hits.
+    return [hit.chunk for hit in doc_hits[: config.DOCS_LINKS_SHOWN]]
+
+
+def _best_dense(query_vec: list[float], doc_hits: list[DocHit]) -> float:
+    if not query_vec or not doc_hits:
+        return 0.0
+    return max(cosine(query_vec, hit.chunk.embedding) for hit in doc_hits)
+
+
+def answer(
+    gh: GitHubClient,
+    *,
+    title: str,
+    body: str,
+    number: int,
+    token: str,
+) -> RagResult | None:
+    """Run the RAG pipeline for one post. ``None`` when disabled or on failure."""
+    if not (config.AI_ENABLED and config.RAG_ENABLED):
+        return None
+    try:
+        query_text = f"{title}\n\n{body}".strip()
+        query_vec = embeddings.embed_text(query_text, token=token)
+        if query_vec is None:
+            # Embeddings unavailable (e.g. rate limited) → skip the whole layer.
+            return None
+
+        chunks = embeddings.load_docs_chunks(gh)
+        doc_hits = retrieve_docs(query_vec, query_text, chunks)
+
+        judge: DocAnswer | None = None
+        if doc_hits:
+            judge = ai.judge_answer(title, body, doc_hits, token=token)
+
+        # Decide the confidence tier.
+        if judge is not None:
+            tier = tier_for(judge.confidence) if judge.answers_question else "low"
+        elif doc_hits and _best_dense(query_vec, doc_hits) >= config.DOCS_MIN_DENSE:
+            # Judge call failed but retrieval is strong → links-only MEDIUM.
+            tier = "medium"
+        else:
+            tier = "low"
+
+        # Suppression: demote if this answer shape was previously downvoted.
+        suppressed = False
+        cited_ids = judge.cited_sections if judge else [h.chunk.id for h in doc_hits[:1]]
+        fp = fingerprint(cited_ids)
+        if tier in ("high", "medium") and is_suppressed(
+            fp, embeddings.load_suppress(gh)
+        ):
+            tier = demote(tier)
+            suppressed = True
+
+        # Resolve what the comment will render for the docs section.
+        doc_answer: DocAnswer | None = None
+        cited_chunks: list[DocChunk] = []
+        if tier == "high" and judge is not None and judge.answers_question:
+            doc_answer = judge
+            cited_chunks = _resolve_cited(judge, doc_hits)
+
+        # Related posts are independent of the docs tier (dupes may post even
+        # when the docs answer is LOW).
+        posts = embeddings.load_posts(gh)
+        related = similar.find_related(
+            gh,
+            query_vec=query_vec,
+            title=title,
+            posts=posts,
+            exclude_number=number,
+        )
+
+        result = RagResult(
+            tier=tier,
+            doc_answer=doc_answer,
+            cited_chunks=cited_chunks,
+            doc_hits=doc_hits,
+            related_posts=related,
+            suppressed=suppressed,
+        )
+        return result if result.has_output else None
+    except Exception as exc:  # noqa: BLE001 — never let RAG break triage
+        log(f"RAG layer skipped: {exc}")
+        return None

--- a/.github/scripts/ma_triage/retrieval.py
+++ b/.github/scripts/ma_triage/retrieval.py
@@ -1,0 +1,140 @@
+"""Local hybrid retrieval — dense cosine + BM25, fused with RRF.
+
+No model cost: the incoming post is embedded **once** by the caller; everything
+here is pure Python over the in-memory index (a few thousand vectors at most, so
+plain lists are fast enough and keep the dependency footprint at zero).
+
+* **Dense** cosine over the embedding vectors captures semantic similarity.
+* **BM25** over tokenized breadcrumbs+body rescues exact tokens the embedder can
+  blur — provider domains (``youtube_music``), error codes, CLI flags, etc.
+* **Reciprocal Rank Fusion (RRF)** combines the two rankings without needing the
+  scores to be on comparable scales.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+
+from . import config
+from .models import DocChunk, DocHit
+
+_RE_TOKEN = re.compile(r"[a-z0-9_]+")
+
+
+def tokenize(text: str | None) -> list[str]:
+    """Lower-case tokeniser that also splits underscore-joined identifiers.
+
+    ``youtube_music`` yields ``["youtube_music", "youtube", "music"]`` so both the
+    exact domain and its parts contribute to BM25.
+    """
+    if not text:
+        return []
+    tokens: list[str] = []
+    for raw in _RE_TOKEN.findall(text.lower()):
+        tokens.append(raw)
+        if "_" in raw:
+            tokens.extend(part for part in raw.split("_") if part)
+    return tokens
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity of two equal-length vectors (0.0 if either is empty)."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def rank_by_cosine(query: list[float], vectors: list[list[float]]) -> list[int]:
+    """Indices of ``vectors`` ordered by descending cosine to ``query``."""
+    if not query:
+        return []
+    scored = [(i, cosine(query, vec)) for i, vec in enumerate(vectors)]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return [i for i, score in scored if score > 0.0]
+
+
+def bm25_scores(
+    query_tokens: list[str], docs_tokens: list[list[str]]
+) -> list[float]:
+    """Okapi BM25 score of each document for the query."""
+    n = len(docs_tokens)
+    if n == 0 or not query_tokens:
+        return [0.0] * n
+    doc_len = [len(tokens) for tokens in docs_tokens]
+    avgdl = sum(doc_len) / n if n else 0.0
+    # Document frequency per term.
+    df: Counter[str] = Counter()
+    doc_counters: list[Counter[str]] = []
+    for tokens in docs_tokens:
+        counts = Counter(tokens)
+        doc_counters.append(counts)
+        for term in counts:
+            df[term] += 1
+
+    k1 = config.BM25_K1
+    b = config.BM25_B
+    query_terms = set(query_tokens)
+    scores = [0.0] * n
+    for term in query_terms:
+        n_qi = df.get(term, 0)
+        if n_qi == 0:
+            continue
+        idf = math.log(1 + (n - n_qi + 0.5) / (n_qi + 0.5))
+        for i, counts in enumerate(doc_counters):
+            freq = counts.get(term, 0)
+            if not freq:
+                continue
+            denom = freq + k1 * (1 - b + b * (doc_len[i] / avgdl if avgdl else 0))
+            scores[i] += idf * (freq * (k1 + 1)) / denom
+    return scores
+
+
+def rank_by_bm25(query_tokens: list[str], docs_tokens: list[list[str]]) -> list[int]:
+    """Indices ordered by descending BM25 score (only positive scores kept)."""
+    scores = bm25_scores(query_tokens, docs_tokens)
+    order = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
+    return [i for i in order if scores[i] > 0.0]
+
+
+def rrf(rank_lists: list[list[int]], *, k: int | None = None) -> dict[int, float]:
+    """Reciprocal Rank Fusion: ``score(d) = Σ 1/(k + rank_in_list(d))``."""
+    k = config.RRF_K if k is None else k
+    fused: dict[int, float] = {}
+    for ranking in rank_lists:
+        for rank, idx in enumerate(ranking):
+            fused[idx] = fused.get(idx, 0.0) + 1.0 / (k + rank + 1)
+    return fused
+
+
+def retrieve_docs(
+    query_vec: list[float] | None,
+    query_text: str,
+    chunks: list[DocChunk],
+    *,
+    k: int | None = None,
+) -> list[DocHit]:
+    """Hybrid retrieval → the top-``k`` :class:`DocHit` for a query."""
+    if not chunks:
+        return []
+    top_k = config.DOCS_TOP_K if k is None else k
+
+    dense_rank = rank_by_cosine(query_vec or [], [c.embedding for c in chunks])
+    docs_tokens = [tokenize(f"{c.label} {c.text}") for c in chunks]
+    lexical_rank = rank_by_bm25(tokenize(query_text), docs_tokens)
+
+    fused = rrf([dense_rank, lexical_rank])
+    if not fused:
+        return []
+    ordered = sorted(fused.items(), key=lambda pair: pair[1], reverse=True)
+    return [DocHit(chunk=chunks[idx], score=score) for idx, score in ordered[:top_k]]

--- a/.github/scripts/ma_triage/sanitize.py
+++ b/.github/scripts/ma_triage/sanitize.py
@@ -12,9 +12,16 @@ GitHub comment, to prevent:
 
 from __future__ import annotations
 
+import re
+
 from . import config
 
 _ZERO_WIDTH = "\u200b"
+_RE_URL_SCHEME = re.compile(
+    r"(?i)\b([a-z][a-z0-9+.-]{1,31}):(?=//)"
+)
+_RE_MAILTO = re.compile(r"(?i)\b(mailto):")
+_RE_WWW = re.compile(r"(?i)\b(www)(?=\.)")
 
 
 def _common(value: str, max_len: int) -> str:
@@ -42,3 +49,39 @@ def fenced(value: str | None, max_len: int = config.MAX_STRING_ECHO * 4) -> str:
         return ""
     value = str(value).replace("`", "'")  # can't break out of the fence
     return _common(value, max_len)
+
+
+def _escape_markdown_brackets(value: str) -> str:
+    """Escape link-label delimiters without a preceding backslash undoing it."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+    )
+
+
+def link_label(
+    value: str | None, max_len: int = config.MAX_STRING_ECHO
+) -> str:
+    """Sanitise untrusted text used inside a Markdown link label."""
+    return _escape_markdown_brackets(inline(value, max_len=max_len))
+
+
+def markdown_safe(
+    value: str | None, max_len: int = config.MAX_STRING_ECHO * 4
+) -> str:
+    """Sanitise multi-line prose rendered directly as Markdown.
+
+    In addition to the common mention/HTML/fence protections, link/image syntax
+    is escaped and URL schemes are broken so model-influenced prose cannot make
+    the trusted bot publish an arbitrary clickable link. Deliberate trusted
+    citations are rendered separately by the caller.
+    """
+    if not value:
+        return ""
+    value = str(value).replace("`", "'")
+    value = _common(value, max_len)
+    value = _escape_markdown_brackets(value)
+    value = _RE_URL_SCHEME.sub(r"\1:" + _ZERO_WIDTH, value)
+    value = _RE_MAILTO.sub(r"\1:" + _ZERO_WIDTH, value)
+    return _RE_WWW.sub(r"\1" + _ZERO_WIDTH, value)

--- a/.github/scripts/ma_triage/similar.py
+++ b/.github/scripts/ma_triage/similar.py
@@ -1,0 +1,130 @@
+"""Related-post / duplicate detection.
+
+Surfaces earlier issues and discussions that look similar to the incoming post,
+so a reporter (and a maintainer) can spot an existing answer or a likely
+duplicate. Two paths:
+
+* **primary** — dense cosine over the ``posts.json`` embeddings index (semantic,
+  free, catches rewordings),
+* **fallback** — when the index is absent/empty, degrade gracefully to GitHub's
+  own issue search over the report's title keywords.
+
+The incoming post's own number is always excluded, and results are de-duplicated
+and thresholded so the comment only ever shows genuinely-relevant links.
+"""
+
+from __future__ import annotations
+
+import re
+
+from . import config
+from .gh import GitHubClient, log
+from .models import RelatedPost
+from .retrieval import cosine
+
+_RE_WORD = re.compile(r"[A-Za-z0-9]+")
+
+
+def related_from_index(
+    query_vec: list[float] | None,
+    posts: list[dict],
+    *,
+    exclude_number: int,
+    k: int | None = None,
+    min_score: float | None = None,
+) -> list[RelatedPost]:
+    """Dense-cosine related posts from the loaded posts index (pure)."""
+    if not query_vec or not posts:
+        return []
+    top_k = config.RELATED_POSTS if k is None else k
+    threshold = config.RELATED_MIN_SCORE if min_score is None else min_score
+
+    scored: list[tuple[float, dict]] = []
+    seen: set[tuple[str, int]] = set()
+    for post in posts:
+        number = int(post.get("number", 0))
+        kind = post.get("kind", "issue")
+        if kind == "issue" and number == exclude_number:
+            continue
+        key = (kind, number)
+        if key in seen:
+            continue
+        seen.add(key)
+        score = cosine(query_vec, [float(x) for x in post.get("embedding", [])])
+        if score >= threshold:
+            scored.append((score, post))
+
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    results: list[RelatedPost] = []
+    for score, post in scored[:top_k]:
+        results.append(
+            RelatedPost(
+                kind=post.get("kind", "issue"),
+                number=int(post.get("number", 0)),
+                title=str(post.get("title", "")),
+                url=str(post.get("url", "")),
+                score=round(score, 4),
+                state=post.get("state"),
+            )
+        )
+    return results
+
+
+def _title_query(title: str) -> str:
+    """Reduce a (untrusted) title to plain keywords for a search query."""
+    words = _RE_WORD.findall(title or "")
+    # Drop very short/noise words and cap the number of terms.
+    keywords = [w for w in words if len(w) > 2][:8]
+    return " ".join(keywords)
+
+
+def related_from_search(
+    gh: GitHubClient, title: str, *, exclude_number: int, k: int | None = None
+) -> list[RelatedPost]:
+    """Fallback: GitHub issue search over the title keywords."""
+    top_k = config.RELATED_POSTS if k is None else k
+    keywords = _title_query(title)
+    if not keywords:
+        return []
+    query = f"repo:{gh.repo} is:issue {keywords}"
+    try:
+        data = gh.search_issues(query, per_page=top_k + 5)
+    except Exception as exc:  # noqa: BLE001
+        log(f"Related-post search fallback failed: {exc}")
+        return []
+    results: list[RelatedPost] = []
+    for item in data.get("items", []) or []:
+        if "pull_request" in item:
+            continue
+        number = int(item.get("number", 0))
+        if number == exclude_number:
+            continue
+        results.append(
+            RelatedPost(
+                kind="issue",
+                number=number,
+                title=str(item.get("title", "")),
+                url=str(item.get("html_url", "")),
+                score=0.0,
+                state=item.get("state"),
+            )
+        )
+        if len(results) >= top_k:
+            break
+    return results
+
+
+def find_related(
+    gh: GitHubClient,
+    *,
+    query_vec: list[float] | None,
+    title: str,
+    posts: list[dict],
+    exclude_number: int,
+) -> list[RelatedPost]:
+    """Related posts from the index when available, else the search fallback."""
+    if posts and query_vec:
+        hits = related_from_index(query_vec, posts, exclude_number=exclude_number)
+        if hits:
+            return hits
+    return related_from_search(gh, title, exclude_number=exclude_number)

--- a/.github/scripts/tests/conftest.py
+++ b/.github/scripts/tests/conftest.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import pathlib
+import re
 import sys
 
 import pytest
@@ -19,17 +21,41 @@ FIXTURES = pathlib.Path(__file__).resolve().parent / "fixtures"
 os.environ.setdefault("TRIAGE_DRY_RUN", "false")
 os.environ.setdefault("TRIAGE_AI_ENABLED", "false")
 
+# Small embedding dimension used by the deterministic fake embedder below.
+FAKE_DIM = 16
+
+
+def fake_embedding(text: str | None, dim: int = FAKE_DIM) -> list[float]:
+    """Deterministic bag-of-tokens embedding for offline tests.
+
+    Texts that share tokens get a higher cosine similarity, so retrieval /
+    related-post ordering is meaningful without any network calls.
+    """
+    vec = [0.0] * dim
+    for token in re.findall(r"[a-z0-9]+", (text or "").lower()):
+        idx = int(hashlib.md5(token.encode()).hexdigest(), 16) % dim
+        vec[idx] += 1.0
+    return vec
+
+
 
 class FakeGH:
     """A stand-in for GitHubClient that records mutations and serves canned reads."""
 
-    def __init__(self, *, latest_tag="2.9.5", labels=None, manifests=None):
+    def __init__(self, *, latest_tag="2.9.5", labels=None, manifests=None,
+                 index_files=None, tree=None, issues=None, discussions=None,
+                 search_items=None):
         self.dry_run = False
         self.repo = "music-assistant/support"
         self._latest_tag = latest_tag
         self._labels = set(labels or [])
         self._manifests = manifests or {}
         self._comments: list[dict] = []
+        self._index_files: dict[str, str] = dict(index_files or {})
+        self._tree = list(tree or [])
+        self._issues = list(issues or [])
+        self._discussions = list(discussions or [])
+        self._search_items = list(search_items or [])
         self.calls: list[tuple] = []
 
     # reads -----------------------------------------------------------------
@@ -37,22 +63,37 @@ class FakeGH:
         return {"tag_name": self._latest_tag} if self._latest_tag else None
 
     def get_raw_file(self, repo, path, ref="main"):
+        if path in self._index_files:
+            return self._index_files[path]
         for domain, content in self._manifests.items():
             if f"/{domain}/" in path:
                 return json.dumps(content)
+        return None
+
+    def get_tree(self, repo, ref="main", *, recursive=True):
+        return list(self._tree)
+
+    def get_ref_sha(self, branch, *, repo=None):
         return None
 
     def list_labels(self):
         return set(self._labels)
 
     def search_issues(self, query, per_page=10):
-        return {"total_count": 0, "items": []}
+        return {"total_count": len(self._search_items),
+                "items": list(self._search_items)[:per_page]}
 
     def list_comments(self, number):
         return list(self._comments)
 
     def get_issue(self, number):
         return {"number": number, "labels": [], "user": {"login": "reporter"}}
+
+    def list_recent_issues(self, *, state="all", limit=500):
+        return list(self._issues)[:limit]
+
+    def list_discussions(self, *, limit=500):
+        return list(self._discussions)[:limit]
 
     # mutations (recorded) --------------------------------------------------
     def add_labels(self, number, labels):
@@ -77,6 +118,13 @@ class FakeGH:
 
     def list_issues_with_label(self, label, state="open"):
         return []
+
+    def commit_files(self, branch, files, message, *, repo=None):
+        self.calls.append(("commit_files", branch, tuple(sorted(files)), message))
+        if self.dry_run:
+            return None
+        self._index_files.update(files)
+        return "deadbeef"
 
 
 @pytest.fixture
@@ -104,3 +152,30 @@ def injection_raw():
 @pytest.fixture
 def sample_log():
     return (FIXTURES / "sample.log").read_bytes()
+
+
+@pytest.fixture
+def fake_embed():
+    """The deterministic embedding function (see :func:`fake_embedding`)."""
+    return fake_embedding
+
+
+@pytest.fixture
+def ai_on(monkeypatch):
+    """Enable the RAG layer with a small dim and a deterministic embedder.
+
+    Patches the embeddings client so no network is touched; returns the
+    ``fake_embedding`` helper so tests can build matching index vectors.
+    """
+    from ma_triage import config, embeddings
+
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", True)
+    monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, token: [fake_embedding(t) for t in texts],
+    )
+    return fake_embedding
+

--- a/.github/scripts/tests/test_ai_judge.py
+++ b/.github/scripts/tests/test_ai_judge.py
@@ -1,0 +1,121 @@
+"""Tests for the Tier-1.5 doc-answer judge (ai.judge_answer)."""
+
+import json
+
+from ma_triage import ai, config
+from ma_triage.models import DocChunk, DocHit
+
+
+class _Resp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+        self.content = b"x"
+
+    def json(self):
+        return self._payload
+
+    @property
+    def text(self):
+        return json.dumps(self._payload)
+
+
+def _hit(cid="faq/x#h", text="some docs text"):
+    return DocHit(
+        chunk=DocChunk(
+            id=cid, path="faq/x", url="https://x/faq/x/#h", title="X", heading="h",
+            text=text, breadcrumbs=["X", "h"],
+        ),
+        score=0.5,
+    )
+
+
+def _payload(obj):
+    return {"choices": [{"message": {"content": json.dumps(obj)}}]}
+
+
+def _enable(monkeypatch):
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", True)
+
+
+def test_judge_disabled_returns_none(monkeypatch):
+    monkeypatch.setattr(config, "AI_ENABLED", False)
+    assert ai.judge_answer("t", "b", [_hit()], token="x") is None
+
+
+def test_judge_no_hits_returns_none(monkeypatch):
+    _enable(monkeypatch)
+    assert ai.judge_answer("t", "b", [], token="x") is None
+
+
+def test_judge_happy_path_filters_cited(monkeypatch):
+    _enable(monkeypatch)
+    obj = {
+        "answers_question": True, "confidence": 0.9,
+        "answer": "Try enabling multicast.",
+        "cited_sections": ["faq/x#h", "totally-made-up"],
+    }
+    monkeypatch.setattr(ai.requests, "post", lambda *a, **k: _Resp(_payload(obj)))
+    result = ai.judge_answer("title", "body", [_hit("faq/x#h")], token="x")
+    assert result is not None
+    assert result.answers_question is True
+    assert result.confidence == 0.9
+    # Hallucinated id dropped; only the real section id survives.
+    assert result.cited_sections == ["faq/x#h"]
+
+
+def test_judge_http_error_returns_none(monkeypatch):
+    _enable(monkeypatch)
+    monkeypatch.setattr(
+        ai.requests, "post", lambda *a, **k: _Resp({"error": "no"}, status=429)
+    )
+    assert ai.judge_answer("t", "b", [_hit()], token="x") is None
+
+
+def test_judge_malformed_returns_none(monkeypatch):
+    _enable(monkeypatch)
+    bad = {"choices": [{"message": {"content": "not json"}}]}
+    monkeypatch.setattr(ai.requests, "post", lambda *a, **k: _Resp(bad))
+    assert ai.judge_answer("t", "b", [_hit()], token="x") is None
+
+
+def test_judge_coerces_and_clamps(monkeypatch):
+    _enable(monkeypatch)
+    monkeypatch.setattr(config, "MAX_DOC_ANSWER_CHARS", 10)
+    obj = {
+        "answers_question": True, "confidence": 5,  # out of range
+        "answer": "x" * 100,  # too long
+        "cited_sections": "not-a-list",
+    }
+    monkeypatch.setattr(ai.requests, "post", lambda *a, **k: _Resp(_payload(obj)))
+    result = ai.judge_answer("t", "b", [_hit()], token="x")
+    assert result.confidence == 1.0
+    assert len(result.answer) == 10
+    assert result.cited_sections == []
+
+
+def test_judge_messages_are_sanitized(monkeypatch):
+    _enable(monkeypatch)
+    hit = _hit(text="ping @maintainer see <script>")
+    messages = ai.build_answer_messages("title @x", "body #1", [hit])
+    blob = json.dumps(messages)
+    assert "<script>" not in blob
+    assert "@maintainer" not in blob  # mentions neutralised
+
+
+def test_judge_shows_raw_cited_id_and_round_trips(monkeypatch):
+    _enable(monkeypatch)
+    cid = "faq/troubleshooting#networking"
+    hit = _hit(cid)
+    # The id must appear verbatim (no zero-width space injected after '#'), or the
+    # model can't echo an id that survives the exact-match citation filter.
+    content = ai.build_answer_messages("t", "b", [hit])[1]["content"]
+    assert f"[{cid}]" in content
+    assert "\u200b" not in content
+
+    obj = {"answers_question": True, "confidence": 0.9, "answer": "a",
+           "cited_sections": [cid]}
+    monkeypatch.setattr(ai.requests, "post", lambda *a, **k: _Resp(_payload(obj)))
+    res = ai.judge_answer("t", "b", [hit], token="x")
+    assert res.cited_sections == [cid]  # faithfully-echoed id is kept, not dropped

--- a/.github/scripts/tests/test_comment_rag.py
+++ b/.github/scripts/tests/test_comment_rag.py
@@ -1,5 +1,7 @@
 """Tests for rendering the RAG sections into the sticky comment."""
 
+import re
+
 from ma_triage import comment, config
 from ma_triage.models import (
     DocAnswer,
@@ -77,3 +79,51 @@ def test_build_body_low_tier_shows_only_related():
     assert config.DOCS_LINKS_HEADING not in body
     assert config.RELATED_POSTS_HEADING in body
     assert "#12: similar q" in body
+
+
+def test_related_post_title_cannot_break_out_of_link_label():
+    rag = RagResult(
+        tier="low",
+        related_posts=[
+            RelatedPost(
+                "issue",
+                50,
+                "pwn](https://evil.example)",
+                "https://github.com/music-assistant/support/issues/50",
+                0.9,
+                "open",
+            )
+        ],
+    )
+    body = comment.build_body(
+        TriageResult(form_kind="main", missing_attachment=True, rag=rag)
+    )
+    assert (
+        r"[#50: pwn\](https://evil.example)]"
+        "(https://github.com/music-assistant/support/issues/50)"
+    ) in body
+    assert re.search(r"(?<!\\)\]\(https://evil\.example\)", body) is None
+
+
+def test_judge_answer_cannot_publish_markdown_or_bare_links():
+    answer = (
+        "[click](https://evil.example) "
+        "![x](https://evil.example/image.png) "
+        "or visit https://evil.example directly"
+    )
+    rag = RagResult(
+        tier="high",
+        doc_answer=DocAnswer(True, 0.9, answer, ["faq/net#mdns"]),
+        cited_chunks=[_chunk()],
+    )
+    body = comment.build_body(
+        TriageResult(form_kind="main", missing_attachment=True, rag=rag)
+    )
+    assert "https://evil.example" not in body
+    assert r"\[click\]" in body
+    assert r"!\[x\]" in body
+    assert "https:\u200b//evil.example" in body
+    # The separately-rendered, trusted citation remains clickable.
+    assert (
+        "](https://www.music-assistant.io/faq/net/#mdns)" in body
+    )

--- a/.github/scripts/tests/test_comment_rag.py
+++ b/.github/scripts/tests/test_comment_rag.py
@@ -1,0 +1,79 @@
+"""Tests for rendering the RAG sections into the sticky comment."""
+
+from ma_triage import comment, config
+from ma_triage.models import (
+    DocAnswer,
+    DocChunk,
+    DocHit,
+    RagResult,
+    RelatedPost,
+    TriageResult,
+)
+
+
+def _chunk(cid="faq/net#mdns"):
+    return DocChunk(
+        id=cid, path="faq/net", url="https://www.music-assistant.io/faq/net/#mdns",
+        title="Networking", heading="mDNS", text="multicast", breadcrumbs=["Networking", "mDNS"],
+    )
+
+
+def test_build_body_high_tier_renders_answer_and_sources():
+    rag = RagResult(
+        tier="high",
+        doc_answer=DocAnswer(True, 0.9, "Enable multicast on your switch.", ["faq/net#mdns"]),
+        cited_chunks=[_chunk()],
+        related_posts=[RelatedPost("issue", 50, "sonos discovery", "https://x/50", 0.8, "closed")],
+    )
+    result = TriageResult(form_kind="main", missing_attachment=True, rag=rag)
+    body = comment.build_body(result)
+    assert config.DOCS_ANSWER_HEADING in body
+    assert "Enable multicast on your switch." in body
+    assert "https://www.music-assistant.io/faq/net/#mdns" in body
+    assert config.RELATED_POSTS_HEADING in body
+    assert "#50: sonos discovery" in body
+    assert "_(closed)_" in body
+
+
+def test_build_body_medium_tier_links_only():
+    rag = RagResult(tier="medium", doc_hits=[DocHit(_chunk(), 0.4)])
+    result = TriageResult(form_kind="main", missing_attachment=True, rag=rag)
+    body = comment.build_body(result)
+    assert config.DOCS_LINKS_HEADING in body
+    assert "https://www.music-assistant.io/faq/net/#mdns" in body
+    # No generated prose in a medium (links-only) answer.
+    assert config.DOCS_ANSWER_HEADING not in body
+
+
+def test_build_body_sanitizes_answer():
+    rag = RagResult(
+        tier="high",
+        doc_answer=DocAnswer(True, 0.9, "ping @maintainer and <script>alert(1)</script>", ["faq/net#mdns"]),
+        cited_chunks=[_chunk()],
+    )
+    result = TriageResult(form_kind="main", missing_attachment=True, rag=rag)
+    body = comment.build_body(result)
+    assert "@maintainer" not in body  # mention neutralised
+    assert "<script>" not in body  # HTML escaped
+
+
+def test_build_body_no_rag_is_unchanged():
+    """With rag=None (AI off) the comment carries no RAG sections at all."""
+    result = TriageResult(form_kind="main", missing_attachment=True, rag=None)
+    body = comment.build_body(result)
+    assert config.DOCS_ANSWER_HEADING not in body
+    assert config.DOCS_LINKS_HEADING not in body
+    assert config.RELATED_POSTS_HEADING not in body
+
+
+def test_build_body_low_tier_shows_only_related():
+    rag = RagResult(
+        tier="low",
+        related_posts=[RelatedPost("discussion", 12, "similar q", "https://x/12", 0.6, "open")],
+    )
+    result = TriageResult(form_kind="main", missing_attachment=True, rag=rag)
+    body = comment.build_body(result)
+    assert config.DOCS_ANSWER_HEADING not in body
+    assert config.DOCS_LINKS_HEADING not in body
+    assert config.RELATED_POSTS_HEADING in body
+    assert "#12: similar q" in body

--- a/.github/scripts/tests/test_docs.py
+++ b/.github/scripts/tests/test_docs.py
@@ -1,0 +1,117 @@
+"""Tests for docs fetching / heading-based chunking (pure, offline)."""
+
+from ma_triage import config, docs
+
+
+def test_slug_for_variants():
+    assert docs.slug_for("src/content/docs/faq/troubleshooting.md") == "faq/troubleshooting"
+    assert docs.slug_for("src/content/docs/index.md") == ""
+    assert docs.slug_for("src/content/docs/settings/core.mdx") == "settings/core"
+    assert docs.slug_for("src/content/docs/player-support/index.md") == "player-support"
+
+
+def test_url_and_anchor():
+    assert docs.url_for("faq/troubleshooting") == "https://www.music-assistant.io/faq/troubleshooting/"
+    assert docs.url_for("") == "https://www.music-assistant.io/"
+    assert (
+        docs.url_for("faq/troubleshooting", "my-heading")
+        == "https://www.music-assistant.io/faq/troubleshooting/#my-heading"
+    )
+    assert docs.anchor_for("Networking & mDNS!") == "networking-mdns"
+
+
+def test_parse_frontmatter():
+    title, body = docs.parse_frontmatter("---\ntitle: Hello World\ndescription: x\n---\n\n# H1\ntext")
+    assert title == "Hello World"
+    assert body.strip().startswith("# H1")
+
+
+def test_strip_mdx_removes_imports_and_jsx():
+    body = "import Foo from 'bar';\n\n<Card>hi</Card>\n<!-- secret -->\ntext"
+    out = docs.strip_mdx(body)
+    assert "import Foo" not in out
+    assert "<Card>" not in out
+    assert "secret" not in out
+    assert "text" in out
+
+
+def test_chunk_document_by_heading():
+    raw = (
+        "---\ntitle: Troubleshooting\n---\n\n"
+        "# First steps\n\nLook in the logs.\n\n"
+        "## Networking\n\nRunning behind VPNs is not supported.\n\n"
+        "### mDNS\n\nPlayers are discovered using mDNS.\n"
+    )
+    chunks = docs.chunk_document("src/content/docs/faq/troubleshooting.md", raw)
+    ids = [c.id for c in chunks]
+    assert ids == [
+        "faq/troubleshooting#first-steps",
+        "faq/troubleshooting#networking",
+        "faq/troubleshooting#mdns",
+    ]
+    networking = next(c for c in chunks if c.heading == "Networking")
+    assert networking.breadcrumbs == ["Troubleshooting", "First steps", "Networking"]
+    assert networking.url == "https://www.music-assistant.io/faq/troubleshooting/#networking"
+    assert all(c.sha for c in chunks)  # every chunk has a content SHA
+
+
+def test_chunk_document_intro_before_first_heading():
+    raw = "---\ntitle: Intro Page\n---\n\nSome intro text with no heading yet.\n\n# Later\n\nmore\n"
+    chunks = docs.chunk_document("src/content/docs/intro.md", raw)
+    assert chunks[0].id == "intro"
+    assert chunks[0].heading == ""
+    assert chunks[0].breadcrumbs == ["Intro Page"]
+
+
+def test_chunk_document_splits_long_sections(monkeypatch):
+    monkeypatch.setattr(config, "DOCS_CHUNK_MAX_CHARS", 40)
+    para = "word " * 20  # ~100 chars
+    raw = f"---\ntitle: Big\n---\n\n# Section\n\n{para}\n\n{para}\n"
+    chunks = docs.chunk_document("src/content/docs/big.md", raw)
+    assert len(chunks) >= 2
+    assert all(len(c.text) <= 40 for c in chunks)
+    # Split pieces get suffixed, unique ids.
+    assert len(set(c.id for c in chunks)) == len(chunks)
+
+
+def test_chunk_document_ignores_headings_in_code_fences():
+    raw = (
+        "---\ntitle: Code\n---\n\n"
+        "# Real heading\n\n```\n# not a heading\nsome code\n```\n\nmore text\n"
+    )
+    chunks = docs.chunk_document("src/content/docs/code.md", raw)
+    assert len(chunks) == 1
+    assert chunks[0].heading == "Real heading"
+    assert "not a heading" in chunks[0].text
+
+
+def test_chunk_sha_changes_when_title_changes():
+    body = "# Section\n\nidentical body text\n"
+    old = docs.chunk_document("src/content/docs/p.md", "---\ntitle: Old\n---\n\n" + body)
+    new = docs.chunk_document("src/content/docs/p.md", "---\ntitle: New\n---\n\n" + body)
+    # Body text is identical, but the breadcrumb label changed with the title, so
+    # the SHA (used as the embed cache key) must differ to force a re-embed.
+    assert old[0].text == new[0].text
+    assert old[0].sha != new[0].sha
+
+
+def test_doc_paths_filters_and_excludes(fake_gh, monkeypatch):
+    monkeypatch.setattr(
+        fake_gh,
+        "_tree",
+        [
+            {"path": "src/content/docs/faq/troubleshooting.md", "type": "blob"},
+            {"path": "src/content/docs/settings/core.mdx", "type": "blob"},
+            {"path": "src/content/docs/blog/2024/post.md", "type": "blob"},
+            {"path": "src/content/docs/assets/logo.png", "type": "blob"},
+            {"path": "src/content/docs/faq", "type": "tree"},
+            {"path": "README.md", "type": "blob"},
+        ],
+        raising=False,
+    )
+    paths = docs.doc_paths(fake_gh)
+    assert "src/content/docs/faq/troubleshooting.md" in paths
+    assert "src/content/docs/settings/core.mdx" in paths
+    assert not any("blog/" in p for p in paths)  # blog excluded by default
+    assert not any(p.endswith(".png") for p in paths)
+    assert "README.md" not in paths

--- a/.github/scripts/tests/test_embeddings.py
+++ b/.github/scripts/tests/test_embeddings.py
@@ -1,0 +1,193 @@
+"""Tests for the embeddings client + JSON index read/write/build."""
+
+import json
+
+import pytest
+
+from conftest import FAKE_DIM, FakeGH, fake_embedding
+from ma_triage import config, embeddings
+from ma_triage.models import DocChunk
+
+
+class _Resp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+        self.content = b"x"
+
+    def json(self):
+        return self._payload
+
+    @property
+    def text(self):
+        return json.dumps(self._payload)
+
+
+def _emb_payload(vectors):
+    return {"data": [{"index": i, "embedding": v} for i, v in enumerate(vectors)]}
+
+
+def _chunk(cid, text):
+    # sha == text so identical text reuses the cache, changed text invalidates it.
+    return DocChunk(
+        id=cid, path=cid.split("#")[0], url=f"https://x/{cid}", title="T",
+        heading=cid, text=text, breadcrumbs=["T", cid], sha=text,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Client
+# --------------------------------------------------------------------------- #
+def test_embed_texts_happy(monkeypatch):
+    monkeypatch.setattr(
+        embeddings.requests, "post",
+        lambda *a, **k: _Resp(_emb_payload([[1.0, 2.0], [3.0, 4.0]])),
+    )
+    assert embeddings.embed_texts(["a", "b"], token="x") == [[1.0, 2.0], [3.0, 4.0]]
+
+
+def test_embed_texts_http_error_returns_none(monkeypatch):
+    monkeypatch.setattr(
+        embeddings.requests, "post", lambda *a, **k: _Resp({"error": "no"}, status=429)
+    )
+    assert embeddings.embed_texts(["a"], token="x") is None
+
+
+def test_embed_texts_count_mismatch_returns_none(monkeypatch):
+    monkeypatch.setattr(
+        embeddings.requests, "post", lambda *a, **k: _Resp(_emb_payload([[1.0]]))
+    )
+    assert embeddings.embed_texts(["a", "b"], token="x") is None
+
+
+def test_embed_text_single(monkeypatch):
+    monkeypatch.setattr(
+        embeddings.requests, "post", lambda *a, **k: _Resp(_emb_payload([[9.0]]))
+    )
+    assert embeddings.embed_text("hello", token="x") == [9.0]
+
+
+# --------------------------------------------------------------------------- #
+# Docs index build + round-trip
+# --------------------------------------------------------------------------- #
+def test_build_docs_index_roundtrip(ai_on):
+    gh = FakeGH()
+    chunks = [_chunk("a#x", "sonos grouping"), _chunk("b#y", "spotify login")]
+    index, changed = embeddings.build_docs_index(gh, token="t", chunks=chunks)
+    assert changed is True and index is not None
+    embeddings.save_index(gh, config.DOCS_INDEX_PATH, index, message="build")
+
+    loaded = embeddings.load_docs_chunks(gh)
+    assert {c.id for c in loaded} == {"a#x", "b#y"}
+    assert all(len(c.embedding) == FAKE_DIM for c in loaded)
+
+
+def test_build_docs_index_sha_cache(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
+    calls = []
+
+    def spy(texts, *, token):
+        calls.append(list(texts))
+        return [fake_embedding(t) for t in texts]
+
+    monkeypatch.setattr(embeddings, "embed_texts", spy)
+    gh = FakeGH()
+
+    index1, changed1 = embeddings.build_docs_index(
+        gh, token="t", chunks=[_chunk("a#x", "alpha"), _chunk("b#y", "beta")]
+    )
+    assert changed1 is True and len(calls[-1]) == 2
+
+    # Rebuild with identical content -> nothing re-embedded, unchanged.
+    calls.clear()
+    _, changed2 = embeddings.build_docs_index(
+        gh, token="t", chunks=[_chunk("a#x", "alpha"), _chunk("b#y", "beta")],
+        previous=index1,
+    )
+    assert changed2 is False
+    assert calls == []  # cache hit for both chunks
+
+    # Change only one chunk -> only that one is re-embedded.
+    calls.clear()
+    _, changed3 = embeddings.build_docs_index(
+        gh, token="t",
+        chunks=[_chunk("a#x", "alpha"), _chunk("b#y", "beta modified")],
+        previous=index1,
+    )
+    assert changed3 is True
+    assert len(calls[-1]) == 1
+
+
+def test_build_docs_index_skip_on_limit(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    gh = FakeGH()
+    index, changed = embeddings.build_docs_index(
+        gh, token="t", chunks=[_chunk("a#x", "alpha")]
+    )
+    assert index is None and changed is False
+
+
+def test_save_index_dry_run_makes_no_commit():
+    gh = FakeGH()
+    gh.dry_run = True
+    embeddings.save_index(gh, config.DOCS_INDEX_PATH, {"schema": 1}, message="m")
+    assert config.DOCS_INDEX_PATH not in gh._index_files
+    assert any(c[0] == "commit_files" for c in gh.calls)
+
+
+def test_load_index_absent_and_malformed():
+    assert embeddings.load_index(FakeGH(), "docs.json") is None
+    gh = FakeGH(index_files={"docs.json": "{not json"})
+    assert embeddings.load_index(gh, "docs.json") is None
+
+
+def test_load_docs_chunks_model_mismatch_ignored(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
+    bad = {"model": "other/model", "dim": FAKE_DIM, "chunks": [
+        {"id": "a", "embedding": [1.0] * FAKE_DIM}]}
+    gh = FakeGH(index_files={config.DOCS_INDEX_PATH: json.dumps(bad)})
+    assert embeddings.load_docs_chunks(gh) == []
+
+
+# --------------------------------------------------------------------------- #
+# Posts index build + incremental append
+# --------------------------------------------------------------------------- #
+def test_build_posts_index_and_append_dedupe(ai_on):
+    gh = FakeGH()
+    posts = [
+        {"kind": "issue", "number": 1, "title": "sonos", "body": "b1",
+         "url": "u1", "state": "open"},
+        {"kind": "issue", "number": 2, "title": "spotify", "body": "b2",
+         "url": "u2", "state": "closed"},
+    ]
+    index, changed = embeddings.build_posts_index(gh, posts, token="t")
+    assert changed is True and len(index["posts"]) == 2
+    embeddings.save_index(gh, config.POSTS_INDEX_PATH, index, message="posts")
+
+    # Append an existing number -> upsert (still one record for #1).
+    idx2, changed2 = embeddings.append_post(
+        gh, {"kind": "issue", "number": 1, "title": "sonos v2", "body": "b1b",
+             "url": "u1", "state": "open"}, token="t",
+    )
+    assert changed2 is True
+    ones = [p for p in idx2["posts"] if p["number"] == 1]
+    assert len(ones) == 1 and ones[0]["title"] == "sonos v2"
+
+    # Append a brand-new number -> added.
+    embeddings.save_index(gh, config.POSTS_INDEX_PATH, idx2, message="posts")
+    idx3, _ = embeddings.append_post(
+        gh, {"kind": "issue", "number": 3, "title": "tidal", "body": "b3",
+             "url": "u3", "state": "open"}, token="t",
+    )
+    assert {p["number"] for p in idx3["posts"]} == {1, 2, 3}
+
+
+def test_append_post_skip_on_embed_failure(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    gh = FakeGH()
+    index, changed = embeddings.append_post(
+        gh, {"kind": "issue", "number": 5, "title": "x", "body": "y"}, token="t"
+    )
+    assert index is None and changed is False

--- a/.github/scripts/tests/test_index_cmd.py
+++ b/.github/scripts/tests/test_index_cmd.py
@@ -1,0 +1,95 @@
+"""Tests for the `index` and `index-append` subcommands."""
+
+from conftest import FakeGH
+from ma_triage import __main__ as main
+from ma_triage import config, embeddings
+from ma_triage.models import DocChunk
+
+
+def _chunk(cid, text):
+    return DocChunk(
+        id=cid, path=cid.split("#")[0], url=f"https://x/{cid}", title="T",
+        heading=cid, text=text, breadcrumbs=["T", cid], sha=text,
+    )
+
+
+def _commit_count(gh, path):
+    return sum(1 for c in gh.calls if c[0] == "commit_files" and path in c[2])
+
+
+def test_cmd_index_docs_commits_once_then_skips_unchanged(ai_on, monkeypatch):
+    chunks = [_chunk("a#x", "alpha text"), _chunk("b#y", "beta text")]
+    monkeypatch.setattr(embeddings.docs, "build_chunks", lambda gh: chunks)
+    gh = FakeGH()
+
+    assert main.cmd_index(gh, "t", "docs") == 0
+    assert config.DOCS_INDEX_PATH in gh._index_files
+    assert _commit_count(gh, config.DOCS_INDEX_PATH) == 1
+
+    # Second run with identical content -> unchanged -> no new commit.
+    assert main.cmd_index(gh, "t", "docs") == 0
+    assert _commit_count(gh, config.DOCS_INDEX_PATH) == 1
+
+
+def test_cmd_index_docs_dry_run_makes_no_commit(ai_on, monkeypatch):
+    monkeypatch.setattr(embeddings.docs, "build_chunks", lambda gh: [_chunk("a#x", "t")])
+    gh = FakeGH()
+    gh.dry_run = True
+    assert main.cmd_index(gh, "t", "docs") == 0
+    # commit_files was invoked but, being dry-run, stored nothing.
+    assert any(c[0] == "commit_files" for c in gh.calls)
+    assert config.DOCS_INDEX_PATH not in gh._index_files
+
+
+def test_cmd_index_unknown_target():
+    assert main.cmd_index(FakeGH(), "t", "bogus") == 2
+
+
+def test_cmd_index_append(ai_on, monkeypatch):
+    monkeypatch.setenv("ISSUE_NUMBER", "123")
+    monkeypatch.setenv("ISSUE_TITLE", "sonos grouping bug")
+    monkeypatch.setenv("ISSUE_BODY", "players won't group")
+    gh = FakeGH()
+    monkeypatch.setattr(
+        gh, "get_issue",
+        lambda n: {"number": n, "title": "sonos grouping bug",
+                   "body": "players won't group", "html_url": "https://x/123",
+                   "state": "open"},
+        raising=False,
+    )
+    assert main.cmd_index_append(gh, "t") == 0
+    assert config.POSTS_INDEX_PATH in gh._index_files
+    import json
+    stored = json.loads(gh._index_files[config.POSTS_INDEX_PATH])
+    assert [p["number"] for p in stored["posts"]] == [123]
+
+
+def test_cmd_index_append_skips_pull_requests(ai_on, monkeypatch):
+    monkeypatch.setenv("ISSUE_NUMBER", "9")
+    gh = FakeGH()
+    monkeypatch.setattr(
+        gh, "get_issue",
+        lambda n: {"number": n, "pull_request": {"url": "x"}},
+        raising=False,
+    )
+    assert main.cmd_index_append(gh, "t") == 0
+    assert config.POSTS_INDEX_PATH not in gh._index_files
+
+
+def test_collect_posts_excludes_translation_discussions():
+    gh = FakeGH(
+        issues=[{"number": 1, "title": "bug", "body": "b", "html_url": "u1",
+                 "state": "open", "updated_at": "2024-01-01"}],
+        discussions=[
+            {"number": 2, "title": "how do I", "body": "b", "url": "u2",
+             "updatedAt": "2024-01-02", "closed": False, "category": {"name": "Q&A"}},
+            {"number": 3, "title": "add German", "body": "b", "url": "u3",
+             "updatedAt": "2024-01-03", "closed": False,
+             "category": {"name": "Translations"}},
+        ],
+    )
+    posts = main._collect_posts(gh)
+    keys = {(p["kind"], p["number"]) for p in posts}
+    assert ("issue", 1) in keys
+    assert ("discussion", 2) in keys
+    assert ("discussion", 3) not in keys  # translation category excluded

--- a/.github/scripts/tests/test_rag.py
+++ b/.github/scripts/tests/test_rag.py
@@ -1,0 +1,182 @@
+"""Tests for the RAG orchestrator (rag.answer + tier/suppression logic)."""
+
+import json
+
+from conftest import FakeGH
+from ma_triage import config, embeddings, rag
+from ma_triage.models import DocAnswer, DocChunk
+
+
+def _chunk(cid, text):
+    return DocChunk(
+        id=cid, path=cid.split("#")[0], url=f"https://x/{cid}", title="T",
+        heading=cid, text=text, breadcrumbs=["T", cid], sha=text,
+    )
+
+
+def _gh_with_indexes(topic="sonos players discovered via mdns multicast"):
+    """A FakeGH carrying a docs index and a posts index (built with fakes)."""
+    gh = FakeGH()
+    chunks = [_chunk("faq/net#mdns", topic), _chunk("faq/bill#pay", "unrelated billing")]
+    idx, _ = embeddings.build_docs_index(gh, token="t", chunks=chunks)
+    embeddings.save_index(gh, config.DOCS_INDEX_PATH, idx, message="d")
+    pidx, _ = embeddings.build_posts_index(
+        gh,
+        [{"kind": "issue", "number": 50, "title": topic, "body": "",
+          "url": "u50", "state": "open"}],
+        token="t",
+    )
+    embeddings.save_index(gh, config.POSTS_INDEX_PATH, pidx, message="p")
+    return gh
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+def test_tier_for():
+    assert rag.tier_for(0.9) == "high"
+    assert rag.tier_for(0.5) == "medium"
+    assert rag.tier_for(0.1) == "low"
+
+
+def test_demote():
+    assert rag.demote("high") == "medium"
+    assert rag.demote("medium") == "low"
+    assert rag.demote("low") == "low"
+
+
+def test_fingerprint_stable_and_order_independent():
+    assert rag.fingerprint(["a", "b"]) == rag.fingerprint(["b", "a"])
+    assert rag.fingerprint(["a"]) != rag.fingerprint(["b"])
+
+
+def test_is_suppressed():
+    supp = [{"hash": rag.fingerprint(["a#x"]), "downvotes": 2}]
+    assert rag.is_suppressed(rag.fingerprint(["a#x"]), supp) is True
+    assert rag.is_suppressed(rag.fingerprint(["b#y"]), supp) is False
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+def test_answer_disabled_returns_none(fake_gh):
+    # AI_ENABLED defaults to False in the test environment.
+    assert rag.answer(fake_gh, title="t", body="b", number=1, token="x") is None
+
+
+def test_answer_returns_none_when_nothing_to_show(ai_on):
+    # Enabled, but no docs index, no posts index, and no search hits -> None
+    # (so apply_triage writes no stray RAG state block).
+    gh = FakeGH()
+    assert rag.answer(gh, title="random topic", body="text", number=1, token="t") is None
+
+
+def test_answer_none_on_embed_failure(ai_on, monkeypatch):
+    monkeypatch.setattr(embeddings, "embed_text", lambda text, *, token: None)
+    gh = _gh_with_indexes()
+    assert rag.answer(gh, title="sonos mdns", body="", number=1, token="t") is None
+
+
+def test_answer_high_tier(ai_on, monkeypatch):
+    gh = _gh_with_indexes()
+    monkeypatch.setattr(
+        rag.ai, "judge_answer",
+        lambda t, b, hits, *, token: DocAnswer(
+            True, 0.92, "Enable multicast on your network.", [hits[0].chunk.id]
+        ),
+    )
+    res = rag.answer(gh, title="sonos not discovered", body="mdns multicast",
+                     number=99, token="t")
+    assert res is not None and res.tier == "high"
+    assert res.doc_answer is not None
+    assert res.cited_chunks and res.cited_chunks[0].id == "faq/net#mdns"
+    assert [p.number for p in res.related_posts] == [50]
+    assert res.has_docs_output is True
+
+
+def test_answer_medium_tier_links_only(ai_on, monkeypatch):
+    gh = _gh_with_indexes()
+    monkeypatch.setattr(
+        rag.ai, "judge_answer",
+        lambda t, b, hits, *, token: DocAnswer(True, 0.55, "maybe", [hits[0].chunk.id]),
+    )
+    res = rag.answer(gh, title="sonos mdns", body="multicast", number=99, token="t")
+    assert res.tier == "medium"
+    assert res.doc_answer is None  # links only, no prose
+    assert res.doc_hits  # links available for rendering
+
+
+def test_answer_low_tier_still_shows_related(ai_on, monkeypatch):
+    gh = _gh_with_indexes()
+    monkeypatch.setattr(
+        rag.ai, "judge_answer",
+        lambda t, b, hits, *, token: DocAnswer(False, 0.1, "", []),
+    )
+    res = rag.answer(gh, title="sonos mdns", body="multicast", number=99, token="t")
+    assert res.tier == "low"
+    assert res.doc_answer is None
+    assert res.cited_chunks == []
+    # Duplicate/related detection is independent of the docs tier.
+    assert res.related_posts
+    assert res.has_output is True
+
+
+def test_answer_judge_failure_falls_back_to_medium(ai_on, monkeypatch):
+    gh = _gh_with_indexes()
+    monkeypatch.setattr(rag.ai, "judge_answer", lambda *a, **k: None)
+    res = rag.answer(gh, title="sonos mdns multicast", body="players discovered",
+                     number=99, token="t")
+    assert res.tier == "medium"
+    assert res.doc_answer is None
+    assert res.doc_hits
+
+
+def test_answer_suppression_demotes(ai_on, monkeypatch):
+    gh = _gh_with_indexes()
+    # Pre-load a suppression fingerprint for the section the judge will cite.
+    fp = rag.fingerprint(["faq/net#mdns"])
+    gh._index_files[config.SUPPRESS_INDEX_PATH] = json.dumps(
+        {"schema": 1, "fingerprints": [{"hash": fp, "downvotes": 3}]}
+    )
+    monkeypatch.setattr(
+        rag.ai, "judge_answer",
+        lambda t, b, hits, *, token: DocAnswer(True, 0.95, "answer", ["faq/net#mdns"]),
+    )
+    res = rag.answer(gh, title="sonos mdns", body="multicast", number=99, token="t")
+    assert res.suppressed is True
+    assert res.tier == "medium"  # demoted from high
+    assert res.doc_answer is None
+
+
+# --------------------------------------------------------------------------- #
+# build_result wiring (AI on attaches RAG; AI off leaves it None)
+# --------------------------------------------------------------------------- #
+def test_build_result_wires_rag_when_enabled(ai_on, monkeypatch):
+    from ma_triage import __main__ as main
+
+    gh = _gh_with_indexes()
+    monkeypatch.setattr(main, "find_diagnostics_url", lambda body: None)
+    monkeypatch.setattr(main, "find_log_urls", lambda body: [])
+    monkeypatch.setattr(
+        rag.ai, "judge_answer",
+        lambda t, b, hits, *, token: DocAnswer(True, 0.9, "a", [hits[0].chunk.id]),
+    )
+    body = (
+        "### What happened?\n\nsonos mdns discovery\n\n"
+        "### How to reproduce\n\nx\n\n"
+        "### Music Assistant version\n\n2.9.5\n\n"
+        "### How do you run Music Assistant?\n\nHome Assistant add-on"
+    )
+    res = main.build_result(
+        gh, "sonos not discovered", body, token="t", labels=["triage"], number=99
+    )
+    assert res.rag is not None and res.rag.tier == "high"
+
+
+def test_build_result_no_rag_when_disabled(fake_gh, monkeypatch):
+    from ma_triage import __main__ as main
+
+    monkeypatch.setattr(main, "find_diagnostics_url", lambda body: None)
+    monkeypatch.setattr(main, "find_log_urls", lambda body: [])
+    res = main.build_result(fake_gh, "t", "b", token="t", labels=["triage"])
+    assert res.rag is None

--- a/.github/scripts/tests/test_retrieval.py
+++ b/.github/scripts/tests/test_retrieval.py
@@ -1,0 +1,71 @@
+"""Tests for the pure-Python hybrid retrieval math."""
+
+import math
+
+from ma_triage import retrieval
+from ma_triage.models import DocChunk
+
+
+def _chunk(cid, text, embedding):
+    return DocChunk(
+        id=cid, path=cid, url=f"https://x/{cid}", title=cid, heading=cid,
+        text=text, breadcrumbs=[cid], embedding=embedding,
+    )
+
+
+def test_tokenize_splits_underscores():
+    toks = retrieval.tokenize("YouTube_Music playback error_code 42")
+    assert "youtube_music" in toks
+    assert "youtube" in toks and "music" in toks
+    assert "42" in toks
+
+
+def test_cosine_basic():
+    assert retrieval.cosine([1, 0], [1, 0]) == 1.0
+    assert retrieval.cosine([1, 0], [0, 1]) == 0.0
+    assert retrieval.cosine([], [1]) == 0.0
+    assert abs(retrieval.cosine([1, 1], [1, 0]) - 1 / math.sqrt(2)) < 1e-9
+
+
+def test_rank_by_cosine_orders_desc():
+    query = [1.0, 0.0]
+    vecs = [[0.0, 1.0], [1.0, 0.0], [0.7, 0.7]]
+    assert retrieval.rank_by_cosine(query, vecs)[0] == 1  # perfect match first
+    # Orthogonal vector (score 0) is dropped.
+    assert 0 not in retrieval.rank_by_cosine(query, vecs)
+
+
+def test_bm25_rewards_rare_terms():
+    docs_tokens = [
+        ["sonos", "playback", "stops"],
+        ["spotify", "login", "fails"],
+        ["general", "playback", "info"],
+    ]
+    scores = retrieval.bm25_scores(["sonos"], docs_tokens)
+    assert scores[0] > 0
+    assert scores[1] == 0.0
+    # "sonos" (rare) should make doc 0 the top hit.
+    assert retrieval.rank_by_bm25(["sonos"], docs_tokens)[0] == 0
+
+
+def test_rrf_fuses_rankings():
+    # Item 2 is ranked highly by both lists -> should win the fusion.
+    fused = retrieval.rrf([[0, 2, 1], [2, 1, 0]])
+    best = max(fused.items(), key=lambda kv: kv[1])[0]
+    assert best == 2
+
+
+def test_retrieve_docs_hybrid(monkeypatch):
+    chunks = [
+        _chunk("a", "sonos speaker grouping", [1.0, 0.0, 0.0]),
+        _chunk("b", "spotify premium login", [0.0, 1.0, 0.0]),
+        _chunk("c", "general playback notes", [0.0, 0.0, 1.0]),
+    ]
+    # Query vector closest to chunk "a"; query text also mentions "sonos".
+    hits = retrieval.retrieve_docs([0.9, 0.1, 0.0], "sonos grouping issue", chunks, k=2)
+    assert hits[0].chunk.id == "a"
+    assert len(hits) == 2
+
+
+def test_retrieve_docs_empty():
+    assert retrieval.retrieve_docs([1.0], "q", []) == []

--- a/.github/scripts/tests/test_sanitize.py
+++ b/.github/scripts/tests/test_sanitize.py
@@ -1,5 +1,5 @@
 from ma_triage import config
-from ma_triage.sanitize import fenced, inline
+from ma_triage.sanitize import fenced, inline, link_label, markdown_safe
 
 
 def test_inline_neutralizes_mentions():
@@ -48,3 +48,23 @@ def test_fenced_defuses_state_marker():
     out = fenced("<!-- ma-triage-state:{\"x\":1} -->")
     assert "<!--" not in out
     assert "&lt;!--" in out
+
+
+def test_link_label_escapes_brackets_and_preceding_backslashes():
+    out = link_label(r"pwn\](https://evil.example)")
+    assert out.startswith(r"pwn\\\]")
+    assert "\u200b" not in out
+
+
+def test_markdown_safe_defangs_links_images_and_bare_urls():
+    out = markdown_safe(
+        "[click](https://evil.example) ![x](http://evil.example) "
+        "https://evil.example mailto:bad@example.com www.evil.example"
+    )
+    assert r"\[click\]" in out
+    assert r"!\[x\]" in out
+    assert "https://evil.example" not in out
+    assert "http://evil.example" not in out
+    assert "mailto:bad@example.com" not in out
+    assert "www.evil.example" not in out
+    assert "https:\u200b//evil.example" in out

--- a/.github/scripts/tests/test_similar.py
+++ b/.github/scripts/tests/test_similar.py
@@ -1,0 +1,82 @@
+"""Tests for related-post detection (dense index + search fallback)."""
+
+from conftest import FAKE_DIM, fake_embedding
+from ma_triage import config, similar
+
+
+def _post(number, text, kind="issue", state="open"):
+    return {
+        "kind": kind, "number": number, "title": text, "url": f"https://x/{number}",
+        "state": state, "embedding": fake_embedding(text),
+    }
+
+
+def test_related_from_index_ranks_and_thresholds():
+    query = fake_embedding("sonos speaker grouping")
+    posts = [
+        _post(1, "sonos speaker grouping problem"),
+        {"kind": "issue", "number": 2, "title": "unrelated", "url": "https://x/2",
+         "state": "open", "embedding": [0.0] * FAKE_DIM},
+    ]
+    hits = similar.related_from_index(query, posts, exclude_number=99)
+    assert [h.number for h in hits] == [1]  # #2 (zero vector) below the threshold
+
+
+def test_related_from_index_excludes_self():
+    query = fake_embedding("sonos speaker grouping")
+    posts = [_post(1, "sonos speaker grouping problem")]
+    assert similar.related_from_index(query, posts, exclude_number=1) == []
+
+
+def test_related_from_index_respects_k(monkeypatch):
+    monkeypatch.setattr(config, "RELATED_MIN_SCORE", 0.0)
+    query = fake_embedding("alpha")
+    posts = [_post(i, "alpha beta") for i in range(1, 6)]
+    hits = similar.related_from_index(query, posts, exclude_number=99, k=2)
+    assert len(hits) == 2
+
+
+def test_related_from_search_filters_prs_and_self(fake_gh, monkeypatch):
+    monkeypatch.setattr(
+        fake_gh, "_search_items",
+        [
+            {"number": 10, "title": "matching issue", "html_url": "u10", "state": "open"},
+            {"number": 11, "title": "a PR", "html_url": "u11", "pull_request": {}},
+            {"number": 7, "title": "self", "html_url": "u7", "state": "open"},
+        ],
+        raising=False,
+    )
+    hits = similar.related_from_search(fake_gh, "streaming problem", exclude_number=7)
+    numbers = [h.number for h in hits]
+    assert 10 in numbers
+    assert 11 not in numbers  # PR filtered
+    assert 7 not in numbers  # self excluded
+
+
+def test_find_related_falls_back_to_search_when_no_index_hits(fake_gh, monkeypatch):
+    monkeypatch.setattr(
+        fake_gh, "_search_items",
+        [{"number": 42, "title": "fallback hit", "html_url": "u42", "state": "open"}],
+        raising=False,
+    )
+    # Posts present but none similar -> index yields nothing -> search fallback.
+    query = fake_embedding("sonos grouping")
+    posts = [{"kind": "issue", "number": 1, "title": "x", "url": "u",
+              "state": "open", "embedding": [0.0] * FAKE_DIM}]
+    hits = similar.find_related(
+        fake_gh, query_vec=query, title="sonos grouping", posts=posts,
+        exclude_number=99,
+    )
+    assert [h.number for h in hits] == [42]
+
+
+def test_find_related_uses_index_when_available(fake_gh):
+    query = fake_embedding("sonos speaker grouping")
+    posts = [{"kind": "issue", "number": 3, "title": "sonos speaker grouping",
+              "url": "u3", "state": "open",
+              "embedding": fake_embedding("sonos speaker grouping")}]
+    hits = similar.find_related(
+        fake_gh, query_vec=query, title="sonos speaker grouping", posts=posts,
+        exclude_number=99,
+    )
+    assert [h.number for h in hits] == [3]

--- a/.github/workflows/docs_embeddings.yml
+++ b/.github/workflows/docs_embeddings.yml
@@ -1,0 +1,72 @@
+# RAG index build (experimental, Phase 2).
+#
+# Builds the two embedding indexes the triage bot's RAG layer reads at runtime —
+# `docs.json` (documentation chunks) and `posts.json` (past issues + discussions)
+# — and commits them to the orphan `triage-index` branch so `main` stays clean.
+#
+# COST / RATE LIMITS: embeddings run via GitHub Models (free tier is rate
+# limited). The build is cached by content SHA, so unchanged chunks are never
+# re-embedded, and a rate-limited run skips the commit rather than writing a
+# broken index. Runs nightly (not per-minute).
+#
+# SAFETY: this job needs `contents: write` to push the index branch, but it has
+# NO `issues:` permission — it can never comment on or modify issues. Honours the
+# TRIAGE_DRY_RUN kill switch (dry-run previews the commit in the job summary).
+name: RAG index build
+
+on:
+  schedule:
+    - cron: "37 4 * * *" # nightly at 04:37 UTC (offset from the triage sweep)
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which index to build
+        type: choice
+        default: all
+        options: [all, docs, posts]
+  # Lets the docs repo trigger a rebuild on a docs change via a cross-repo
+  # `repository_dispatch` (GitHub cannot path-filter another repo's pushes).
+  repository_dispatch:
+    types: [docs-changed]
+
+concurrency:
+  group: rag-index-write
+  cancel-in-progress: false
+
+permissions:
+  contents: write # commit the indexes to the triage-index branch
+  models: read # GitHub Models embeddings
+
+jobs:
+  build:
+    # Manual dispatch always runs; scheduled/dispatch builds only when AI is on.
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch'
+      || vars.TRIAGE_AI_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        working-directory: .github/scripts
+        run: pip install -r requirements.txt
+      - name: Build RAG indexes
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          # Untrusted only in the sense of a maintainer-chosen enum; passed as an
+          # env var (never interpolated into the shell command line).
+          INDEX_TARGET: ${{ github.event.inputs.target || 'all' }}
+          TRIAGE_DRY_RUN: ${{ vars.TRIAGE_DRY_RUN }}
+          TRIAGE_AI_ENABLED: ${{ vars.TRIAGE_AI_ENABLED }}
+          TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
+          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
+          TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
+          TRIAGE_DOCS_REPO: ${{ vars.TRIAGE_DOCS_REPO }}
+          TRIAGE_DOCS_SITE: ${{ vars.TRIAGE_DOCS_SITE }}
+          TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
+          TRIAGE_INDEX_MAX_POSTS: ${{ vars.TRIAGE_INDEX_MAX_POSTS }}
+        run: python -m ma_triage index "$INDEX_TARGET"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -54,6 +54,16 @@ jobs:
           TRIAGE_AI_MODEL: ${{ vars.TRIAGE_AI_MODEL }}
           TRIAGE_SCAN_LOGS: ${{ vars.TRIAGE_SCAN_LOGS }}
           TRIAGE_COPILOT_AUTO: ${{ vars.TRIAGE_COPILOT_AUTO }}
+          # RAG layer (Phase 2) — only active when TRIAGE_AI_ENABLED is true.
+          TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
+          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
+          TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
+          TRIAGE_ANSWER_MODEL: ${{ vars.TRIAGE_ANSWER_MODEL }}
+          TRIAGE_ANSWER_HI: ${{ vars.TRIAGE_ANSWER_HI }}
+          TRIAGE_ANSWER_LO: ${{ vars.TRIAGE_ANSWER_LO }}
+          TRIAGE_DOCS_REPO: ${{ vars.TRIAGE_DOCS_REPO }}
+          TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
+          TRIAGE_RELATED_POSTS: ${{ vars.TRIAGE_RELATED_POSTS }}
         run: python -m ma_triage triage
 
   respond:
@@ -82,3 +92,47 @@ jobs:
           COMMENT_USER_TYPE: ${{ github.event.comment.user.type }}
           TRIAGE_DRY_RUN: ${{ vars.TRIAGE_DRY_RUN }}
         run: python -m ma_triage respond
+
+  # Separate, least-privilege job: embed a newly-opened issue and append it to
+  # the posts index on the `triage-index` branch. It has `contents: write` (to
+  # commit the index) but deliberately NOT `issues: write` — so the job that can
+  # write repo contents can never comment, and vice-versa. Only runs when the AI
+  # layer is enabled (it makes one embedding call).
+  index-append:
+    if: >-
+      ${{ github.event_name == 'issues'
+      && github.event.action == 'opened'
+      && !github.event.issue.pull_request
+      && vars.TRIAGE_AI_ENABLED == 'true'
+      && vars.TRIAGE_RAG_ENABLED != 'false' }}
+    runs-on: ubuntu-latest
+    # Serialise with the nightly index build (and other appends) so concurrent
+    # force-pushes to the triage-index branch can't drop each other's writes.
+    concurrency:
+      group: rag-index-write
+      cancel-in-progress: false
+    permissions:
+      contents: write # commit the posts index to the triage-index branch
+      models: read # embeddings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        working-directory: .github/scripts
+        run: pip install -r requirements.txt
+      - name: Append issue to posts index
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TRIAGE_DRY_RUN: ${{ vars.TRIAGE_DRY_RUN }}
+          TRIAGE_AI_ENABLED: ${{ vars.TRIAGE_AI_ENABLED }}
+          TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
+          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
+          TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
+          TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
+          TRIAGE_INDEX_MAX_POSTS: ${{ vars.TRIAGE_INDEX_MAX_POSTS }}
+        run: python -m ma_triage index-append


### PR DESCRIPTION
## Problem

The experimental issue-triage bot (`.github/scripts/ma_triage/`) does deterministic diagnostics analysis and an optional short AI assessment, but it can't yet point reporters at the documentation that already answers their question, or flag likely duplicates. Many incoming issues are already covered by the docs (especially the FAQ) or repeat an existing report.

## What this adds

A retrieval-augmented (RAG) layer on top of the existing package, modelled on `zwave-js-bot`. It is **experimental, fully behind `TRIAGE_AI_ENABLED`, cost-guarded, and dry-run-safe** — when disabled, rate-limited, or missing its indexes, the bot behaves exactly as before and deterministic Tier 0 still runs.

- **Docs-grounded answers.** Chunks the public docs (`music-assistant.io`) by heading, embeds them, and retrieves with dense cosine + BM25 fused via Reciprocal Rank Fusion (pure Python, no new runtime dependency). One judge call decides whether the docs answer the issue and returns a confidence-scored, cited answer.
- **Similar past reports.** Dense-cosine match against an index of past issues + discussions to surface likely duplicates and prior answers; degrades to GitHub issue search when the index is absent.
- **Confidence tiers.** HIGH posts a cited answer, MEDIUM posts doc links only, and LOW stays silent. A previously down-voted answer is demoted using `suppress.json`.
- **Orphan-branch indexes.** `docs.json`, `posts.json`, and `suppress.json` live on `triage-index`, keeping `main` clean. A new nightly `docs_embeddings.yml` rebuilds with SHA caching and skip-on-rate-limit; a separate job appends newly opened issues.
- **One sticky comment.** Docs answers, links, and similar reports render as extra sections in the existing sticky comment. Link labels are Markdown-escaped, and model prose has link syntax and URL schemes defanged; only trusted citation/index targets remain clickable.

## Scope and safeguards

- Live triage of Discussions and the full reaction-harvest/evaluation loop are intentionally deferred. Discussions are currently only read into the similar-posts index; translation-category discussions are excluded as noise.
- Least privilege per job: commenting jobs stay `contents: read`; index writers get `contents: write` + `models: read` and no `issues:` access. All index writers share one concurrency group to avoid lost updates.
- Model ids, confidence thresholds, dimensions, and the default ~500-post backfill cap are configurable via `TRIAGE_*` repository variables.
- Any embeddings/judge/index failure degrades cleanly to the existing Phase-1 result.

## Testing

- **191 offline tests pass**, including 72 new deterministic tests for chunking, cosine/BM25/RRF, tier routing, suppression, citation round-trips, SHA-cache invalidation, index persistence/fallbacks, Markdown link/URL injection, sanitization, and the AI-off no-op invariant.
- Modules compile with warnings treated as errors and all workflow YAML parses.
- Live smoke test confirmed docs enumeration and generated cite URLs resolve.