### PR TITLE
Support a GH_MODELS_TOKEN secret for GitHub Models calls

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -168,6 +168,7 @@ and vice-versa. Both honour `TRIAGE_DRY_RUN` (dry-run previews the commit).
 ### Repo secret
 | Secret | Needed for | Notes |
 |---|---|---|
+| `GH_MODELS_TOKEN` | Tier 1 / RAG (optional) | PAT with the **Models** permission. Used for GitHub Models calls (embeddings + judge/assessment) when the org hasn't enabled Models for the default Actions token. Falls back to `GITHUB_TOKEN` when unset. |
 | `COPILOT_DISPATCH_TOKEN` | Tier 2 only | Must be a **user-to-server** token. |
 
 ### Copilot dispatch token

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -47,6 +47,18 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _models_token(default_token: str) -> str:
+    """Token for GitHub Models (embeddings + chat) calls.
+
+    Uses the optional ``GH_MODELS_TOKEN`` secret when present, so Models
+    inference can authenticate via a PAT even when the org has not enabled
+    Models for the default Actions token. Falls back to the default token
+    (and treats an unset/empty secret as absent). Only Models calls use this;
+    all GitHub API calls keep using the default token via the gh client.
+    """
+    return os.environ.get("GH_MODELS_TOKEN") or default_token
+
+
 # --------------------------------------------------------------------------- #
 # Shared analysis pipeline (no mutations)
 # --------------------------------------------------------------------------- #
@@ -492,23 +504,25 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     repo = os.environ.get("REPOSITORY", config.SUPPORT_REPO)
     gh = GitHubClient(token, repo=repo)
+    # Models (embeddings/judge/assessment) may use a dedicated PAT secret.
+    models_token = _models_token(token)
 
     if config.DRY_RUN:
         summary("> 🟡 **Dry-run mode** — no changes will be made.\n")
 
     if command == "triage":
-        return cmd_triage(gh, token)
+        return cmd_triage(gh, models_token)
     if command == "respond":
         return cmd_respond(gh)
     if command == "sweep":
         return cmd_sweep(gh)
     if command == "dispatch":
-        return cmd_dispatch(gh, token)
+        return cmd_dispatch(gh, models_token)
     if command == "index":
         target = argv[1] if len(argv) > 1 else "all"
-        return cmd_index(gh, token, target)
+        return cmd_index(gh, models_token, target)
     if command == "index-append":
-        return cmd_index_append(gh, token)
+        return cmd_index_append(gh, models_token)
     log(f"unknown command: {command}")
     return 2
 

--- a/.github/scripts/tests/test_main.py
+++ b/.github/scripts/tests/test_main.py
@@ -168,3 +168,15 @@ def test_build_result_unsupported_install_flagged(fake_gh, monkeypatch):
     )
     result = main.build_result(fake_gh, "x", body, token="t", labels=["triage"])
     assert any("unsupported" in f.title.lower() for f in result.findings)
+
+
+def test_models_token_prefers_secret(monkeypatch):
+    monkeypatch.setenv("GH_MODELS_TOKEN", "pat-xyz")
+    assert main._models_token("ghtok") == "pat-xyz"
+
+
+def test_models_token_falls_back_when_unset_or_blank(monkeypatch):
+    monkeypatch.delenv("GH_MODELS_TOKEN", raising=False)
+    assert main._models_token("ghtok") == "ghtok"
+    monkeypatch.setenv("GH_MODELS_TOKEN", "")
+    assert main._models_token("ghtok") == "ghtok"

--- a/.github/workflows/docs_embeddings.yml
+++ b/.github/workflows/docs_embeddings.yml
@@ -69,4 +69,5 @@ jobs:
           TRIAGE_DOCS_SITE: ${{ vars.TRIAGE_DOCS_SITE }}
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
           TRIAGE_INDEX_MAX_POSTS: ${{ vars.TRIAGE_INDEX_MAX_POSTS }}
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
         run: python -m ma_triage index "$INDEX_TARGET"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -64,6 +64,9 @@ jobs:
           TRIAGE_DOCS_REPO: ${{ vars.TRIAGE_DOCS_REPO }}
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
           TRIAGE_RELATED_POSTS: ${{ vars.TRIAGE_RELATED_POSTS }}
+          # Optional PAT for GitHub Models (used only when set); falls back to
+          # the default token. Lets Models work when the org token can't.
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
         run: python -m ma_triage triage
 
   respond:
@@ -135,4 +138,5 @@ jobs:
           TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
           TRIAGE_INDEX_MAX_POSTS: ${{ vars.TRIAGE_INDEX_MAX_POSTS }}
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
         run: python -m ma_triage index-append


### PR DESCRIPTION
## Problem

GitHub Models inference via the default Actions `GITHUB_TOKEN` needs the org to have GitHub Models enabled; when it isn't, the calls return **HTTP 403** and the AI tiers can't run (they degrade to deterministic Tier 0). We want a way to power the AI features without depending on the org-level toggle.

## Changes

- Add an optional **`GH_MODELS_TOKEN`** secret (a PAT with the *Models* permission). When set, only the GitHub Models calls (embeddings + judge/assessment) use it; it falls back to `GITHUB_TOKEN` when unset/blank. **All GitHub API calls keep using the default token** (verified: `docs.py` and the index writes use the `gh` client, not this token).
- Pass the secret to the three Models-calling jobs (triage `analyze`, `index-append`, and the RAG `index build`).
- Document the secret in the scripts README; add tests for the token resolution.

No behaviour change when the secret is unset.