### PR TITLE
Pass GH_MODELS_TOKEN to the Copilot dispatch workflow

### DIFF
--- a/.github/workflows/copilot_dispatch.yml
+++ b/.github/workflows/copilot_dispatch.yml
@@ -46,6 +46,9 @@ jobs:
         working-directory: .github/scripts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional PAT for GitHub Models, so the dispatched task prompt can be
+          # enriched with the Tier-1 assessment; falls back to the default token.
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
           COPILOT_DISPATCH_TOKEN: ${{ secrets.COPILOT_DISPATCH_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}


### PR DESCRIPTION
## Problem

The Tier-2 dispatch workflow builds the coding-agent task prompt from the triage result, which includes the Tier-1 GitHub Models assessment. But the job didn't pass `GH_MODELS_TOKEN`, so on setups relying on the PAT the assessment would 403 and the prompt would fall back to deterministic context only.

## Changes

- Pass `GH_MODELS_TOKEN` to the `copilot_dispatch.yml` job (falls back to the default token when unset).