### PR TITLE
Show the AI root-cause assessment in a collapsed block

### DIFF
--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -97,11 +97,11 @@ def _ai_section(result: TriageResult) -> str:
     ai = result.ai
     if ai is None:
         return ""
-    lines = ["\n### 🤖 AI assessment\n"]
+    inner: list[str] = []
     if ai.summary:
-        lines.append(inline(ai.summary, max_len=1000))
+        inner.append(inline(ai.summary, max_len=1000))
     if ai.likely_root_cause:
-        lines.append(f"\n**Likely cause:** {inline(ai.likely_root_cause, max_len=1000)}")
+        inner.append(f"\n**Likely cause:** {inline(ai.likely_root_cause, max_len=1000)}")
     meta = []
     if ai.category:
         meta.append(f"category: `{inline(ai.category, max_len=40)}`")
@@ -110,8 +110,19 @@ def _ai_section(result: TriageResult) -> str:
     if ai.possibly_fixed_in_version:
         meta.append(f"possibly fixed in: `{inline(ai.possibly_fixed_in_version, max_len=40)}`")
     if meta:
-        lines.append("\n_" + " · ".join(meta) + "_")
-    return "\n".join(lines)
+        inner.append("\n_" + " · ".join(meta) + "_")
+    if not inner:
+        return ""
+    # Rendered collapsed: it's an AI hypothesis for a maintainer to sanity-check,
+    # not a conclusion shown front-and-centre to the reporter.
+    body = "\n".join(inner)
+    return (
+        "\n<details>\n"
+        "<summary>🤖 AI assessment — possible root cause (for maintainers; may be "
+        "wrong)</summary>\n\n"
+        f"{body}\n"
+        "</details>"
+    )
 
 
 def _system_summary(result: TriageResult) -> str:

--- a/.github/scripts/tests/test_comment.py
+++ b/.github/scripts/tests/test_comment.py
@@ -93,6 +93,9 @@ def test_ai_section_rendered(sample_raw, fake_gh):
     assert "AI assessment" in body
     assert "Sonos device offline." in body
     assert "60%" in body
+    # rendered as a collapsed block for maintainers, not an always-open section
+    assert "<details>" in body and "<summary>" in body
+    assert "### 🤖 AI assessment" not in body
 
 
 def test_state_roundtrip():


### PR DESCRIPTION
## Problem

The Tier-1 AI assessment (possible root cause) was rendered as an always-open section. It's an AI hypothesis for a maintainer to sanity-check, so it shouldn't dominate the comment the reporter sees.

## Changes

- Render the assessment (summary, likely cause, category, confidence) inside a collapsed `<details>` block labelled for maintainers.
- Content stays sanitized as before.