### PR TITLE
Add a manual trigger to run triage on an existing issue

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -259,10 +259,12 @@ def apply_triage(
 # --------------------------------------------------------------------------- #
 def cmd_triage(gh: GitHubClient, token: str) -> int:
     number = int(_env("ISSUE_NUMBER"))
-    title = _env("ISSUE_TITLE")
-    body = _env("ISSUE_BODY")
 
     issue = gh.get_issue(number)
+    # On a manual workflow_dispatch there is no issue event payload, so fall back
+    # to the values fetched from the API.
+    title = _env("ISSUE_TITLE") or issue.get("title") or ""
+    body = _env("ISSUE_BODY") or issue.get("body") or ""
     labels = lifecycle.issue_labels(issue)
     if config.LABEL_HOLD in labels or config.LABEL_SKIP in labels:
         summary(f"#{number}: skipped (hold/skip label present).")

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -16,10 +16,16 @@ on:
     types: [opened, edited, reopened]
   issue_comment:
     types: [created]
+  # Manual re-triage of an existing issue (e.g. to backfill after a change).
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to (re)triage
+        required: true
 
 # One run at a time per issue; queue rather than cancel so state stays coherent.
 concurrency:
-  group: triage-${{ github.event.issue.number }}
+  group: triage-${{ github.event.issue.number || github.event.inputs.issue_number }}
   cancel-in-progress: false
 
 permissions:
@@ -29,8 +35,10 @@ permissions:
 
 jobs:
   analyze:
-    # Opened/edited/reopened issues (never PRs).
-    if: ${{ github.event_name == 'issues' && !github.event.issue.pull_request }}
+    # Opened/edited/reopened issues (never PRs), or a manual dispatch.
+    if: >-
+      ${{ (github.event_name == 'issues' && !github.event.issue.pull_request)
+      || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
           # Untrusted content — safe because it is an env var, not shell input.
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}


### PR DESCRIPTION
## Problem

The triage workflow only fired on `opened`/`edited`/`reopened` issue events, so there was no way to (re)run it on an existing issue — e.g. to backfill after enabling AI.

## Changes

- Add a `workflow_dispatch` trigger to `triage.yml` with an `issue_number` input; the `analyze` job now also runs for manual dispatch, and the issue number / concurrency group read from the input.
- `cmd_triage` falls back to the fetched issue's title/body when there's no event payload (manual dispatch).