### PR TITLE
Keep the two response-state labels mutually exclusive

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -226,6 +226,16 @@ def apply_triage(
     if labels:
         gh.add_labels(number, labels)
 
+    # Keep the two response-state labels mutually exclusive: if this pass set one,
+    # drop the opposite when the issue still carries it (e.g. on re-triage of an
+    # issue whose state has since flipped).
+    state_pair = {config.LABEL_NEEDS_ATTENTION, config.LABEL_WAITING_FOR_USER}
+    applied_state = state_pair & set(labels)
+    if applied_state:
+        current = set(lifecycle.issue_labels(issue))
+        for stale in (state_pair & current) - applied_state:
+            gh.remove_label(number, stale)
+
     if result.should_comment or (result.rag is not None and result.rag.has_output):
         state = {
             "v": 1,

--- a/.github/scripts/tests/test_main.py
+++ b/.github/scripts/tests/test_main.py
@@ -180,3 +180,24 @@ def test_models_token_falls_back_when_unset_or_blank(monkeypatch):
     assert main._models_token("ghtok") == "ghtok"
     monkeypatch.setenv("GH_MODELS_TOKEN", "")
     assert main._models_token("ghtok") == "ghtok"
+
+
+def test_apply_triage_state_labels_mutually_exclusive(fake_gh):
+    from ma_triage.models import TriageResult
+    # Existing issue already needs-attention; this pass -> waiting-for-user.
+    issue = {"number": 42, "labels": [{"name": "needs-attention"}, {"name": "sonos"}]}
+    result = TriageResult(form_kind="main", missing_sections=["What happened?"])
+    main.apply_triage(fake_gh, 42, issue, result)
+    added = [c for c in fake_gh.calls if c[0] == "add_labels"]
+    assert any("waiting-for-user" in c[2] for c in added)
+    # the opposite state label is removed rather than left to contradict
+    assert ("remove_label", 42, "needs-attention") in fake_gh.calls
+
+
+def test_apply_triage_keeps_state_when_unchanged(fake_gh):
+    from ma_triage.models import TriageResult
+    # Already waiting-for-user; a still-missing-info pass must not remove it.
+    issue = {"number": 43, "labels": [{"name": "waiting-for-user"}]}
+    result = TriageResult(form_kind="main", missing_sections=["What happened?"])
+    main.apply_triage(fake_gh, 43, issue, result)
+    assert not any(c[0] == "remove_label" for c in fake_gh.calls)


### PR DESCRIPTION
## Problem

Re-triaging an issue that already had a response-state label (e.g. `needs-attention`) would *add* the new state (`waiting-for-user`) without removing the old one, leaving the two contradictory labels on the issue. This affects edited issues and manual re-triage.

## Changes

- When a triage pass applies a response-state label, remove the opposite one if the issue still carries it.
- Tests for the flip (removes opposite) and the no-op (keeps unchanged state).