### PR TITLE
Add experimental triage for GitHub Discussions

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -7,6 +7,7 @@ shell interpolation of untrusted issue content):
     python -m ma_triage triage     # analyse an opened/edited issue
     python -m ma_triage respond     # react to a new issue comment
     python -m ma_triage sweep       # scheduled reminder / auto-close pass
+    python -m ma_triage discussion  # answer a new/edited discussion (RAG)
 
 Required env: ``GITHUB_TOKEN``. Issue subcommands also read ``ISSUE_NUMBER``
 (and, for triage, ``ISSUE_TITLE`` / ``ISSUE_BODY``). Feature flags come from the
@@ -444,12 +445,107 @@ def cmd_index_append(gh: GitHubClient, token: str) -> int:
     return 0
 
 
+# --------------------------------------------------------------------------- #
+# Discussions (GraphQL) — docs-grounded answers on Q&A discussions
+# --------------------------------------------------------------------------- #
+def cmd_discussion(gh: GitHubClient, token: str) -> int:
+    """Answer a new/edited Discussion with docs-grounded RAG output.
+
+    Discussions carry no diagnostics, issue-form or labels, so this is a pure
+    RAG pass: retrieve → judge → post the same confidence-tiered sticky comment
+    used for issues (HIGH = answer + sources, MEDIUM = doc links, plus related
+    past posts). Stays silent on LOW confidence with nothing related to show.
+    """
+    number = int(_env("DISCUSSION_NUMBER"))
+    if not (config.AI_ENABLED and config.RAG_ENABLED and config.DISCUSSIONS_ENABLED):
+        summary(f"discussion #{number}: skipped (discussion triage disabled).")
+        return 0
+
+    disc = gh.get_discussion(number)
+    if not disc:
+        summary(f"discussion #{number}: not found or unavailable; skipping.")
+        return 0
+
+    category = ((disc.get("category") or {}).get("name") or "").lower()
+    if category in config.DISCUSSION_EXCLUDE_CATEGORIES:
+        summary(f"discussion #{number}: skipped (excluded category '{category}').")
+        return 0
+
+    title = _env("DISCUSSION_TITLE") or disc.get("title") or ""
+    body = _env("DISCUSSION_BODY") or disc.get("body") or ""
+    summary(f"## Triage of discussion #{number}\n")
+
+    rag_result = rag.answer(gh, title=title, body=body, number=number, token=token)
+    if rag_result is None or not rag_result.has_output:
+        summary(f"#{number}: no confident docs answer or related posts; staying silent.")
+        return 0
+
+    summary(
+        f"- tier: {rag_result.tier} · docs: {rag_result.has_docs_output}"
+        f" · related: {len(rag_result.related_posts)}"
+    )
+    state = {
+        "v": 1,
+        "last_run": _now_iso(),
+        "kind": "discussion",
+        "rag": {
+            "tier": rag_result.tier,
+            "cited": [c.id for c in rag_result.cited_chunks],
+            "related": [p.number for p in rag_result.related_posts],
+            "suppressed": rag_result.suppressed,
+        },
+    }
+    comment.upsert_discussion(
+        gh,
+        disc["id"],
+        comment.build_discussion_body(rag_result, title=title),
+        state,
+        comments=disc.get("comments") or [],
+    )
+    return 0
+
+
+def cmd_discussion_append(gh: GitHubClient, token: str) -> int:
+    """Embed a single new discussion and upsert it into the posts index."""
+    number = int(_env("DISCUSSION_NUMBER"))
+    summary(f"## RAG posts-index append for discussion #{number}\n")
+    disc = gh.get_discussion(number)
+    if not disc:
+        summary(f"discussion #{number}: not found; skipping append.")
+        return 0
+    category = ((disc.get("category") or {}).get("name") or "").lower()
+    if category in config.DISCUSSION_EXCLUDE_CATEGORIES:
+        summary(f"discussion #{number}: excluded category '{category}'; not indexed.")
+        return 0
+    post = {
+        "kind": "discussion",
+        "number": number,
+        "title": disc.get("title") or _env("DISCUSSION_TITLE"),
+        "body": disc.get("body") or _env("DISCUSSION_BODY"),
+        "url": disc.get("url") or "",
+        "state": "open",
+        "updated_at": _now_iso(),
+    }
+    index, _changed = embeddings.append_post(gh, post, token=token)
+    if index is None:
+        summary(f"#{number}: append skipped (embeddings unavailable).")
+        return 0
+    embeddings.save_index(
+        gh,
+        config.POSTS_INDEX_PATH,
+        index,
+        message=f"Append discussion #{number} to posts index",
+    )
+    summary(f"#{number}: appended ({len(index.get('posts', []))} posts total).")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = argv if argv is not None else sys.argv[1:]
     if not argv:
         log(
             "usage: python -m ma_triage "
-            "{triage|respond|sweep|index|index-append}"
+            "{triage|respond|sweep|index|index-append|discussion|discussion-append}"
         )
         return 2
     command = argv[0]
@@ -477,6 +573,10 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_index(gh, models_token, target)
     if command == "index-append":
         return cmd_index_append(gh, models_token)
+    if command == "discussion":
+        return cmd_discussion(gh, models_token)
+    if command == "discussion-append":
+        return cmd_discussion_append(gh, models_token)
     log(f"unknown command: {command}")
     return 2
 

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -475,7 +475,9 @@ def cmd_discussion(gh: GitHubClient, token: str) -> int:
     body = _env("DISCUSSION_BODY") or disc.get("body") or ""
     summary(f"## Triage of discussion #{number}\n")
 
-    rag_result = rag.answer(gh, title=title, body=body, number=number, token=token)
+    rag_result = rag.answer(
+        gh, title=title, body=body, number=number, token=token, kind="discussion"
+    )
     if rag_result is None or not rag_result.has_output:
         summary(f"#{number}: no confident docs answer or related posts; staying silent.")
         return 0
@@ -508,6 +510,9 @@ def cmd_discussion(gh: GitHubClient, token: str) -> int:
 def cmd_discussion_append(gh: GitHubClient, token: str) -> int:
     """Embed a single new discussion and upsert it into the posts index."""
     number = int(_env("DISCUSSION_NUMBER"))
+    if not (config.AI_ENABLED and config.RAG_ENABLED and config.DISCUSSIONS_ENABLED):
+        summary(f"discussion #{number}: skipped (discussion triage disabled).")
+        return 0
     summary(f"## RAG posts-index append for discussion #{number}\n")
     disc = gh.get_discussion(number)
     if not disc:

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -185,13 +185,13 @@ def _doc_link(label: str, url: str) -> str:
     return f"- [{link_label(label, max_len=160) or url}]({url})"
 
 
-def _rag_section(result: TriageResult) -> str:
+def _render_rag(rag: RagResult | None) -> str:
     """Render the optional docs-answer + related-posts sections.
 
     Returns ``""`` when the RAG layer produced nothing (or is disabled), so the
-    comment is byte-identical to Phase 1 in that case.
+    issue comment is byte-identical to Phase 1 in that case. Shared by the issue
+    comment and the discussion comment.
     """
-    rag: RagResult | None = result.rag
     if rag is None or not rag.has_output:
         return ""
     parts: list[str] = []
@@ -225,6 +225,26 @@ def _rag_section(result: TriageResult) -> str:
             title = link_label(post.title, max_len=140)
             parts.append(f"- [#{post.number}: {title}]({post.url}){closed}")
 
+    return "\n".join(parts)
+
+
+def _rag_section(result: TriageResult) -> str:
+    return _render_rag(result.rag)
+
+
+def build_discussion_body(rag: RagResult, *, title: str = "") -> str:
+    """Render the sticky comment for a Discussion.
+
+    Discussions have no diagnostics, template or labels — the body is purely the
+    RAG output (a docs-grounded answer and/or related past posts) wrapped in the
+    standard greeting + disclosure footer. Callers only invoke this when
+    ``rag.has_output`` is true.
+    """
+    parts = [config.STICKY_MARKER, "", config.DISCUSSION_GREETING, ""]
+    section = _render_rag(rag)
+    if section:
+        parts.append(section)
+    parts.append(config.DISCLOSURE_FOOTER)
     return "\n".join(parts)
 
 
@@ -321,3 +341,25 @@ def upsert(
         gh.update_comment(existing["id"], full)
     else:
         gh.create_comment(number, full)
+
+
+def upsert_discussion(
+    gh: GitHubClient,
+    discussion_id: str,
+    body: str,
+    state: dict[str, Any],
+    *,
+    comments: list[dict[str, Any]],
+) -> None:
+    """Create or update the single sticky comment on a Discussion (GraphQL).
+
+    ``comments`` are the discussion's existing comments (``{id, body}`` nodes);
+    the sticky is found via the hidden marker and updated in place, else a new
+    comment is added to the discussion.
+    """
+    full = f"{body}\n\n{_render_state(state)}"
+    existing = find_sticky(comments)
+    if existing:
+        gh.update_discussion_comment(existing["id"], full)
+    else:
+        gh.add_discussion_comment(discussion_id, full)

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -353,12 +353,14 @@ def upsert_discussion(
 ) -> None:
     """Create or update the single sticky comment on a Discussion (GraphQL).
 
-    ``comments`` are the discussion's existing comments (``{id, body}`` nodes);
-    the sticky is found via the hidden marker and updated in place, else a new
-    comment is added to the discussion.
+    ``comments`` are the discussion's existing comments (``{id, body,
+    viewerDidAuthor}`` nodes). Only comments the bot itself authored
+    (``viewerDidAuthor``) are considered when locating the sticky, so a user
+    can't hijack the update by planting the marker text in their own comment.
     """
     full = f"{body}\n\n{_render_state(state)}"
-    existing = find_sticky(comments)
+    owned = [c for c in comments if c.get("viewerDidAuthor")]
+    existing = find_sticky(owned)
     if existing:
         gh.update_discussion_comment(existing["id"], full)
     else:

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -250,6 +250,13 @@ AI_ENDPOINT = _env_str("TRIAGE_AI_ENDPOINT", "https://models.github.ai/inference
 # Tier-1 assessment. Effective enablement is ``AI_ENABLED and RAG_ENABLED``.
 RAG_ENABLED = _flag("TRIAGE_RAG_ENABLED", True)
 
+# Live discussion triage (docs-grounded answers + related posts on GitHub
+# Discussions). Gated *additionally* behind AI_ENABLED and RAG_ENABLED, and
+# defaults OFF so merging the feature is dormant until a maintainer opts in by
+# setting TRIAGE_DISCUSSIONS_ENABLED=true. Effective enablement is
+# ``AI_ENABLED and RAG_ENABLED and DISCUSSIONS_ENABLED``.
+DISCUSSIONS_ENABLED = _flag("TRIAGE_DISCUSSIONS_ENABLED", False)
+
 # Public docs repository (Astro/Starlight). Readable with the default
 # GITHUB_TOKEN — it is public, so no secret is required.
 DOCS_REPO = _env_str("TRIAGE_DOCS_REPO", "music-assistant/music-assistant.io")
@@ -263,11 +270,10 @@ DOCS_EXCLUDE_PREFIXES = tuple(
     for p in _env_str("TRIAGE_DOCS_EXCLUDE", "blog/").split(",")
     if p.strip()
 )
-# Discussion categories excluded from the similar-posts index (case-insensitive).
-# Translation contributions live in a Discussion category and are not useful as
-# "similar reports" for bug issues, so they are skipped by default. (Live
-# discussion triage is out of scope for this phase; discussions are only read
-# into the posts index for related-post links.)
+# Discussion categories excluded (case-insensitive) from BOTH the similar-posts
+# index and live discussion triage. Translation contributions live in a
+# Discussion category and are neither useful as "similar reports" for bug issues
+# nor something the bot should auto-answer, so they are skipped by default.
 DISCUSSION_EXCLUDE_CATEGORIES = tuple(
     c.strip().lower()
     for c in _env_str("TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES", "translations,translation").split(",")
@@ -328,6 +334,13 @@ DISCLOSURE_FOOTER = (
 )
 
 GREETING = "Hi, and thanks for taking the time to report this! 🙏"
+
+# Greeting for the sticky comment posted on a Discussion (a question, not a bug
+# report). Kept short and clearly automated; the disclosure footer still applies.
+DISCUSSION_GREETING = (
+    "👋 Thanks for starting a discussion! Here are a few automated pointers that "
+    "might help while the community and maintainers take a look."
+)
 
 # Lifecycle reminder / close copy. `{days}` is filled in at send time.
 REMINDER_1_MESSAGE = (

--- a/.github/scripts/ma_triage/gh.py
+++ b/.github/scripts/ma_triage/gh.py
@@ -306,6 +306,65 @@ class GitHubClient:
             cursor = page_info.get("endCursor")
         return out[:limit]
 
+    def get_discussion(self, number: int) -> dict[str, Any] | None:
+        """Fetch one discussion + all its comment ids/bodies via GraphQL.
+
+        Discussions are GraphQL-only (no REST). Returns a normalized dict
+        ``{id, number, title, body, url, category, comments}`` where each comment
+        is ``{id, body}`` (the node id is needed to update the sticky comment in
+        place). Returns ``None`` when the discussion can't be read (Discussions
+        disabled, not found, or an API error) so callers degrade to a no-op.
+        """
+        owner, name = self.repo.split("/", 1)
+        query = """
+        query($o:String!,$n:String!,$num:Int!,$c:String){
+          repository(owner:$o,name:$n){
+            discussion(number:$num){
+              id number title body url
+              category { name }
+              comments(first:100, after:$c){
+                pageInfo{ hasNextPage endCursor }
+                nodes{ id body }
+              }
+            }
+          }
+        }
+        """
+        comments: list[dict[str, Any]] = []
+        cursor: str | None = None
+        node: dict[str, Any] = {}
+        while True:
+            try:
+                data = self.graphql(
+                    query, {"o": owner, "n": name, "num": number, "c": cursor}
+                )
+            except Exception as exc:  # noqa: BLE001
+                log(f"Discussion #{number} fetch failed: {exc}")
+                return None
+            found = ((data.get("data") or {}).get("repository") or {}).get(
+                "discussion"
+            )
+            if not found:
+                return None
+            node = found
+            block = node.get("comments") or {}
+            comments.extend(
+                c for c in (block.get("nodes") or []) if isinstance(c, dict)
+            )
+            page_info = block.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                break
+            cursor = page_info.get("endCursor")
+        return {
+            "id": node.get("id"),
+            "number": node.get("number"),
+            "title": node.get("title") or "",
+            "body": node.get("body") or "",
+            "url": node.get("url") or "",
+            "category": node.get("category") or {},
+            "comments": comments,
+        }
+
     # ------------------------------------------------------------------ #
     # Mutating helpers (no-op + log when dry-run)
     # ------------------------------------------------------------------ #
@@ -403,6 +462,32 @@ class GitHubClient:
         return self._mutate(
             f"minimize comment {node_id}",
             lambda: self.graphql(query, {"id": node_id, "classifier": classifier}),
+        )
+
+    def add_discussion_comment(self, discussion_id: str, body: str) -> Any:
+        query = """
+        mutation($d:ID!,$b:String!){
+          addDiscussionComment(input:{discussionId:$d, body:$b}){
+            comment { id }
+          }
+        }
+        """
+        return self._mutate(
+            f"post a comment on discussion {discussion_id}",
+            lambda: self.graphql(query, {"d": discussion_id, "b": body}),
+        )
+
+    def update_discussion_comment(self, comment_id: str, body: str) -> Any:
+        query = """
+        mutation($id:ID!,$b:String!){
+          updateDiscussionComment(input:{commentId:$id, body:$b}){
+            comment { id }
+          }
+        }
+        """
+        return self._mutate(
+            f"update discussion comment {comment_id}",
+            lambda: self.graphql(query, {"id": comment_id, "b": body}),
         )
 
     def commit_files(

--- a/.github/scripts/ma_triage/gh.py
+++ b/.github/scripts/ma_triage/gh.py
@@ -324,7 +324,7 @@ class GitHubClient:
               category { name }
               comments(first:100, after:$c){
                 pageInfo{ hasNextPage endCursor }
-                nodes{ id body }
+                nodes{ id body viewerDidAuthor }
               }
             }
           }

--- a/.github/scripts/ma_triage/rag.py
+++ b/.github/scripts/ma_triage/rag.py
@@ -80,6 +80,7 @@ def answer(
     body: str,
     number: int,
     token: str,
+    kind: str = "issue",
 ) -> RagResult | None:
     """Run the RAG pipeline for one post. ``None`` when disabled or on failure."""
     if not (config.AI_ENABLED and config.RAG_ENABLED):
@@ -133,6 +134,7 @@ def answer(
             title=title,
             posts=posts,
             exclude_number=number,
+            exclude_kind=kind,
         )
 
         result = RagResult(

--- a/.github/scripts/ma_triage/similar.py
+++ b/.github/scripts/ma_triage/similar.py
@@ -30,6 +30,7 @@ def related_from_index(
     posts: list[dict],
     *,
     exclude_number: int,
+    exclude_kind: str = "issue",
     k: int | None = None,
     min_score: float | None = None,
 ) -> list[RelatedPost]:
@@ -44,7 +45,7 @@ def related_from_index(
     for post in posts:
         number = int(post.get("number", 0))
         kind = post.get("kind", "issue")
-        if kind == "issue" and number == exclude_number:
+        if kind == exclude_kind and number == exclude_number:
             continue
         key = (kind, number)
         if key in seen:
@@ -79,7 +80,8 @@ def _title_query(title: str) -> str:
 
 
 def related_from_search(
-    gh: GitHubClient, title: str, *, exclude_number: int, k: int | None = None
+    gh: GitHubClient, title: str, *, exclude_number: int, exclude_kind: str = "issue",
+    k: int | None = None
 ) -> list[RelatedPost]:
     """Fallback: GitHub issue search over the title keywords."""
     top_k = config.RELATED_POSTS if k is None else k
@@ -97,7 +99,10 @@ def related_from_search(
         if "pull_request" in item:
             continue
         number = int(item.get("number", 0))
-        if number == exclude_number:
+        # The search only returns issues, so only skip the self-number when the
+        # incoming post is itself an issue (a discussion sharing that number is
+        # a different post and should still be surfaceable).
+        if exclude_kind == "issue" and number == exclude_number:
             continue
         results.append(
             RelatedPost(
@@ -121,10 +126,15 @@ def find_related(
     title: str,
     posts: list[dict],
     exclude_number: int,
+    exclude_kind: str = "issue",
 ) -> list[RelatedPost]:
     """Related posts from the index when available, else the search fallback."""
     if posts and query_vec:
-        hits = related_from_index(query_vec, posts, exclude_number=exclude_number)
+        hits = related_from_index(
+            query_vec, posts, exclude_number=exclude_number, exclude_kind=exclude_kind
+        )
         if hits:
             return hits
-    return related_from_search(gh, title, exclude_number=exclude_number)
+    return related_from_search(
+        gh, title, exclude_number=exclude_number, exclude_kind=exclude_kind
+    )

--- a/.github/scripts/tests/conftest.py
+++ b/.github/scripts/tests/conftest.py
@@ -44,7 +44,7 @@ class FakeGH:
 
     def __init__(self, *, latest_tag="2.9.5", labels=None, manifests=None,
                  index_files=None, tree=None, issues=None, discussions=None,
-                 search_items=None):
+                 search_items=None, discussion=None):
         self.dry_run = False
         self.repo = "music-assistant/support"
         self._latest_tag = latest_tag
@@ -55,6 +55,7 @@ class FakeGH:
         self._tree = list(tree or [])
         self._issues = list(issues or [])
         self._discussions = list(discussions or [])
+        self._discussion_obj = discussion
         self._search_items = list(search_items or [])
         self.calls: list[tuple] = []
 
@@ -95,6 +96,9 @@ class FakeGH:
     def list_discussions(self, *, limit=500):
         return list(self._discussions)[:limit]
 
+    def get_discussion(self, number):
+        return self._discussion_obj
+
     # mutations (recorded) --------------------------------------------------
     def add_labels(self, number, labels):
         self.calls.append(("add_labels", number, tuple(labels)))
@@ -109,6 +113,12 @@ class FakeGH:
 
     def update_comment(self, comment_id, body):
         self.calls.append(("update_comment", comment_id, body))
+
+    def add_discussion_comment(self, discussion_id, body):
+        self.calls.append(("add_discussion_comment", discussion_id, body))
+
+    def update_discussion_comment(self, comment_id, body):
+        self.calls.append(("update_discussion_comment", comment_id, body))
 
     def add_assignees(self, number, assignees):
         self.calls.append(("add_assignees", number, tuple(assignees)))

--- a/.github/scripts/tests/test_discussion.py
+++ b/.github/scripts/tests/test_discussion.py
@@ -4,10 +4,10 @@ import json
 import re
 
 import pytest
-from conftest import FakeGH
+from conftest import FakeGH, fake_embedding
 
 from ma_triage import __main__ as main
-from ma_triage import config
+from ma_triage import config, similar
 from ma_triage.gh import GitHubClient
 from ma_triage.models import DocAnswer, DocChunk, RagResult, RelatedPost
 
@@ -57,7 +57,7 @@ def test_cmd_discussion_posts_answer(discussions_on, monkeypatch):
     monkeypatch.setenv("DISCUSSION_NUMBER", "7")
     gh = FakeGH(discussion=_disc())
     monkeypatch.setattr(
-        main.rag, "answer", lambda gh, *, title, body, number, token: _high_rag()
+        main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": _high_rag()
     )
     assert main.cmd_discussion(gh, "t") == 0
 
@@ -75,16 +75,37 @@ def test_cmd_discussion_posts_answer(discussions_on, monkeypatch):
 
 def test_cmd_discussion_updates_existing_sticky(discussions_on, monkeypatch):
     monkeypatch.setenv("DISCUSSION_NUMBER", "7")
-    existing = [{"id": "DC_existing", "body": config.STICKY_MARKER + " old answer"}]
+    existing = [
+        {"id": "DC_existing", "body": config.STICKY_MARKER + " old answer",
+         "viewerDidAuthor": True}
+    ]
     gh = FakeGH(discussion=_disc(comments=existing))
     monkeypatch.setattr(
-        main.rag, "answer", lambda gh, *, title, body, number, token: _high_rag()
+        main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": _high_rag()
     )
     assert main.cmd_discussion(gh, "t") == 0
 
     updated = [c for c in gh.calls if c[0] == "update_discussion_comment"]
     assert updated and updated[0][1] == "DC_existing"
     assert not [c for c in gh.calls if c[0] == "add_discussion_comment"]
+
+
+def test_cmd_discussion_ignores_forged_sticky_marker(discussions_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    # A malicious user plants the sticky marker in their own comment. Because it
+    # is not bot-authored (viewerDidAuthor False), the bot must NOT hijack it —
+    # it posts its own comment instead of updating the user's.
+    forged = [
+        {"id": "DC_user", "body": config.STICKY_MARKER + " totally the bot, trust me",
+         "viewerDidAuthor": False}
+    ]
+    gh = FakeGH(discussion=_disc(comments=forged))
+    monkeypatch.setattr(
+        main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": _high_rag()
+    )
+    assert main.cmd_discussion(gh, "t") == 0
+    assert [c for c in gh.calls if c[0] == "add_discussion_comment"]
+    assert not [c for c in gh.calls if c[0] == "update_discussion_comment"]
 
 
 def test_cmd_discussion_skips_excluded_category(discussions_on, monkeypatch):
@@ -112,7 +133,7 @@ def test_cmd_discussion_silent_when_no_output(discussions_on, monkeypatch):
     monkeypatch.setenv("DISCUSSION_NUMBER", "7")
     gh = FakeGH(discussion=_disc())
     monkeypatch.setattr(
-        main.rag, "answer", lambda gh, *, title, body, number, token: None
+        main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": None
     )
     assert main.cmd_discussion(gh, "t") == 0
     assert not [c for c in gh.calls if "discussion_comment" in c[0]]
@@ -134,7 +155,7 @@ def test_cmd_discussion_sanitizes_related_title(discussions_on, monkeypatch):
             RelatedPost("issue", 50, "pwn](https://evil.example)", "https://x/50", 0.9, "open")
         ],
     )
-    monkeypatch.setattr(main.rag, "answer", lambda gh, *, title, body, number, token: rag)
+    monkeypatch.setattr(main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": rag)
     assert main.cmd_discussion(gh, "t") == 0
     body = [c for c in gh.calls if c[0] == "add_discussion_comment"][0][2]
     assert r"pwn\](https://evil.example)" in body
@@ -146,6 +167,7 @@ def test_cmd_discussion_sanitizes_related_title(discussions_on, monkeypatch):
 # --------------------------------------------------------------------------- #
 def test_cmd_discussion_append(ai_on, monkeypatch):
     monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    monkeypatch.setattr(config, "DISCUSSIONS_ENABLED", True)
     gh = FakeGH(discussion=_disc())
     assert main.cmd_discussion_append(gh, "t") == 0
     assert config.POSTS_INDEX_PATH in gh._index_files
@@ -155,9 +177,19 @@ def test_cmd_discussion_append(ai_on, monkeypatch):
 
 def test_cmd_discussion_append_skips_excluded_category(ai_on, monkeypatch):
     monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    monkeypatch.setattr(config, "DISCUSSIONS_ENABLED", True)
     gh = FakeGH(discussion=_disc(category="Translations"))
     assert main.cmd_discussion_append(gh, "t") == 0
     assert config.POSTS_INDEX_PATH not in gh._index_files
+
+
+def test_cmd_discussion_append_disabled_is_noop(ai_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    monkeypatch.setattr(config, "DISCUSSIONS_ENABLED", False)
+    gh = FakeGH(discussion=_disc())
+    assert main.cmd_discussion_append(gh, "t") == 0
+    assert config.POSTS_INDEX_PATH not in gh._index_files
+    assert gh.calls == []
 
 
 # --------------------------------------------------------------------------- #
@@ -224,3 +256,21 @@ def test_discussion_comment_mutations_respect_dry_run(monkeypatch):
     client.dry_run = False
     assert client.add_discussion_comment("D_1", "hi") == {"ok": True}
     assert sent == [{"d": "D_1", "b": "hi"}]
+
+
+def test_related_index_excludes_self_discussion_keeps_same_number_issue():
+    # A discussion being triaged must not list itself, but a *different* post
+    # (an issue sharing the number) should still be surfaceable.
+    vec = fake_embedding("group sonos speakers")
+    posts = [
+        {"kind": "discussion", "number": 7, "title": "group sonos speakers",
+         "url": "d7", "state": "open", "embedding": fake_embedding("group sonos speakers")},
+        {"kind": "issue", "number": 7, "title": "group sonos speakers",
+         "url": "i7", "state": "open", "embedding": fake_embedding("group sonos speakers")},
+    ]
+    out = similar.related_from_index(
+        vec, posts, exclude_number=7, exclude_kind="discussion", min_score=0.0
+    )
+    keys = {(r.kind, r.number) for r in out}
+    assert ("discussion", 7) not in keys
+    assert ("issue", 7) in keys

--- a/.github/scripts/tests/test_discussion.py
+++ b/.github/scripts/tests/test_discussion.py
@@ -1,0 +1,226 @@
+"""Tests for live discussion triage (the GraphQL discussions path)."""
+
+import json
+import re
+
+import pytest
+from conftest import FakeGH
+
+from ma_triage import __main__ as main
+from ma_triage import config
+from ma_triage.gh import GitHubClient
+from ma_triage.models import DocAnswer, DocChunk, RagResult, RelatedPost
+
+
+def _chunk(cid="faq/net#mdns"):
+    return DocChunk(
+        id=cid, path="faq/net", url="https://www.music-assistant.io/faq/net/#mdns",
+        title="Networking", heading="mDNS", text="multicast",
+        breadcrumbs=["Networking", "mDNS"],
+    )
+
+
+def _high_rag():
+    return RagResult(
+        tier="high",
+        doc_answer=DocAnswer(True, 0.9, "Enable multicast on your switch.", ["faq/net#mdns"]),
+        cited_chunks=[_chunk()],
+        related_posts=[RelatedPost("discussion", 12, "similar q", "https://x/12", 0.6, "open")],
+    )
+
+
+def _disc(comments=None, category="Q&A"):
+    return {
+        "id": "D_kwABC",
+        "number": 7,
+        "title": "how do I group sonos speakers",
+        "body": "trying to group",
+        "url": "https://github.com/music-assistant/support/discussions/7",
+        "category": {"name": category},
+        "comments": comments or [],
+    }
+
+
+@pytest.fixture
+def discussions_on(monkeypatch):
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", True)
+    monkeypatch.setattr(config, "DISCUSSIONS_ENABLED", True)
+    monkeypatch.delenv("DISCUSSION_TITLE", raising=False)
+    monkeypatch.delenv("DISCUSSION_BODY", raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# cmd_discussion
+# --------------------------------------------------------------------------- #
+def test_cmd_discussion_posts_answer(discussions_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    gh = FakeGH(discussion=_disc())
+    monkeypatch.setattr(
+        main.rag, "answer", lambda gh, *, title, body, number, token: _high_rag()
+    )
+    assert main.cmd_discussion(gh, "t") == 0
+
+    posted = [c for c in gh.calls if c[0] == "add_discussion_comment"]
+    assert len(posted) == 1
+    disc_id, body = posted[0][1], posted[0][2]
+    assert disc_id == "D_kwABC"
+    assert config.STICKY_MARKER in body
+    assert config.DISCUSSION_GREETING in body
+    assert config.DOCS_ANSWER_HEADING in body
+    assert "Enable multicast on your switch." in body
+    assert config.RELATED_POSTS_HEADING in body
+    assert config.STATE_BEGIN in body  # hidden state embedded
+
+
+def test_cmd_discussion_updates_existing_sticky(discussions_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    existing = [{"id": "DC_existing", "body": config.STICKY_MARKER + " old answer"}]
+    gh = FakeGH(discussion=_disc(comments=existing))
+    monkeypatch.setattr(
+        main.rag, "answer", lambda gh, *, title, body, number, token: _high_rag()
+    )
+    assert main.cmd_discussion(gh, "t") == 0
+
+    updated = [c for c in gh.calls if c[0] == "update_discussion_comment"]
+    assert updated and updated[0][1] == "DC_existing"
+    assert not [c for c in gh.calls if c[0] == "add_discussion_comment"]
+
+
+def test_cmd_discussion_skips_excluded_category(discussions_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    gh = FakeGH(discussion=_disc(category="Translations"))
+    monkeypatch.setattr(
+        main.rag, "answer",
+        lambda *a, **k: pytest.fail("rag.answer must not run for excluded category"),
+    )
+    assert main.cmd_discussion(gh, "t") == 0
+    assert not [c for c in gh.calls if "discussion_comment" in c[0]]
+
+
+def test_cmd_discussion_disabled_is_noop(monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", True)
+    monkeypatch.setattr(config, "DISCUSSIONS_ENABLED", False)
+    gh = FakeGH(discussion=_disc())
+    assert main.cmd_discussion(gh, "t") == 0
+    assert gh.calls == []
+
+
+def test_cmd_discussion_silent_when_no_output(discussions_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    gh = FakeGH(discussion=_disc())
+    monkeypatch.setattr(
+        main.rag, "answer", lambda gh, *, title, body, number, token: None
+    )
+    assert main.cmd_discussion(gh, "t") == 0
+    assert not [c for c in gh.calls if "discussion_comment" in c[0]]
+
+
+def test_cmd_discussion_not_found_is_noop(discussions_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    gh = FakeGH(discussion=None)
+    assert main.cmd_discussion(gh, "t") == 0
+    assert gh.calls == []
+
+
+def test_cmd_discussion_sanitizes_related_title(discussions_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    gh = FakeGH(discussion=_disc())
+    rag = RagResult(
+        tier="low",
+        related_posts=[
+            RelatedPost("issue", 50, "pwn](https://evil.example)", "https://x/50", 0.9, "open")
+        ],
+    )
+    monkeypatch.setattr(main.rag, "answer", lambda gh, *, title, body, number, token: rag)
+    assert main.cmd_discussion(gh, "t") == 0
+    body = [c for c in gh.calls if c[0] == "add_discussion_comment"][0][2]
+    assert r"pwn\](https://evil.example)" in body
+    assert re.search(r"(?<!\\)\]\(https://evil\.example\)", body) is None
+
+
+# --------------------------------------------------------------------------- #
+# cmd_discussion_append
+# --------------------------------------------------------------------------- #
+def test_cmd_discussion_append(ai_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    gh = FakeGH(discussion=_disc())
+    assert main.cmd_discussion_append(gh, "t") == 0
+    assert config.POSTS_INDEX_PATH in gh._index_files
+    stored = json.loads(gh._index_files[config.POSTS_INDEX_PATH])
+    assert [(p["kind"], p["number"]) for p in stored["posts"]] == [("discussion", 7)]
+
+
+def test_cmd_discussion_append_skips_excluded_category(ai_on, monkeypatch):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    gh = FakeGH(discussion=_disc(category="Translations"))
+    assert main.cmd_discussion_append(gh, "t") == 0
+    assert config.POSTS_INDEX_PATH not in gh._index_files
+
+
+# --------------------------------------------------------------------------- #
+# GitHubClient GraphQL helpers (network-free)
+# --------------------------------------------------------------------------- #
+def _disc_page(next_page, cursor, comment_node):
+    return {
+        "data": {
+            "repository": {
+                "discussion": {
+                    "id": "D_1", "number": 7, "title": "T", "body": "B",
+                    "url": "u", "category": {"name": "Q&A"},
+                    "comments": {
+                        "pageInfo": {"hasNextPage": next_page, "endCursor": cursor},
+                        "nodes": [comment_node],
+                    },
+                }
+            }
+        }
+    }
+
+
+def test_get_discussion_aggregates_comment_pages(monkeypatch):
+    client = GitHubClient("tok", repo="music-assistant/support")
+    pages = [
+        _disc_page(True, "c1", {"id": "DC_1", "body": "one"}),
+        _disc_page(False, None, {"id": "DC_2", "body": "two"}),
+    ]
+    seen = []
+
+    def fake_graphql(query, variables=None, *, features=None):
+        seen.append(variables)
+        return pages[len(seen) - 1]
+
+    monkeypatch.setattr(client, "graphql", fake_graphql)
+    disc = client.get_discussion(7)
+    assert disc["id"] == "D_1"
+    assert [c["id"] for c in disc["comments"]] == ["DC_1", "DC_2"]
+    assert seen[0]["num"] == 7 and seen[1]["c"] == "c1"  # cursor forwarded
+
+
+def test_get_discussion_missing_returns_none(monkeypatch):
+    client = GitHubClient("tok")
+    monkeypatch.setattr(
+        client, "graphql",
+        lambda q, v=None, *, features=None: {"data": {"repository": {"discussion": None}}},
+    )
+    assert client.get_discussion(999) is None
+
+
+def test_discussion_comment_mutations_respect_dry_run(monkeypatch):
+    client = GitHubClient("tok")
+    sent = []
+    monkeypatch.setattr(
+        client, "graphql",
+        lambda q, v=None, *, features=None: sent.append(v) or {"ok": True},
+    )
+
+    client.dry_run = True
+    assert client.add_discussion_comment("D_1", "hi") is None
+    assert client.update_discussion_comment("DC_1", "hi") is None
+    assert sent == []  # dry-run sends no mutation
+
+    client.dry_run = False
+    assert client.add_discussion_comment("D_1", "hi") == {"ok": True}
+    assert sent == [{"d": "D_1", "b": "hi"}]

--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -1,0 +1,114 @@
+# Music Assistant discussion triage (experimental).
+#
+# Answers newly opened/edited Discussions with a docs-grounded RAG reply and
+# links to similar past reports, posting a single sticky comment. Discussions
+# carry no diagnostics/labels, so this is purely the docs-answer + related-posts
+# pipeline shared with issue triage.
+#
+# SAFETY:
+# * All discussion content is treated as untrusted and passed to the script via
+#   `env:` only — never interpolated into a shell command.
+# * Least-privilege token; the answer job cannot write repo contents and the
+#   index job cannot write discussions.
+# * Dormant until opted in: requires the repo variables TRIAGE_AI_ENABLED=true
+#   AND TRIAGE_DISCUSSIONS_ENABLED=true (and defaults to dry-run otherwise).
+name: Discussion triage
+
+on:
+  discussion:
+    types: [created, edited]
+
+# One run at a time per discussion; queue rather than cancel so the sticky
+# comment stays coherent across quick edits.
+concurrency:
+  group: discussion-${{ github.event.discussion.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  discussions: write
+  models: read # docs-grounded answer via GitHub Models (only when AI enabled)
+
+jobs:
+  answer:
+    if: >-
+      ${{ vars.TRIAGE_AI_ENABLED == 'true'
+      && vars.TRIAGE_RAG_ENABLED != 'false'
+      && vars.TRIAGE_DISCUSSIONS_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        working-directory: .github/scripts
+        run: pip install -r requirements.txt
+      - name: Triage discussion
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
+          # Untrusted content — safe because it is an env var, not shell input.
+          DISCUSSION_TITLE: ${{ github.event.discussion.title }}
+          DISCUSSION_BODY: ${{ github.event.discussion.body }}
+          TRIAGE_DRY_RUN: ${{ vars.TRIAGE_DRY_RUN }}
+          TRIAGE_AI_ENABLED: ${{ vars.TRIAGE_AI_ENABLED }}
+          TRIAGE_DISCUSSIONS_ENABLED: ${{ vars.TRIAGE_DISCUSSIONS_ENABLED }}
+          TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
+          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
+          TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
+          TRIAGE_ANSWER_MODEL: ${{ vars.TRIAGE_ANSWER_MODEL }}
+          TRIAGE_ANSWER_HI: ${{ vars.TRIAGE_ANSWER_HI }}
+          TRIAGE_ANSWER_LO: ${{ vars.TRIAGE_ANSWER_LO }}
+          TRIAGE_DOCS_REPO: ${{ vars.TRIAGE_DOCS_REPO }}
+          TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
+          TRIAGE_RELATED_POSTS: ${{ vars.TRIAGE_RELATED_POSTS }}
+          TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES: ${{ vars.TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES }}
+          # Optional PAT for GitHub Models (used only when set); falls back to
+          # the default token. Lets Models work when the org token can't.
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
+        run: python -m ma_triage discussion
+
+  # Separate, least-privilege job: embed a newly-created discussion and append it
+  # to the posts index on the `triage-index` branch. It has `contents: write`
+  # (to commit the index) but deliberately NOT `discussions: write`.
+  index-append:
+    if: >-
+      ${{ github.event.action == 'created'
+      && vars.TRIAGE_AI_ENABLED == 'true'
+      && vars.TRIAGE_RAG_ENABLED != 'false' }}
+    runs-on: ubuntu-latest
+    # Serialise with the nightly index build (and issue appends) so concurrent
+    # force-pushes to the triage-index branch can't drop each other's writes.
+    concurrency:
+      group: rag-index-write
+      cancel-in-progress: false
+    permissions:
+      contents: write # commit the posts index to the triage-index branch
+      models: read # embeddings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        working-directory: .github/scripts
+        run: pip install -r requirements.txt
+      - name: Append discussion to posts index
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
+          TRIAGE_DRY_RUN: ${{ vars.TRIAGE_DRY_RUN }}
+          TRIAGE_AI_ENABLED: ${{ vars.TRIAGE_AI_ENABLED }}
+          TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
+          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
+          TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
+          TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
+          TRIAGE_INDEX_MAX_POSTS: ${{ vars.TRIAGE_INDEX_MAX_POSTS }}
+          TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES: ${{ vars.TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES }}
+          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
+        run: python -m ma_triage discussion-append

--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -78,7 +78,8 @@ jobs:
     if: >-
       ${{ github.event.action == 'created'
       && vars.TRIAGE_AI_ENABLED == 'true'
-      && vars.TRIAGE_RAG_ENABLED != 'false' }}
+      && vars.TRIAGE_RAG_ENABLED != 'false'
+      && vars.TRIAGE_DISCUSSIONS_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     # Serialise with the nightly index build (and issue appends) so concurrent
     # force-pushes to the triage-index branch can't drop each other's writes.
@@ -105,6 +106,7 @@ jobs:
           TRIAGE_DRY_RUN: ${{ vars.TRIAGE_DRY_RUN }}
           TRIAGE_AI_ENABLED: ${{ vars.TRIAGE_AI_ENABLED }}
           TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
+          TRIAGE_DISCUSSIONS_ENABLED: ${{ vars.TRIAGE_DISCUSSIONS_ENABLED }}
           TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
           TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}


### PR DESCRIPTION
## Problem

The triage bot only handles **issues** today. Lots of "how do I…?" questions land in **GitHub Discussions** with no automated help — even though the docs-grounded answer + similar-report pipeline that's already live for issues is exactly what those discussions need.

## Changes

- **New `Discussion triage` workflow** (`.github/workflows/discussions.yml`) on `discussion` *created/edited*: posts a single sticky comment with a docs-grounded answer (or relevant doc links) plus similar past reports, reusing the existing RAG pipeline and output sanitizers.
- **Dormant by default:** gated behind a new `TRIAGE_DISCUSSIONS_ENABLED` repo variable (default off) on top of `TRIAGE_AI_ENABLED` / `TRIAGE_RAG_ENABLED`, so merging changes nothing until you opt in. Fully dry-run aware.
- **Quiet & scoped:** skips excluded categories (translations) and stays silent when there's nothing confident to add. Discussions get no diagnostics/label logic — it's a pure answer pass.
- **Least-privilege:** the answer job gets `discussions: write` only; a separate job embeds new discussions into the similar-posts index with `contents: write` (and no discussions access). All discussion content is passed via `env:`, never shell-interpolated.
- **GraphQL helpers** to read a discussion + its comments and add/update the sticky comment (dry-run aware), plus new `discussion` and `discussion-append` subcommands.
- **Tests** for the discussion path, category skip, flag-off no-op, related-title sanitization, and the GraphQL helpers — full suite is 205 passing.

Experimental and safe to dry-run: with the flag unset, the workflow jobs are skipped entirely.
