### PR TITLE
Improve live triage relevance

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -49,10 +49,12 @@ From the diagnostics file the bot derives, with no AI:
 - **safe mode** banner;
 - **providers in error** (with sanitized error text);
 - **top exception fingerprints** by count;
-- **provider/setup labels** — from the diagnostics census *and* provider names
-  mentioned in the form text (only labels that already exist are applied);
-- **community maintainer** ping (from each provider's `codeowners`, skipping the
-  core `@music-assistant` team; never triggered by heuristic log parsing);
+- **provider/setup labels** — provider labels come only from the provider reported
+  in the title/form text (never the full diagnostics census); title matches win
+  over incidental comparisons in the body;
+- the reported provider's authoritative **documentation link** and, for one
+  actionable provider, its community **codeowner** (from the current server
+  manifest on `dev`, skipping the core `@music-assistant` team);
 - low-disk and other resource hints.
 
 If only a **raw log file** is attached (older Music Assistant versions), the bot
@@ -85,10 +87,12 @@ adds a **retrieval-augmented** layer on top of the tiers above, modelled on
   judge call that returns `{answers_question, confidence, answer, cited_sections}`.
 - **Similar past reports.** The issue embedding is compared (dense cosine) to an
   index of past issues + discussions to surface likely duplicates / prior answers.
-  If the index is missing, this degrades to a plain GitHub issue search.
-  Translation-category discussions are excluded from this index (they aren't
-  docs-answerable and would only add noise). Live triage of discussions
-  themselves is out of scope for this phase.
+  When a provider is known, candidates must match that provider exactly; weak
+  matches stay collapsed, while only strong matches render expanded. Pinned
+  support notices that mention the provider are surfaced separately and Feature
+  Polls are ignored. Translation-category discussions are excluded from the
+  index. New/edited Discussions use the same RAG path when
+  `TRIAGE_DISCUSSIONS_ENABLED=true`.
 - **Confidence tiers.** `HIGH` (≥ `TRIAGE_ANSWER_HI`) posts a doc-grounded answer
   with cited links; `MEDIUM` (≥ `TRIAGE_ANSWER_LO`) posts doc links only;
   `LOW` stays silent (deterministic triage and duplicate links may still post).
@@ -133,6 +137,7 @@ Maintainer override labels: `triage/hold` (pause automation), `triage/skip`
 | `TRIAGE_SCAN_LOGS` | `true` | Scan an attached raw log (redacted) when no diagnostics report is present. |
 | `TRIAGE_AI_MODEL` | `openai/gpt-4o-mini` | Model id for Tier 1. |
 | `TRIAGE_RAG_ENABLED` | `true` | Sub-flag for the Phase-2 RAG layer (still requires `TRIAGE_AI_ENABLED`). |
+| `TRIAGE_DISCUSSIONS_ENABLED` | `false` | Enable docs-grounded triage on new/edited Discussions. |
 | `TRIAGE_EMBED_MODEL` | `openai/text-embedding-3-small` | Embeddings model (GitHub Models). |
 | `TRIAGE_EMBED_DIM` | `512` | Embedding dimensionality (keeps indexes small). |
 | `TRIAGE_ANSWER_MODEL` | `openai/gpt-4o` | Judge/answer chat model. |
@@ -141,6 +146,9 @@ Maintainer override labels: `triage/hold` (pause automation), `triage/skip`
 | `TRIAGE_DOCS_REPO` | `music-assistant/music-assistant.io` | Public docs source. |
 | `TRIAGE_INDEX_BRANCH` | `triage-index` | Orphan branch holding the JSON indexes. |
 | `TRIAGE_INDEX_MAX_POSTS` | `500` | Cap on posts embedded into the similar-posts index. |
+| `TRIAGE_RELATED_EXPAND_SCORE` | `0.80` | Similarity score required to expand related posts; weaker provider-matched results are collapsed. |
+| `TRIAGE_SERVER_REF` | `dev` | Server ref used for provider documentation/codeowner manifests. |
+| `TRIAGE_PINNED_EXCLUDE_CATEGORIES` | `feature polls` | Pinned Discussion categories excluded from support notices. |
 
 ### RAG indexes (`triage-index` branch)
 The `docs_embeddings.yml` workflow builds `docs.json` / `posts.json` and commits
@@ -164,8 +172,8 @@ and vice-versa. Both honour `TRIAGE_DRY_RUN` (dry-run previews the commit).
 
 ## Security model
 
-- Triggers are `issues`, `issue_comment`, `schedule`, `workflow_dispatch` and
-  `repository_dispatch` (the last two only for the RAG index build) — **no
+- Triggers are `issues`, `issue_comment`, `discussion`, `schedule`,
+  `workflow_dispatch` and `repository_dispatch` — **no
   `pull_request_target`**.
 - Issue content flows through `env:` → `os.environ`; it is never placed in a
   shell command line.

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -33,9 +33,10 @@ from .diagnostics import try_parse
 from .gh import GitHubClient, log, summary
 from .models import TriageResult
 from .providers import (
-    detect_provider_labels_from_text,
+    detect_reported_provider_labels,
     filter_existing_labels,
     resolve_maintainers,
+    resolve_provider_doc,
 )
 
 
@@ -101,10 +102,21 @@ def build_result(
     labels_to_add: set[str] = set(result.labels_to_add)
     maintainers: set[str] = set()
 
-    # Provider labels from the free-text fields + title (census gone from form).
-    labels_to_add |= detect_provider_labels_from_text(
-        template.provider_scan_text(body, title)
+    # A title-level provider mention wins over incidental comparisons in the
+    # body. Diagnostics describe the whole installation and must never drive
+    # issue labels.
+    reported_providers = set(
+        sorted(
+            detect_reported_provider_labels(title, body),
+            key=str.lower,
+        )[: config.MAX_REPORTED_PROVIDERS]
     )
+    result.reported_providers = reported_providers
+    labels_to_add |= reported_providers
+    for provider in sorted(reported_providers, key=str.lower):
+        provider_doc = resolve_provider_doc(gh, provider)
+        if provider_doc is not None:
+            result.provider_docs.append(provider_doc)
 
     install_finding = analyze.install_method_finding(result.install_method)
     if install_finding is not None:
@@ -125,12 +137,11 @@ def build_result(
             findings.extend(v_findings)
             labels_to_add |= v_labels
 
-        # Only involve maintainers from a *real* diagnostics census — log parsing
-        # of provider names is heuristic and must not ping people.
-        if diag.source == "json":
-            for provider in diag.providers_in_error:
-                for handle in resolve_maintainers(gh, provider.domain):
-                    maintainers.add(handle)
+        # Ping conservatively: one clearly reported provider on an actionable
+        # report. Never ping maintainers for incidental census/error providers.
+        if len(reported_providers) == 1:
+            provider = next(iter(reported_providers))
+            maintainers.update(resolve_maintainers(gh, provider))
 
         ai_result = ai.assess(
             diag, title, body, token=token, candidate_labels=sorted(labels_to_add)
@@ -151,7 +162,14 @@ def build_result(
 
     # Phase 2 RAG layer (docs-grounded answer + related posts). Returns None when
     # disabled or on any failure, so Tier-0/Tier-1 output is unchanged.
-    result.rag = rag.answer(gh, title=title, body=body, number=number, token=token)
+    result.rag = rag.answer(
+        gh,
+        title=title,
+        body=body,
+        number=number,
+        token=token,
+        provider_labels=reported_providers,
+    )
     return result
 
 
@@ -242,6 +260,7 @@ def apply_triage(
             "v": 1,
             "last_run": _now_iso(),
             "form": result.form_kind,
+            "providers": sorted(result.reported_providers),
             "has_diagnostics": result.has_diagnostics,
             "invalid": result.diagnostics_invalid,
             "ai": result.ai is not None,
@@ -253,6 +272,7 @@ def apply_triage(
             state["rag"] = {
                 "tier": result.rag.tier,
                 "cited": [c.id for c in result.rag.cited_chunks],
+                "pinned": [p.number for p in result.rag.pinned_posts],
                 "related": [p.number for p in result.rag.related_posts],
                 "suppressed": result.rag.suppressed,
             }
@@ -352,12 +372,15 @@ def _build_docs_index(gh: GitHubClient, token: str) -> None:
 def _collect_posts(gh: GitHubClient) -> list[dict[str, Any]]:
     posts: list[dict[str, Any]] = []
     for issue in gh.list_recent_issues(limit=config.INDEX_MAX_POSTS):
+        title = issue.get("title") or ""
+        body = issue.get("body") or ""
         posts.append(
             {
                 "kind": "issue",
                 "number": issue.get("number"),
-                "title": issue.get("title") or "",
-                "body": issue.get("body") or "",
+                "title": title,
+                "body": body,
+                "providers": sorted(detect_reported_provider_labels(title, body)),
                 "url": issue.get("html_url") or "",
                 "state": issue.get("state"),
                 "updated_at": issue.get("updated_at"),
@@ -368,12 +391,15 @@ def _collect_posts(gh: GitHubClient) -> list[dict[str, Any]]:
         if category in config.DISCUSSION_EXCLUDE_CATEGORIES:
             # e.g. translation-category discussions: not useful as related posts.
             continue
+        title = disc.get("title") or ""
+        body = disc.get("body") or ""
         posts.append(
             {
                 "kind": "discussion",
                 "number": disc.get("number"),
-                "title": disc.get("title") or "",
-                "body": disc.get("body") or "",
+                "title": title,
+                "body": body,
+                "providers": sorted(detect_reported_provider_labels(title, body)),
                 "url": disc.get("url") or "",
                 "state": "closed" if disc.get("closed") else "open",
                 "updated_at": disc.get("updatedAt"),
@@ -422,11 +448,14 @@ def cmd_index_append(gh: GitHubClient, token: str) -> int:
     if "pull_request" in issue:
         summary(f"#{number}: is a pull request; skipping append.")
         return 0
+    title = issue.get("title") or _env("ISSUE_TITLE")
+    body = issue.get("body") or _env("ISSUE_BODY")
     post = {
         "kind": "issue",
         "number": number,
-        "title": issue.get("title") or _env("ISSUE_TITLE"),
-        "body": issue.get("body") or _env("ISSUE_BODY"),
+        "title": title,
+        "body": body,
+        "providers": sorted(detect_reported_provider_labels(title, body)),
         "url": issue.get("html_url") or "",
         "state": issue.get("state"),
         "updated_at": issue.get("updated_at"),
@@ -473,10 +502,22 @@ def cmd_discussion(gh: GitHubClient, token: str) -> int:
 
     title = _env("DISCUSSION_TITLE") or disc.get("title") or ""
     body = _env("DISCUSSION_BODY") or disc.get("body") or ""
+    provider_labels = set(
+        sorted(
+            detect_reported_provider_labels(title, body),
+            key=str.lower,
+        )[: config.MAX_REPORTED_PROVIDERS]
+    )
     summary(f"## Triage of discussion #{number}\n")
 
     rag_result = rag.answer(
-        gh, title=title, body=body, number=number, token=token, kind="discussion"
+        gh,
+        title=title,
+        body=body,
+        number=number,
+        token=token,
+        kind="discussion",
+        provider_labels=provider_labels,
     )
     if rag_result is None or not rag_result.has_output:
         summary(f"#{number}: no confident docs answer or related posts; staying silent.")
@@ -494,6 +535,7 @@ def cmd_discussion(gh: GitHubClient, token: str) -> int:
             "tier": rag_result.tier,
             "cited": [c.id for c in rag_result.cited_chunks],
             "related": [p.number for p in rag_result.related_posts],
+            "pinned": [p.number for p in rag_result.pinned_posts],
             "suppressed": rag_result.suppressed,
         },
     }
@@ -522,11 +564,14 @@ def cmd_discussion_append(gh: GitHubClient, token: str) -> int:
     if category in config.DISCUSSION_EXCLUDE_CATEGORIES:
         summary(f"discussion #{number}: excluded category '{category}'; not indexed.")
         return 0
+    title = disc.get("title") or _env("DISCUSSION_TITLE")
+    body = disc.get("body") or _env("DISCUSSION_BODY")
     post = {
         "kind": "discussion",
         "number": number,
-        "title": disc.get("title") or _env("DISCUSSION_TITLE"),
-        "body": disc.get("body") or _env("DISCUSSION_BODY"),
+        "title": title,
+        "body": body,
+        "providers": sorted(detect_reported_provider_labels(title, body)),
         "url": disc.get("url") or "",
         "state": "open",
         "updated_at": _now_iso(),

--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -48,6 +48,7 @@ _OUTPUT_SCHEMA: dict[str, Any] = {
             "likely_root_cause",
             "category",
             "confidence",
+            "possibly_fixed_in_version",
             "suggested_labels",
             "user_message",
         ],
@@ -168,7 +169,15 @@ def assess(
             return None
         content = resp.json()["choices"][0]["message"]["content"]
         data = json.loads(content)
-        return _coerce(data)
+        result = _coerce(data)
+        if candidate_labels is not None:
+            allowed = {label.lower(): label for label in candidate_labels}
+            result.suggested_labels = [
+                allowed[label.lower()]
+                for label in result.suggested_labels
+                if label.lower() in allowed
+            ]
+        return result
     except Exception as exc:  # noqa: BLE001 — never let AI break triage
         print(f"AI assessment skipped: {exc}")
         return None

--- a/.github/scripts/ma_triage/analyze.py
+++ b/.github/scripts/ma_triage/analyze.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from . import config
 from .gh import GitHubClient
 from .models import Diagnostics, Finding, Severity
-from .providers import domain_to_label
 from .sanitize import inline
 from .versioncheck import VersionVerdict, evaluate
 
@@ -22,7 +21,7 @@ def analyze(diag: Diagnostics, gh: GitHubClient) -> tuple[list[Finding], set[str
 
     _check_version(diag, gh, findings, labels)
     _check_safe_mode(diag, findings)
-    _check_providers(diag, findings, labels)
+    _check_providers(diag, findings)
     _check_players(diag, labels)
     _check_exceptions(diag, findings)
     _check_resources(diag, findings)
@@ -100,14 +99,7 @@ def _check_safe_mode(diag: Diagnostics, findings: list[Finding]) -> None:
         )
 
 
-def _check_providers(
-    diag: Diagnostics, findings: list[Finding], labels: set[str]
-) -> None:
-    # Label every configured provider domain (existing-label filtering happens
-    # later against the repo's real labels).
-    for provider in diag.providers:
-        labels.add(domain_to_label(provider.domain))
-
+def _check_providers(diag: Diagnostics, findings: list[Finding]) -> None:
     errored = diag.providers_in_error
     if not errored:
         return
@@ -126,12 +118,6 @@ def _check_providers(
 
 
 def _check_players(diag: Diagnostics, labels: set[str]) -> None:
-    by_provider = diag.players.get("by_provider")
-    if isinstance(by_provider, dict):
-        for domain in by_provider:
-            if isinstance(domain, str):
-                labels.add(domain_to_label(domain))
-
     if diag.system.hass_addon is True:
         # Install method is useful context; only applied if such a label exists.
         labels.add("hass")

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from . import config
 from .gh import GitHubClient
-from .models import RagResult, Severity, TriageResult
+from .models import RagResult, RelatedPost, Severity, TriageResult
 from .sanitize import inline, link_label, markdown_safe
 
 _SEVERITY_ICON = {
@@ -185,6 +185,21 @@ def _doc_link(label: str, url: str) -> str:
     return f"- [{link_label(label, max_len=160) or url}]({url})"
 
 
+def _post_link(post: RelatedPost) -> str:
+    closed = " _(closed)_" if post.state == "closed" else ""
+    title = link_label(post.title, max_len=140)
+    return f"- [#{post.number}: {title}]({post.url}){closed}"
+
+
+def _provider_docs_section(result: TriageResult) -> str:
+    if not result.provider_docs:
+        return ""
+    parts = [config.PROVIDER_DOCS_HEADING]
+    for doc in result.provider_docs:
+        parts.append(_doc_link(doc.name, doc.url))
+    return "\n".join(parts)
+
+
 def _render_rag(rag: RagResult | None) -> str:
     """Render the optional docs-answer + related-posts sections.
 
@@ -217,13 +232,27 @@ def _render_rag(rag: RagResult | None) -> str:
             parts.append(_doc_link(hit.chunk.label, hit.chunk.url))
         parts.append("\n" + config.DOCS_ANSWER_DISCLAIMER)
 
+    if rag.pinned_posts:
+        parts.append("\n" + config.PINNED_POSTS_HEADING)
+        parts.append(config.PINNED_POSTS_INTRO)
+        parts.extend(_post_link(post) for post in rag.pinned_posts)
+
     if rag.related_posts:
-        parts.append("\n" + config.RELATED_POSTS_HEADING)
-        parts.append(config.RELATED_POSTS_INTRO)
-        for post in rag.related_posts:
-            closed = " _(closed)_" if post.state == "closed" else ""
-            title = link_label(post.title, max_len=140)
-            parts.append(f"- [#{post.number}: {title}]({post.url}){closed}")
+        if max(post.score for post in rag.related_posts) >= config.RELATED_EXPAND_SCORE:
+            parts.append("\n" + config.RELATED_POSTS_HEADING)
+            parts.append(config.RELATED_POSTS_INTRO)
+            parts.extend(_post_link(post) for post in rag.related_posts)
+        else:
+            weak = [
+                "<details>",
+                f"<summary>{config.RELATED_POSTS_WEAK_SUMMARY}</summary>",
+                "",
+                config.RELATED_POSTS_WEAK_INTRO,
+                "",
+            ]
+            weak.extend(_post_link(post) for post in rag.related_posts)
+            weak.extend(["", "</details>"])
+            parts.append("\n" + "\n".join(weak))
 
     return "\n".join(parts)
 
@@ -307,6 +336,11 @@ def build_body(result: TriageResult) -> str:
             "A diagnostics report (or a log attached as a file) is much easier for "
             "us to work with than inline logs."
         )
+
+    provider_docs = _provider_docs_section(result)
+    if provider_docs:
+        parts.append("")
+        parts.append(provider_docs)
 
     rag_section = _rag_section(result)
     if rag_section:

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -100,12 +100,14 @@ PROVIDER_LABELS: dict[str, str] = {
     "plex": "plex",
     "jellyfin": "jellyfin",
     "subsonic": "subsonic",
+    "opensubsonic": "subsonic",
     "filesystem_local": "filesystem_local",
     "audiobookshelf": "audiobookshelf",
     "builtin": "builtin",
     "hass": "hass",
     # player providers
     "slimproto": "Squeezelite",
+    "squeezelite": "Squeezelite",
     "sonos": "sonos",
     "airplay": "airplay",
     "chromecast": "Chromecast",
@@ -115,6 +117,16 @@ PROVIDER_LABELS: dict[str, str] = {
     "fully_kiosk": "fully_kiosk",
     "musiccast": "MusicCast",
     "wiim": "WiiM",
+    "heos": "HEOS",
+    "sendspin": "sendspin",
+}
+
+# Provider labels occasionally differ from the current provider directory/domain
+# in the server repository. These overrides are authoritative for manifest
+# metadata (documentation + codeowners).
+PROVIDER_MANIFEST_DOMAINS: dict[str, str] = {
+    "subsonic": "opensubsonic",
+    "squeezelite": "squeezelite",
 }
 
 # codeowners entry for the core team; never pinged/assigned as a "maintainer".
@@ -146,6 +158,8 @@ PROVIDER_TEXT_ALIASES: dict[str, str] = {
     "plex": "plex",
     "jellyfin": "jellyfin",
     "subsonic": "subsonic",
+    "opensubsonic": "subsonic",
+    "funkwhale": "subsonic",
     "navidrome": "subsonic",
     "audiobookshelf": "audiobookshelf",
     "filesystem": "filesystem_local",
@@ -159,6 +173,8 @@ PROVIDER_TEXT_ALIASES: dict[str, str] = {
     "slimproto": "Squeezelite",
     "musiccast": "MusicCast",
     "wiim": "WiiM",
+    "heos": "HEOS",
+    "sendspin": "sendspin",
     "dlna": "dlna",
     "upnp": "dlna",
     "fully kiosk": "fully_kiosk",
@@ -182,6 +198,7 @@ MAX_JSON_DEPTH = 40  # reject absurdly nested JSON (billion-laughs style)
 MAX_STRING_ECHO = 500  # max chars of any diagnostics-derived string echoed back
 MAX_EXCEPTIONS_SHOWN = 5  # top-N exception fingerprints surfaced in the comment
 MAX_PROVIDERS_SHOWN = 20  # cap provider lists in the comment
+MAX_REPORTED_PROVIDERS = 5  # cap provider metadata lookups from untrusted text
 MAX_LOG_WALL_LINES = 30  # a pasted block longer than this counts as a "log wall"
 MAX_AI_INPUT_CHARS = 8000  # bound the text handed to the model
 
@@ -233,6 +250,7 @@ def _env_float(name: str, default: float) -> float:
 
 # Dry-run defaults to TRUE: the prototype logs intended actions and mutates
 # nothing until a maintainer explicitly opts in by setting TRIAGE_DRY_RUN=false.
+SERVER_REF = _env_str("TRIAGE_SERVER_REF", "dev")
 DRY_RUN = _flag("TRIAGE_DRY_RUN", True)
 AI_ENABLED = _flag("TRIAGE_AI_ENABLED", False)
 # Scan an attached raw log file when no diagnostics JSON is present (common on
@@ -304,6 +322,15 @@ ANSWER_LO = _env_float("TRIAGE_ANSWER_LO", 0.45)
 DOCS_TOP_K = _env_int("TRIAGE_DOCS_TOP_K", 6)
 RELATED_POSTS = _env_int("TRIAGE_RELATED_POSTS", 3)
 RELATED_MIN_SCORE = _env_float("TRIAGE_RELATED_MIN_SCORE", 0.35)
+# Keep weak semantic matches available without presenting them as likely
+# duplicates. Only scores at/above this threshold render expanded.
+RELATED_EXPAND_SCORE = _env_float("TRIAGE_RELATED_EXPAND_SCORE", 0.80)
+# Pinned Feature Polls mention providers but are not operational status notices.
+PINNED_EXCLUDE_CATEGORIES = tuple(
+    c.strip().lower()
+    for c in _env_str("TRIAGE_PINNED_EXCLUDE_CATEGORIES", "feature polls").split(",")
+    if c.strip()
+)
 # Minimum dense cosine for the top doc hit to show links when the judge call
 # itself failed (retrieval-only MEDIUM fallback).
 DOCS_MIN_DENSE = _env_float("TRIAGE_DOCS_MIN_DENSE", 0.30)
@@ -419,3 +446,13 @@ RELATED_POSTS_INTRO = (
     "These earlier issues or discussions look related and might already have an "
     "answer (or indicate a duplicate):"
 )
+RELATED_POSTS_WEAK_SUMMARY = "🔁 Possibly related past reports"
+RELATED_POSTS_WEAK_INTRO = (
+    "These reports have some overlap, but the automated match was not strong "
+    "enough to call them likely duplicates:"
+)
+PINNED_POSTS_HEADING = "### 📌 Current support notice"
+PINNED_POSTS_INTRO = (
+    "A pinned Music Assistant support post mentions the affected provider:"
+)
+PROVIDER_DOCS_HEADING = "### 📖 Provider documentation"

--- a/.github/scripts/ma_triage/embeddings.py
+++ b/.github/scripts/ma_triage/embeddings.py
@@ -248,6 +248,14 @@ def _post_record(post: dict[str, Any], embedding: list[float]) -> dict[str, Any]
         "url": str(post.get("url", "")),
         "state": post.get("state"),
         "updated_at": post.get("updated_at"),
+        "providers": sorted(
+            {
+                str(provider)
+                for provider in (post.get("providers") or [])
+                if str(provider).strip()
+            },
+            key=str.lower,
+        ),
         "sha": post_sha(str(post.get("title", "")), str(post.get("body", ""))),
         "embedding": embedding,
     }
@@ -284,12 +292,25 @@ def build_posts_index(
     records: list[dict[str, Any]] = []
     to_embed: list[dict[str, Any]] = []
     embed_targets: list[str] = []
+    metadata_changed = False
     for post in posts[: config.INDEX_MAX_POSTS]:
         key = (post.get("kind", "issue"), int(post.get("number", 0)))
         sha = post_sha(str(post.get("title", "")), str(post.get("body", "")))
         cached = prev_by_key.get(key)
         if cached and cached.get("sha") == sha and cached.get("embedding"):
-            records.append(cached)
+            record = dict(cached)
+            providers = sorted(
+                {
+                    str(provider)
+                    for provider in (post.get("providers") or [])
+                    if str(provider).strip()
+                },
+                key=str.lower,
+            )
+            if record.get("providers") != providers:
+                record["providers"] = providers
+                metadata_changed = True
+            records.append(record)
         else:
             to_embed.append(post)
             # Cap each target so a very long issue/discussion body can't exceed
@@ -307,7 +328,7 @@ def build_posts_index(
         for post, vector in zip(to_embed, vectors):
             records.append(_post_record(post, vector))
 
-    changed = bool(to_embed) or {
+    changed = bool(to_embed) or metadata_changed or {
         (r.get("kind", "issue"), int(r.get("number", 0))) for r in records
     } != set(prev_by_key)
 

--- a/.github/scripts/ma_triage/gh.py
+++ b/.github/scripts/ma_triage/gh.py
@@ -306,6 +306,36 @@ class GitHubClient:
             cursor = page_info.get("endCursor")
         return out[:limit]
 
+    def list_pinned_discussions(self) -> list[dict[str, Any]]:
+        """Pinned support Discussions (empty list if unavailable)."""
+        owner, name = self.repo.split("/", 1)
+        query = """
+        query($o:String!,$n:String!){
+          repository(owner:$o,name:$n){
+            pinnedDiscussions(first:50){
+              nodes{
+                discussion{
+                  number title body url closed category { name }
+                }
+              }
+            }
+          }
+        }
+        """
+        try:
+            data = self.graphql(query, {"o": owner, "n": name})
+        except Exception as exc:  # noqa: BLE001
+            log(f"Pinned discussion listing failed: {exc}")
+            return []
+        repo = (data.get("data") or {}).get("repository") or {}
+        connection = repo.get("pinnedDiscussions") or {}
+        discussions: list[dict[str, Any]] = []
+        for node in connection.get("nodes") or []:
+            discussion = node.get("discussion") if isinstance(node, dict) else None
+            if isinstance(discussion, dict):
+                discussions.append(discussion)
+        return discussions
+
     def get_discussion(self, number: int) -> dict[str, Any] | None:
         """Fetch one discussion + all its comment ids/bodies via GraphQL.
 

--- a/.github/scripts/ma_triage/models.py
+++ b/.github/scripts/ma_triage/models.py
@@ -175,6 +175,15 @@ class RelatedPost:
 
 
 @dataclass
+class ProviderDoc:
+    """Authoritative provider documentation resolved from its server manifest."""
+
+    label: str
+    name: str
+    url: str
+
+
+@dataclass
 class RagResult:
     """Everything the RAG layer decided for one post.
 
@@ -188,6 +197,7 @@ class RagResult:
     doc_answer: DocAnswer | None = None
     cited_chunks: list[DocChunk] = field(default_factory=list)
     doc_hits: list[DocHit] = field(default_factory=list)
+    pinned_posts: list[RelatedPost] = field(default_factory=list)
     related_posts: list[RelatedPost] = field(default_factory=list)
     suppressed: bool = False
 
@@ -199,7 +209,7 @@ class RagResult:
 
     @property
     def has_output(self) -> bool:
-        return self.has_docs_output or bool(self.related_posts)
+        return self.has_docs_output or bool(self.pinned_posts or self.related_posts)
 
 
 @dataclass
@@ -229,6 +239,8 @@ class TriageResult:
 
     findings: list[Finding] = field(default_factory=list)
     labels_to_add: set[str] = field(default_factory=set)
+    reported_providers: set[str] = field(default_factory=set)
+    provider_docs: list[ProviderDoc] = field(default_factory=list)
     maintainers_to_ping: set[str] = field(default_factory=set)
     ai: AIResult | None = None
     diagnostics: Diagnostics | None = None

--- a/.github/scripts/ma_triage/providers.py
+++ b/.github/scripts/ma_triage/providers.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 import json
 import re
 from functools import lru_cache
+from urllib.parse import urlparse
 
-from . import config
+from . import config, template
 from .gh import GitHubClient, log
+from .models import ProviderDoc
 
 
 def domain_to_label(domain: str) -> str:
@@ -50,6 +52,24 @@ def detect_provider_labels_from_text(text: str | None) -> set[str]:
     return found
 
 
+def detect_reported_provider_labels(
+    title: str | None, body: str | None
+) -> set[str]:
+    """Identify the provider(s) the reporter says are affected.
+
+    A provider named in the title is the strongest signal and wins over incidental
+    mentions in the body (for example, "filesystem is wrong; Plex is fine"). If
+    the title has no provider, scan the issue-form problem/reproduction fields;
+    for older issues and Discussions without form sections, fall back to the full
+    body.
+    """
+    title_labels = detect_provider_labels_from_text(title)
+    if title_labels:
+        return title_labels
+    form_text = template.provider_scan_text(body)
+    return detect_provider_labels_from_text(form_text or body)
+
+
 def filter_existing_labels(labels: set[str], existing: set[str]) -> set[str]:
     """Keep only labels that already exist in the repo (case-insensitive)."""
     lower_existing = {e.lower(): e for e in existing}
@@ -61,22 +81,44 @@ def filter_existing_labels(labels: set[str], existing: set[str]) -> set[str]:
     return result
 
 
+def provider_manifest_domain(provider: str) -> str:
+    """Map a diagnostics domain or repo label to the current server domain."""
+    lowered = provider.strip().lower()
+    override = config.PROVIDER_MANIFEST_DOMAINS.get(lowered)
+    if override:
+        return override
+    if lowered in config.PROVIDER_LABELS:
+        return lowered
+    for domain, label in config.PROVIDER_LABELS.items():
+        if label.lower() == lowered:
+            return domain
+    return lowered
+
+
 @lru_cache(maxsize=256)
 def _fetch_manifest(gh: GitHubClient, domain: str) -> str | None:
-    return gh.get_raw_file(config.SERVER_REPO, config.MANIFEST_PATH.format(domain=domain))
+    return gh.get_raw_file(
+        config.SERVER_REPO,
+        config.MANIFEST_PATH.format(domain=provider_manifest_domain(domain)),
+        ref=config.SERVER_REF,
+    )
+
+
+def _load_manifest(gh: GitHubClient, provider: str) -> dict:
+    raw = _fetch_manifest(gh, provider)
+    if not raw:
+        return {}
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        log(f"Manifest for {provider} is not valid JSON: {exc}")
+        return {}
+    return manifest if isinstance(manifest, dict) else {}
 
 
 def resolve_maintainers(gh: GitHubClient, domain: str) -> list[str]:
     """Return community maintainer handles (without ``@``) for a provider domain."""
-    raw = _fetch_manifest(gh, domain)
-    if not raw:
-        return []
-    try:
-        manifest = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        log(f"Manifest for {domain} is not valid JSON: {exc}")
-        return []
-
+    manifest = _load_manifest(gh, domain)
     codeowners = manifest.get("codeowners")
     if not isinstance(codeowners, list):
         return []
@@ -86,7 +128,7 @@ def resolve_maintainers(gh: GitHubClient, domain: str) -> list[str]:
         if not isinstance(entry, str):
             continue
         handle = entry.lstrip("@").strip()
-        if not handle:
+        if not re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})", handle):
             continue
         # Skip the core team handle (and any team-style "org/team" entries).
         if handle.lower() == config.CORE_TEAM_HANDLE.lower():
@@ -95,3 +137,25 @@ def resolve_maintainers(gh: GitHubClient, domain: str) -> list[str]:
             continue
         maintainers.append(handle)
     return maintainers
+
+
+def resolve_provider_doc(gh: GitHubClient, provider: str) -> ProviderDoc | None:
+    """Return a safe documentation link from the provider manifest."""
+    manifest = _load_manifest(gh, provider)
+    raw_url = manifest.get("documentation")
+    if not isinstance(raw_url, str):
+        return None
+    parsed = urlparse(raw_url)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not (
+        host == "music-assistant.io" or host.endswith(".music-assistant.io")
+    ):
+        return None
+    if any(char in raw_url for char in "\r\n\\[]()<>"):
+        return None
+    name = manifest.get("name")
+    return ProviderDoc(
+        label=domain_to_label(provider_manifest_domain(provider)),
+        name=str(name).strip() if isinstance(name, str) and name.strip() else provider,
+        url=raw_url,
+    )

--- a/.github/scripts/ma_triage/rag.py
+++ b/.github/scripts/ma_triage/rag.py
@@ -81,16 +81,20 @@ def answer(
     number: int,
     token: str,
     kind: str = "issue",
+    provider_labels: set[str] | None = None,
 ) -> RagResult | None:
     """Run the RAG pipeline for one post. ``None`` when disabled or on failure."""
     if not (config.AI_ENABLED and config.RAG_ENABLED):
         return None
+    pinned = similar.find_pinned(gh, provider_labels)
     try:
         query_text = f"{title}\n\n{body}".strip()
         query_vec = embeddings.embed_text(query_text, token=token)
         if query_vec is None:
-            # Embeddings unavailable (e.g. rate limited) → skip the whole layer.
-            return None
+            # Pinned notices are deterministic and remain useful if Models is
+            # temporarily unavailable.
+            result = RagResult(pinned_posts=pinned)
+            return result if result.has_output else None
 
         chunks = embeddings.load_docs_chunks(gh)
         doc_hits = retrieve_docs(query_vec, query_text, chunks)
@@ -135,6 +139,7 @@ def answer(
             posts=posts,
             exclude_number=number,
             exclude_kind=kind,
+            provider_labels=provider_labels,
         )
 
         result = RagResult(
@@ -142,10 +147,12 @@ def answer(
             doc_answer=doc_answer,
             cited_chunks=cited_chunks,
             doc_hits=doc_hits,
+            pinned_posts=pinned,
             related_posts=related,
             suppressed=suppressed,
         )
         return result if result.has_output else None
     except Exception as exc:  # noqa: BLE001 — never let RAG break triage
         log(f"RAG layer skipped: {exc}")
-        return None
+        result = RagResult(pinned_posts=pinned)
+        return result if result.has_output else None

--- a/.github/scripts/ma_triage/similar.py
+++ b/.github/scripts/ma_triage/similar.py
@@ -20,9 +20,24 @@ import re
 from . import config
 from .gh import GitHubClient, log
 from .models import RelatedPost
+from .providers import detect_provider_labels_from_text
 from .retrieval import cosine
 
 _RE_WORD = re.compile(r"[A-Za-z0-9]+")
+
+
+def _provider_keys(labels: set[str] | list[str] | None) -> set[str]:
+    return {str(label).strip().lower() for label in (labels or []) if str(label).strip()}
+
+
+def _post_provider_keys(post: dict) -> set[str]:
+    stored = _provider_keys(post.get("providers"))
+    if stored:
+        return stored
+    # Backwards compatibility until the next posts-index rebuild adds metadata.
+    return _provider_keys(
+        detect_provider_labels_from_text(str(post.get("title", "")))
+    )
 
 
 def related_from_index(
@@ -31,6 +46,7 @@ def related_from_index(
     *,
     exclude_number: int,
     exclude_kind: str = "issue",
+    provider_labels: set[str] | None = None,
     k: int | None = None,
     min_score: float | None = None,
 ) -> list[RelatedPost]:
@@ -39,6 +55,7 @@ def related_from_index(
         return []
     top_k = config.RELATED_POSTS if k is None else k
     threshold = config.RELATED_MIN_SCORE if min_score is None else min_score
+    required_providers = _provider_keys(provider_labels)
 
     scored: list[tuple[float, dict]] = []
     seen: set[tuple[str, int]] = set()
@@ -46,6 +63,8 @@ def related_from_index(
         number = int(post.get("number", 0))
         kind = post.get("kind", "issue")
         if kind == exclude_kind and number == exclude_number:
+            continue
+        if required_providers and not (required_providers & _post_provider_keys(post)):
             continue
         key = (kind, number)
         if key in seen:
@@ -127,14 +146,57 @@ def find_related(
     posts: list[dict],
     exclude_number: int,
     exclude_kind: str = "issue",
+    provider_labels: set[str] | None = None,
 ) -> list[RelatedPost]:
     """Related posts from the index when available, else the search fallback."""
     if posts and query_vec:
         hits = related_from_index(
-            query_vec, posts, exclude_number=exclude_number, exclude_kind=exclude_kind
+            query_vec,
+            posts,
+            exclude_number=exclude_number,
+            exclude_kind=exclude_kind,
+            provider_labels=provider_labels,
         )
         if hits:
             return hits
+    # If the report names a provider, an unscoped text-search fallback can only
+    # reintroduce the noisy cross-provider matches this filter is meant to stop.
+    if provider_labels:
+        return []
     return related_from_search(
         gh, title, exclude_number=exclude_number, exclude_kind=exclude_kind
     )
+
+
+def find_pinned(
+    gh: GitHubClient, provider_labels: set[str] | None
+) -> list[RelatedPost]:
+    """Pinned support notices that mention an affected provider exactly."""
+    required = _provider_keys(provider_labels)
+    if not required:
+        return []
+    matches: list[RelatedPost] = []
+    try:
+        discussions = gh.list_pinned_discussions()
+    except Exception as exc:  # noqa: BLE001
+        log(f"Pinned discussion matching failed: {exc}")
+        return []
+    for discussion in discussions:
+        category = ((discussion.get("category") or {}).get("name") or "").lower()
+        if category in config.PINNED_EXCLUDE_CATEGORIES:
+            continue
+        text = f"{discussion.get('title', '')}\n{discussion.get('body', '')}"
+        mentioned = _provider_keys(detect_provider_labels_from_text(text))
+        if not (required & mentioned):
+            continue
+        matches.append(
+            RelatedPost(
+                kind="discussion",
+                number=int(discussion.get("number", 0)),
+                title=str(discussion.get("title", "")),
+                url=str(discussion.get("url", "")),
+                score=1.0,
+                state="closed" if discussion.get("closed") else "open",
+            )
+        )
+    return matches

--- a/.github/scripts/tests/conftest.py
+++ b/.github/scripts/tests/conftest.py
@@ -44,7 +44,7 @@ class FakeGH:
 
     def __init__(self, *, latest_tag="2.9.5", labels=None, manifests=None,
                  index_files=None, tree=None, issues=None, discussions=None,
-                 search_items=None, discussion=None):
+                 search_items=None, discussion=None, pinned_discussions=None):
         self.dry_run = False
         self.repo = "music-assistant/support"
         self._latest_tag = latest_tag
@@ -55,6 +55,7 @@ class FakeGH:
         self._tree = list(tree or [])
         self._issues = list(issues or [])
         self._discussions = list(discussions or [])
+        self._pinned_discussions = list(pinned_discussions or [])
         self._discussion_obj = discussion
         self._search_items = list(search_items or [])
         self.calls: list[tuple] = []
@@ -95,6 +96,9 @@ class FakeGH:
 
     def list_discussions(self, *, limit=500):
         return list(self._discussions)[:limit]
+
+    def list_pinned_discussions(self):
+        return list(self._pinned_discussions)
 
     def get_discussion(self, number):
         return self._discussion_obj
@@ -140,11 +144,16 @@ class FakeGH:
 @pytest.fixture
 def fake_gh():
     return FakeGH(
-        labels={"sonos", "snapcast", "spotify", "Chromecast", "airplay",
+        labels={"sonos", "snapcast", "spotify", "subsonic", "Chromecast", "airplay",
                 "needs-attention", "waiting-for-user", "triage/needs-diagnostics"},
         manifests={
             "sonos": {"codeowners": ["@music-assistant"]},
             "snapcast": {"codeowners": ["@SantiagoSotoC", "@music-assistant"]},
+            "opensubsonic": {
+                "name": "OpenSubsonic Media Server Library",
+                "codeowners": ["@khers"],
+                "documentation": "https://music-assistant.io/music-providers/subsonic/",
+            },
         },
     )
 
@@ -188,4 +197,3 @@ def ai_on(monkeypatch):
         lambda texts, *, token: [fake_embedding(t) for t in texts],
     )
     return fake_embedding
-

--- a/.github/scripts/tests/test_ai.py
+++ b/.github/scripts/tests/test_ai.py
@@ -43,6 +43,21 @@ def test_assess_happy_path(sample_raw, monkeypatch):
     assert result.suggested_labels == ["sonos"]
 
 
+def test_assess_filters_suggested_labels_to_candidates(sample_raw, monkeypatch):
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(ai.requests, "post", lambda *a, **k: _Resp(_ok_payload()))
+    diag = parse_diagnostics(sample_raw)
+    result = ai.assess(
+        diag, "title", "body", token="x", candidate_labels=["snapcast"]
+    )
+    assert result.suggested_labels == []
+
+
+def test_strict_schema_requires_every_property():
+    schema = ai._OUTPUT_SCHEMA["schema"]
+    assert set(schema["required"]) == set(schema["properties"])
+
+
 def test_assess_http_error_returns_none(sample_raw, monkeypatch):
     monkeypatch.setattr(config, "AI_ENABLED", True)
     monkeypatch.setattr(ai.requests, "post",

--- a/.github/scripts/tests/test_analyze.py
+++ b/.github/scripts/tests/test_analyze.py
@@ -16,9 +16,11 @@ def test_analyze_sample(sample_raw, fake_gh):
     # critical findings sort first
     assert findings[0].severity == Severity.CRITICAL
 
-    # provider + player labels suggested (pre-filter)
-    assert "sonos" in labels
-    assert "Chromecast" in labels  # from by_provider chromecast
+    # The diagnostics census describes the whole installation and must not label
+    # every configured provider/player. Setup + version labels are still useful.
+    assert "sonos" not in labels
+    assert "Chromecast" not in labels
+    assert "hass" in labels
 
 
 def test_safe_mode_flagged(injection_raw, fake_gh):

--- a/.github/scripts/tests/test_comment_rag.py
+++ b/.github/scripts/tests/test_comment_rag.py
@@ -7,6 +7,7 @@ from ma_triage.models import (
     DocAnswer,
     DocChunk,
     DocHit,
+    ProviderDoc,
     RagResult,
     RelatedPost,
     TriageResult,
@@ -77,8 +78,56 @@ def test_build_body_low_tier_shows_only_related():
     body = comment.build_body(result)
     assert config.DOCS_ANSWER_HEADING not in body
     assert config.DOCS_LINKS_HEADING not in body
-    assert config.RELATED_POSTS_HEADING in body
+    assert config.RELATED_POSTS_HEADING not in body
+    assert config.RELATED_POSTS_WEAK_SUMMARY in body
+    assert "<details>" in body
     assert "#12: similar q" in body
+
+
+def test_build_body_strong_related_stays_expanded():
+    rag = RagResult(
+        tier="low",
+        related_posts=[
+            RelatedPost("issue", 12, "strong match", "https://x/12", 0.9, "open")
+        ],
+    )
+    body = comment.build_body(
+        TriageResult(form_kind="main", missing_attachment=True, rag=rag)
+    )
+    assert config.RELATED_POSTS_HEADING in body
+    assert config.RELATED_POSTS_WEAK_SUMMARY not in body
+
+
+def test_build_body_renders_provider_docs_and_pinned_notice():
+    rag = RagResult(
+        pinned_posts=[
+            RelatedPost(
+                "discussion",
+                709,
+                "MA Status and Troubleshooting",
+                "https://github.com/orgs/music-assistant/discussions/709",
+                1.0,
+                "open",
+            )
+        ]
+    )
+    result = TriageResult(
+        form_kind="main",
+        missing_attachment=True,
+        provider_docs=[
+            ProviderDoc(
+                "spotify",
+                "Spotify",
+                "https://music-assistant.io/music-providers/spotify/",
+            )
+        ],
+        rag=rag,
+    )
+    body = comment.build_body(result)
+    assert config.PROVIDER_DOCS_HEADING in body
+    assert "](https://music-assistant.io/music-providers/spotify/)" in body
+    assert config.PINNED_POSTS_HEADING in body
+    assert "MA Status and Troubleshooting" in body
 
 
 def test_related_post_title_cannot_break_out_of_link_label():

--- a/.github/scripts/tests/test_discussion.py
+++ b/.github/scripts/tests/test_discussion.py
@@ -25,7 +25,7 @@ def _high_rag():
         tier="high",
         doc_answer=DocAnswer(True, 0.9, "Enable multicast on your switch.", ["faq/net#mdns"]),
         cited_chunks=[_chunk()],
-        related_posts=[RelatedPost("discussion", 12, "similar q", "https://x/12", 0.6, "open")],
+        related_posts=[RelatedPost("discussion", 12, "similar q", "https://x/12", 0.9, "open")],
     )
 
 
@@ -57,7 +57,8 @@ def test_cmd_discussion_posts_answer(discussions_on, monkeypatch):
     monkeypatch.setenv("DISCUSSION_NUMBER", "7")
     gh = FakeGH(discussion=_disc())
     monkeypatch.setattr(
-        main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": _high_rag()
+        main.rag, "answer", lambda gh, *, title, body, number, token,
+        kind="issue", provider_labels=None: _high_rag()
     )
     assert main.cmd_discussion(gh, "t") == 0
 
@@ -81,7 +82,8 @@ def test_cmd_discussion_updates_existing_sticky(discussions_on, monkeypatch):
     ]
     gh = FakeGH(discussion=_disc(comments=existing))
     monkeypatch.setattr(
-        main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": _high_rag()
+        main.rag, "answer", lambda gh, *, title, body, number, token,
+        kind="issue", provider_labels=None: _high_rag()
     )
     assert main.cmd_discussion(gh, "t") == 0
 
@@ -101,7 +103,8 @@ def test_cmd_discussion_ignores_forged_sticky_marker(discussions_on, monkeypatch
     ]
     gh = FakeGH(discussion=_disc(comments=forged))
     monkeypatch.setattr(
-        main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": _high_rag()
+        main.rag, "answer", lambda gh, *, title, body, number, token,
+        kind="issue", provider_labels=None: _high_rag()
     )
     assert main.cmd_discussion(gh, "t") == 0
     assert [c for c in gh.calls if c[0] == "add_discussion_comment"]
@@ -133,7 +136,8 @@ def test_cmd_discussion_silent_when_no_output(discussions_on, monkeypatch):
     monkeypatch.setenv("DISCUSSION_NUMBER", "7")
     gh = FakeGH(discussion=_disc())
     monkeypatch.setattr(
-        main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": None
+        main.rag, "answer", lambda gh, *, title, body, number, token,
+        kind="issue", provider_labels=None: None
     )
     assert main.cmd_discussion(gh, "t") == 0
     assert not [c for c in gh.calls if "discussion_comment" in c[0]]
@@ -155,7 +159,12 @@ def test_cmd_discussion_sanitizes_related_title(discussions_on, monkeypatch):
             RelatedPost("issue", 50, "pwn](https://evil.example)", "https://x/50", 0.9, "open")
         ],
     )
-    monkeypatch.setattr(main.rag, "answer", lambda gh, *, title, body, number, token, kind="issue": rag)
+    monkeypatch.setattr(
+        main.rag,
+        "answer",
+        lambda gh, *, title, body, number, token, kind="issue",
+        provider_labels=None: rag,
+    )
     assert main.cmd_discussion(gh, "t") == 0
     body = [c for c in gh.calls if c[0] == "add_discussion_comment"][0][2]
     assert r"pwn\](https://evil.example)" in body
@@ -238,6 +247,37 @@ def test_get_discussion_missing_returns_none(monkeypatch):
         lambda q, v=None, *, features=None: {"data": {"repository": {"discussion": None}}},
     )
     assert client.get_discussion(999) is None
+
+
+def test_list_pinned_discussions_unwraps_nodes(monkeypatch):
+    client = GitHubClient("tok")
+    payload = {
+        "data": {
+            "repository": {
+                "pinnedDiscussions": {
+                    "nodes": [
+                        {
+                            "discussion": {
+                                "number": 709,
+                                "title": "MA Status and Troubleshooting",
+                                "body": "Spotify outage",
+                                "url": "u709",
+                                "closed": False,
+                                "category": {"name": "Show and tell"},
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    monkeypatch.setattr(
+        client,
+        "graphql",
+        lambda q, v=None, *, features=None: payload,
+    )
+    pinned = client.list_pinned_discussions()
+    assert [post["number"] for post in pinned] == [709]
 
 
 def test_discussion_comment_mutations_respect_dry_run(monkeypatch):

--- a/.github/scripts/tests/test_embeddings.py
+++ b/.github/scripts/tests/test_embeddings.py
@@ -212,3 +212,32 @@ def test_append_post_skip_on_embed_failure(monkeypatch):
         gh, {"kind": "issue", "number": 5, "title": "x", "body": "y"}, token="t"
     )
     assert index is None and changed is False
+
+
+def test_build_posts_index_refreshes_provider_metadata_without_reembedding(
+    ai_on, monkeypatch
+):
+    gh = FakeGH()
+    posts = [
+        {
+            "kind": "issue",
+            "number": 1,
+            "title": "Subsonic error",
+            "body": "404",
+            "providers": [],
+        }
+    ]
+    previous, _ = embeddings.build_posts_index(gh, posts, token="t")
+    calls = []
+    monkeypatch.setattr(
+        embeddings,
+        "embed_texts",
+        lambda texts, *, token: calls.append(texts) or [],
+    )
+    posts[0]["providers"] = ["subsonic"]
+    updated, changed = embeddings.build_posts_index(
+        gh, posts, token="t", previous=previous
+    )
+    assert changed is True
+    assert calls == []
+    assert updated["posts"][0]["providers"] == ["subsonic"]

--- a/.github/scripts/tests/test_main.py
+++ b/.github/scripts/tests/test_main.py
@@ -12,11 +12,39 @@ MAIN_BODY_FULL = (
 def test_build_result_actionable(sample_raw, fake_gh, monkeypatch):
     monkeypatch.setattr(main, "find_diagnostics_url", lambda body: "http://x")
     monkeypatch.setattr(main, "download_capped", lambda url: sample_raw)
-    result = main.build_result(fake_gh, "title", "body", token="t")
+    result = main.build_result(fake_gh, "snapcast timeout", "body", token="t")
     assert result.is_actionable
     assert result.findings
-    # snapcast community maintainer surfaced (sonos is core-team only)
+    # A single explicitly-reported provider routes to its community codeowner.
     assert "SantiagoSotoC" in result.maintainers_to_ping
+
+
+def test_build_result_uses_reported_provider_not_diagnostics_census(
+    sample_raw, fake_gh, monkeypatch
+):
+    monkeypatch.setattr(main, "find_diagnostics_url", lambda body: "http://x")
+    monkeypatch.setattr(main, "download_capped", lambda url: sample_raw)
+    body = (
+        "### What happened?\n\nFunkwhale via Subsonic returns 404; Sonos is fine.\n\n"
+        "### How to reproduce\n\nOpen a Subsonic album.\n\n"
+        "### Music Assistant version\n\n2.9.7\n\n"
+        "### How do you run Music Assistant?\n\nHome Assistant add-on"
+    )
+    result = main.build_result(
+        fake_gh,
+        "Subsonic getLyrics returns 404",
+        body,
+        token="t",
+        labels=["triage"],
+    )
+    assert result.reported_providers == {"subsonic"}
+    assert "subsonic" in result.labels_to_add
+    assert "sonos" not in result.labels_to_add
+    assert "Chromecast" not in result.labels_to_add
+    assert result.maintainers_to_ping == {"khers"}
+    assert [doc.url for doc in result.provider_docs] == [
+        "https://music-assistant.io/music-providers/subsonic/"
+    ]
 
 
 def test_build_result_no_diagnostics(fake_gh, monkeypatch):

--- a/.github/scripts/tests/test_providers.py
+++ b/.github/scripts/tests/test_providers.py
@@ -1,8 +1,11 @@
 from ma_triage import config
 from ma_triage.providers import (
+    detect_reported_provider_labels,
     domain_to_label,
     filter_existing_labels,
+    provider_manifest_domain,
     resolve_maintainers,
+    resolve_provider_doc,
 )
 
 
@@ -13,6 +16,21 @@ def test_domain_to_label_known():
 
 def test_domain_to_label_fallback():
     assert domain_to_label("some_new_provider") == "some_new_provider"
+
+
+def test_reported_provider_title_wins_over_incidental_body_mention():
+    body = (
+        "### What happened?\n\nFilesystem albums are marked new; Plex is fine.\n\n"
+        "### How to reproduce\n\nOpen the filesystem album."
+    )
+    assert detect_reported_provider_labels(
+        "Old filesystem albums marked as new", body
+    ) == {"filesystem_local"}
+
+
+def test_reported_provider_falls_back_to_form_body():
+    body = "### What happened?\n\nFunkwhale via OpenSubsonic returns 404."
+    assert detect_reported_provider_labels("Album page fails", body) == {"subsonic"}
 
 
 def test_filter_existing_case_insensitive():
@@ -33,3 +51,20 @@ def test_resolve_maintainers_community(fake_gh):
 
 def test_resolve_maintainers_unknown(fake_gh):
     assert resolve_maintainers(fake_gh, "does_not_exist") == []
+
+
+def test_subsonic_resolves_current_manifest_metadata(fake_gh):
+    assert provider_manifest_domain("subsonic") == "opensubsonic"
+    assert resolve_maintainers(fake_gh, "subsonic") == ["khers"]
+    doc = resolve_provider_doc(fake_gh, "subsonic")
+    assert doc is not None
+    assert doc.name == "OpenSubsonic Media Server Library"
+    assert doc.url == "https://music-assistant.io/music-providers/subsonic/"
+
+
+def test_provider_doc_rejects_external_url(fake_gh):
+    fake_gh._manifests["evil"] = {
+        "name": "Evil",
+        "documentation": "https://evil.example/steal",
+    }
+    assert resolve_provider_doc(fake_gh, "evil") is None

--- a/.github/scripts/tests/test_rag.py
+++ b/.github/scripts/tests/test_rag.py
@@ -77,6 +77,34 @@ def test_answer_none_on_embed_failure(ai_on, monkeypatch):
     assert rag.answer(gh, title="sonos mdns", body="", number=1, token="t") is None
 
 
+def test_answer_keeps_provider_matched_pinned_notice_on_embed_failure(
+    ai_on, monkeypatch
+):
+    monkeypatch.setattr(embeddings, "embed_text", lambda text, *, token: None)
+    gh = FakeGH(
+        pinned_discussions=[
+            {
+                "number": 709,
+                "title": "MA Status and Troubleshooting",
+                "body": "Spotify login outage",
+                "url": "u709",
+                "closed": False,
+                "category": {"name": "Show and tell"},
+            }
+        ]
+    )
+    result = rag.answer(
+        gh,
+        title="Spotify login fails",
+        body="403",
+        number=1,
+        token="t",
+        provider_labels={"spotify"},
+    )
+    assert result is not None
+    assert [post.number for post in result.pinned_posts] == [709]
+
+
 def test_answer_high_tier(ai_on, monkeypatch):
     gh = _gh_with_indexes()
     monkeypatch.setattr(

--- a/.github/scripts/tests/test_similar.py
+++ b/.github/scripts/tests/test_similar.py
@@ -4,10 +4,11 @@ from conftest import FAKE_DIM, fake_embedding
 from ma_triage import config, similar
 
 
-def _post(number, text, kind="issue", state="open"):
+def _post(number, text, kind="issue", state="open", providers=None):
     return {
         "kind": kind, "number": number, "title": text, "url": f"https://x/{number}",
-        "state": state, "embedding": fake_embedding(text),
+        "state": state, "providers": providers or [],
+        "embedding": fake_embedding(text),
     }
 
 
@@ -34,6 +35,18 @@ def test_related_from_index_respects_k(monkeypatch):
     posts = [_post(i, "alpha beta") for i in range(1, 6)]
     hits = similar.related_from_index(query, posts, exclude_number=99, k=2)
     assert len(hits) == 2
+
+
+def test_related_from_index_requires_exact_provider_overlap():
+    query = fake_embedding("flow playback error")
+    posts = [
+        _post(1, "flow playback error", providers=["Chromecast"]),
+        _post(2, "deezer playback error", providers=["deezer"]),
+    ]
+    hits = similar.related_from_index(
+        query, posts, exclude_number=99, provider_labels={"deezer"}, min_score=0.0
+    )
+    assert [hit.number for hit in hits] == [2]
 
 
 def test_related_from_search_filters_prs_and_self(fake_gh, monkeypatch):
@@ -70,6 +83,21 @@ def test_find_related_falls_back_to_search_when_no_index_hits(fake_gh, monkeypat
     assert [h.number for h in hits] == [42]
 
 
+def test_find_related_does_not_use_unscoped_fallback_for_provider(fake_gh):
+    fake_gh._search_items = [
+        {"number": 42, "title": "wrong provider", "html_url": "u42", "state": "open"}
+    ]
+    hits = similar.find_related(
+        fake_gh,
+        query_vec=fake_embedding("deezer flow"),
+        title="deezer flow",
+        posts=[_post(1, "chromecast flow", providers=["Chromecast"])],
+        exclude_number=99,
+        provider_labels={"deezer"},
+    )
+    assert hits == []
+
+
 def test_find_related_uses_index_when_available(fake_gh):
     query = fake_embedding("sonos speaker grouping")
     posts = [{"kind": "issue", "number": 3, "title": "sonos speaker grouping",
@@ -80,3 +108,29 @@ def test_find_related_uses_index_when_available(fake_gh):
         exclude_number=99,
     )
     assert [h.number for h in hits] == [3]
+
+
+def test_find_pinned_matches_provider_and_skips_feature_polls():
+    from conftest import FakeGH
+
+    gh = FakeGH(
+        pinned_discussions=[
+            {
+                "number": 709,
+                "title": "MA Status and Troubleshooting",
+                "body": "Spotify users may see 403 errors.",
+                "url": "https://x/709",
+                "closed": False,
+                "category": {"name": "Show and tell"},
+            },
+            {
+                "number": 4755,
+                "title": "Provider poll",
+                "body": "Spotify",
+                "url": "https://x/4755",
+                "closed": False,
+                "category": {"name": "Feature Polls"},
+            },
+        ]
+    )
+    assert [post.number for post in similar.find_pinned(gh, {"spotify"})] == [709]

--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -65,6 +65,8 @@ jobs:
           TRIAGE_DOCS_REPO: ${{ vars.TRIAGE_DOCS_REPO }}
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
           TRIAGE_RELATED_POSTS: ${{ vars.TRIAGE_RELATED_POSTS }}
+          TRIAGE_RELATED_EXPAND_SCORE: ${{ vars.TRIAGE_RELATED_EXPAND_SCORE }}
+          TRIAGE_PINNED_EXCLUDE_CATEGORIES: ${{ vars.TRIAGE_PINNED_EXCLUDE_CATEGORIES }}
           TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES: ${{ vars.TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES }}
           # Optional PAT for GitHub Models (used only when set); falls back to
           # the default token. Lets Models work when the org token can't.

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -40,6 +40,11 @@ jobs:
       ${{ (github.event_name == 'issues' && !github.event.issue.pull_request)
       || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      discussions: read # provider-matched pinned support notices
+      issues: write
+      models: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -69,8 +74,11 @@ jobs:
           TRIAGE_ANSWER_HI: ${{ vars.TRIAGE_ANSWER_HI }}
           TRIAGE_ANSWER_LO: ${{ vars.TRIAGE_ANSWER_LO }}
           TRIAGE_DOCS_REPO: ${{ vars.TRIAGE_DOCS_REPO }}
+          TRIAGE_SERVER_REF: ${{ vars.TRIAGE_SERVER_REF }}
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
           TRIAGE_RELATED_POSTS: ${{ vars.TRIAGE_RELATED_POSTS }}
+          TRIAGE_RELATED_EXPAND_SCORE: ${{ vars.TRIAGE_RELATED_EXPAND_SCORE }}
+          TRIAGE_PINNED_EXCLUDE_CATEGORIES: ${{ vars.TRIAGE_PINNED_EXCLUDE_CATEGORIES }}
           # Optional PAT for GitHub Models (used only when set); falls back to
           # the default token. Lets Models work when the org token can't.
           GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}


### PR DESCRIPTION
## Problem

Two days of live triage exposed several relevance problems: diagnostics labeled every configured provider, weak semantic matches looked like likely duplicates, provider codeowners were never resolved, and Tier-1 AI assessments were silently failing with HTTP 400.

## Changes

- label only the provider actually reported (title-first, then form text), never the full diagnostics/player census
- add the reported provider's authoritative documentation link from its server manifest
- fix provider codeowner lookup to use the server's `dev` branch/current domains, and ping only for one actionable reported provider
- require exact provider overlap for similar posts when a provider is known; collapse matches below 0.80 instead of presenting them as likely duplicates
- surface provider-matched pinned support notices while excluding Feature Polls
- persist provider metadata in the posts index without re-embedding unchanged posts
- fix the strict Tier-1 JSON schema and reject model-suggested labels outside the deterministic candidate set
- document the behavior and configuration knobs

## Verification

- 223 offline tests pass
- Python compile and all workflow YAML checks pass
- read-only replay against issues #5828, #5829, #5831, #5832, and #5834 with live Models/index data confirmed provider labels, docs, pinned notices, codeowners, collapsed/expanded matches, and working Tier-1 assessments
