### PR TITLE
Run triage as a GitHub App

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -165,16 +165,26 @@ appends each new issue) has `contents: write` + `models: read` but **no**
 `issues:` permission — the job that can write repo contents can never comment,
 and vice-versa. Both honour `TRIAGE_DRY_RUN` (dry-run previews the commit).
 
-### Repo secret
+### Repo secrets
 | Secret | Needed for | Notes |
 |---|---|---|
 | `GH_MODELS_TOKEN` | Tier 1 / RAG (optional) | PAT with the **Models** permission. Used for GitHub Models calls (embeddings + judge/assessment) when the org hasn't enabled Models for the default Actions token. Falls back to `GITHUB_TOKEN` when unset. |
+| `TRIAGE_APP_ID` | Bot identity | Numeric ID of the GitHub App installed on this repository. |
+| `TRIAGE_APP_PRIVATE_KEY` | Bot identity | Complete PEM private key for the GitHub App. `actions/create-github-app-token` exchanges it for a repository-scoped, one-hour installation token in mutation jobs. |
+
+Issue/discussion comments, labels and lifecycle mutations use the GitHub App
+identity. Index commits remain on the built-in `GITHUB_TOKEN`, while Models calls
+remain on `GH_MODELS_TOKEN`. Existing `github-actions` sticky comments are left
+unchanged during the rollout; new stickies are owned and updated by the App.
 
 ## Security model
 
 - Triggers are `issues`, `issue_comment`, `discussion`, `schedule`,
   `workflow_dispatch` and `repository_dispatch` — **no
   `pull_request_target`**.
+- Mutation jobs mint short-lived tokens from a narrowly scoped GitHub App; jobs
+  that only manage issue lifecycle further restrict their token to Issues write.
+  The built-in workflow token no longer has issue/discussion write access.
 - Issue content flows through `env:` → `os.environ`; it is never placed in a
   shell command line.
 - Attachment downloads are **host-allowlisted** (`user-attachments` / repo

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -16,7 +16,7 @@ import json
 from typing import Any
 
 from . import config
-from .gh import GitHubClient
+from .gh import GitHubClient, summary
 from .models import RagResult, RelatedPost, Severity, TriageResult
 from .sanitize import inline, link_label, markdown_safe
 
@@ -65,6 +65,26 @@ def find_sticky(comments: list[dict[str, Any]]) -> dict[str, Any] | None:
         if config.STICKY_MARKER in (comment.get("body") or ""):
             return comment
     return None
+
+
+def _author_login(comment: dict[str, Any]) -> str:
+    actor = comment.get("user") or comment.get("author") or {}
+    return str(actor.get("login") or "").lower() if isinstance(actor, dict) else ""
+
+
+def _owned_sticky(comments: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Sticky authored by the current App (or legacy behaviour when unset)."""
+    if not config.BOT_LOGIN:
+        return find_sticky(comments)
+    login = config.BOT_LOGIN.lower()
+    return find_sticky([comment for comment in comments if _author_login(comment) == login])
+
+
+def _legacy_sticky(comments: list[dict[str, Any]]) -> dict[str, Any] | None:
+    logins = {login.lower() for login in config.LEGACY_BOT_LOGINS}
+    return find_sticky(
+        [comment for comment in comments if _author_login(comment) in logins]
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -370,9 +390,14 @@ def upsert(
     full = f"{body}\n\n{_render_state(state)}"
     if comments is None:
         comments = gh.list_comments(number)
-    existing = find_sticky(comments)
+    existing = _owned_sticky(comments)
     if existing:
         gh.update_comment(existing["id"], full)
+    elif config.BOT_LOGIN and _legacy_sticky(comments):
+        summary(
+            f"#{number}: existing github-actions sticky left unchanged during "
+            "GitHub App rollout."
+        )
     else:
         gh.create_comment(number, full)
 
@@ -387,15 +412,27 @@ def upsert_discussion(
 ) -> None:
     """Create or update the single sticky comment on a Discussion (GraphQL).
 
-    ``comments`` are the discussion's existing comments (``{id, body,
-    viewerDidAuthor}`` nodes). Only comments the bot itself authored
-    (``viewerDidAuthor``) are considered when locating the sticky, so a user
-    can't hijack the update by planting the marker text in their own comment.
+    ``comments`` are the discussion's existing comment nodes. Only comments the
+    current App authored are updated; a legacy github-actions sticky is preserved,
+    while a user-forged marker is ignored and cannot block the App's own sticky.
     """
     full = f"{body}\n\n{_render_state(state)}"
-    owned = [c for c in comments if c.get("viewerDidAuthor")]
+    owned = [
+        c
+        for c in comments
+        if c.get("viewerDidAuthor")
+        or (
+            config.BOT_LOGIN
+            and _author_login(c) == config.BOT_LOGIN.lower()
+        )
+    ]
     existing = find_sticky(owned)
     if existing:
         gh.update_discussion_comment(existing["id"], full)
+    elif config.BOT_LOGIN and _legacy_sticky(comments):
+        summary(
+            "Existing github-actions discussion sticky left unchanged during "
+            "GitHub App rollout."
+        )
     else:
         gh.add_discussion_comment(discussion_id, full)

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -22,6 +22,9 @@ MANIFEST_PATH = "music_assistant/providers/{domain}/manifest.json"
 # --------------------------------------------------------------------------- #
 # Hidden HTML comment used to find (and update in place) the single bot comment.
 STICKY_MARKER = "<!-- ma-triage-bot -->"
+# Existing sticky comments were created before the GitHub App rollout. Keep
+# those comments intact instead of replacing them and losing their history.
+LEGACY_BOT_LOGINS = frozenset({"github-actions", "github-actions[bot]"})
 # Hidden machine-readable state is stored between these fences inside the comment.
 STATE_BEGIN = "<!-- ma-triage-state:"
 STATE_END = "-->"
@@ -251,6 +254,9 @@ def _env_float(name: str, default: float) -> float:
 # Dry-run defaults to TRUE: the prototype logs intended actions and mutates
 # nothing until a maintainer explicitly opts in by setting TRIAGE_DRY_RUN=false.
 SERVER_REF = _env_str("TRIAGE_SERVER_REF", "dev")
+# Login of the current GitHub App bot (set from create-github-app-token's
+# ``app-slug`` output). Empty preserves the legacy single-token behaviour.
+BOT_LOGIN = _env_str("TRIAGE_BOT_LOGIN", "")
 DRY_RUN = _flag("TRIAGE_DRY_RUN", True)
 AI_ENABLED = _flag("TRIAGE_AI_ENABLED", False)
 # Scan an attached raw log file when no diagnostics JSON is present (common on

--- a/.github/scripts/ma_triage/gh.py
+++ b/.github/scripts/ma_triage/gh.py
@@ -341,8 +341,9 @@ class GitHubClient:
 
         Discussions are GraphQL-only (no REST). Returns a normalized dict
         ``{id, number, title, body, url, category, comments}`` where each comment
-        is ``{id, body}`` (the node id is needed to update the sticky comment in
-        place). Returns ``None`` when the discussion can't be read (Discussions
+        carries its node id, body and author (the id is needed to update the
+        sticky comment in place). Returns ``None`` when the discussion can't be
+        read (Discussions
         disabled, not found, or an API error) so callers degrade to a no-op.
         """
         owner, name = self.repo.split("/", 1)
@@ -354,7 +355,7 @@ class GitHubClient:
               category { name }
               comments(first:100, after:$c){
                 pageInfo{ hasNextPage endCursor }
-                nodes{ id body viewerDidAuthor }
+                nodes{ id body viewerDidAuthor author { login } }
               }
             }
           }

--- a/.github/scripts/tests/test_comment.py
+++ b/.github/scripts/tests/test_comment.py
@@ -124,6 +124,45 @@ def test_upsert_creates_then_updates(fake_gh):
     assert not any(c[0] == "create_comment" for c in fake_gh.calls)
 
 
+def test_app_rollout_preserves_legacy_actions_sticky(fake_gh, monkeypatch):
+    monkeypatch.setattr(config, "BOT_LOGIN", "music-assistant-triage[bot]")
+    comments = [
+        {
+            "id": 1,
+            "body": config.STICKY_MARKER + " old",
+            "user": {"login": "github-actions"},
+        }
+    ]
+    comment.upsert(fake_gh, 5, "new", {"v": 2}, comments=comments)
+    assert fake_gh.calls == []
+
+
+def test_app_rollout_updates_its_own_sticky(fake_gh, monkeypatch):
+    monkeypatch.setattr(config, "BOT_LOGIN", "music-assistant-triage[bot]")
+    comments = [
+        {
+            "id": 1,
+            "body": config.STICKY_MARKER + " old",
+            "user": {"login": "music-assistant-triage[bot]"},
+        }
+    ]
+    comment.upsert(fake_gh, 5, "new", {"v": 2}, comments=comments)
+    assert any(call[0] == "update_comment" for call in fake_gh.calls)
+
+
+def test_app_rollout_ignores_user_forged_marker(fake_gh, monkeypatch):
+    monkeypatch.setattr(config, "BOT_LOGIN", "music-assistant-triage[bot]")
+    comments = [
+        {
+            "id": 1,
+            "body": config.STICKY_MARKER + " forged",
+            "user": {"login": "attacker"},
+        }
+    ]
+    comment.upsert(fake_gh, 5, "new", {"v": 2}, comments=comments)
+    assert any(call[0] == "create_comment" for call in fake_gh.calls)
+
+
 def test_injection_body_has_no_live_mentions(injection_raw, fake_gh):
     result = _actionable_result(injection_raw, fake_gh)
     body = comment.build_body(result)

--- a/.github/scripts/tests/test_discussion.py
+++ b/.github/scripts/tests/test_discussion.py
@@ -111,6 +111,30 @@ def test_cmd_discussion_ignores_forged_sticky_marker(discussions_on, monkeypatch
     assert not [c for c in gh.calls if c[0] == "update_discussion_comment"]
 
 
+def test_discussion_app_rollout_preserves_legacy_sticky(
+    discussions_on, monkeypatch
+):
+    monkeypatch.setenv("DISCUSSION_NUMBER", "7")
+    monkeypatch.setattr(config, "BOT_LOGIN", "music-assistant-triage[bot]")
+    legacy = [
+        {
+            "id": "DC_legacy",
+            "body": config.STICKY_MARKER + " old answer",
+            "viewerDidAuthor": False,
+            "author": {"login": "github-actions"},
+        }
+    ]
+    gh = FakeGH(discussion=_disc(comments=legacy))
+    monkeypatch.setattr(
+        main.rag,
+        "answer",
+        lambda gh, *, title, body, number, token, kind="issue",
+        provider_labels=None: _high_rag(),
+    )
+    assert main.cmd_discussion(gh, "t") == 0
+    assert not [c for c in gh.calls if "discussion_comment" in c[0]]
+
+
 def test_cmd_discussion_skips_excluded_category(discussions_on, monkeypatch):
     monkeypatch.setenv("DISCUSSION_NUMBER", "7")
     gh = FakeGH(discussion=_disc(category="Translations"))

--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -26,7 +26,6 @@ concurrency:
 
 permissions:
   contents: read
-  discussions: write
   models: read # docs-grounded answer via GitHub Models (only when AI enabled)
 
 jobs:
@@ -38,6 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Create triage App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -47,7 +52,8 @@ jobs:
       - name: Triage discussion
         working-directory: .github/scripts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          TRIAGE_BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
           REPOSITORY: ${{ github.repository }}
           DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           # Untrusted content — safe because it is an env var, not shell input.

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -30,8 +30,6 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
-  models: read # Tier-1 GitHub Models inference (only used when TRIAGE_AI_ENABLED)
 
 jobs:
   analyze:
@@ -42,11 +40,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      discussions: read # provider-matched pinned support notices
-      issues: write
       models: read
     steps:
       - uses: actions/checkout@v4
+      - name: Create triage App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -56,7 +58,8 @@ jobs:
       - name: Triage issue
         working-directory: .github/scripts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          TRIAGE_BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
           REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
           # Untrusted content — safe because it is an env var, not shell input.
@@ -91,8 +94,17 @@ jobs:
       && !github.event.issue.pull_request
       && github.event.comment.user.type != 'Bot' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Create triage App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          permission-issues: write
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -102,7 +114,8 @@ jobs:
       - name: Update response state
         working-directory: .github/scripts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          TRIAGE_BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
           REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login }}

--- a/.github/workflows/triage_scheduled.yml
+++ b/.github/workflows/triage_scheduled.yml
@@ -17,13 +17,19 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   sweep:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Create triage App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TRIAGE_APP_ID }}
+          private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
+          permission-issues: write
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -33,7 +39,8 @@ jobs:
       - name: Run sweep
         working-directory: .github/scripts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          TRIAGE_BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
           REPOSITORY: ${{ github.repository }}
           TRIAGE_DRY_RUN: ${{ vars.TRIAGE_DRY_RUN }}
         run: python -m ma_triage sweep


### PR DESCRIPTION
## Problem

Triage comments and lifecycle actions currently appear under the generic `github-actions` account. The new organization-owned `musicassistant-bot` GitHub App should be the visible automation identity without introducing a long-lived user PAT.

## Changes

- mint repository-scoped, one-hour installation tokens with `actions/create-github-app-token@v2`
- use the App token only for issue analysis/respond, Discussion answers, and scheduled lifecycle mutations
- keep RAG index commits on the built-in `GITHUB_TOKEN` and Models calls on `GH_MODELS_TOKEN`
- remove issue/discussion write permissions from the built-in workflow token
- preserve existing `github-actions` sticky comments while new stickies are owned and updated by the App
- distinguish App-owned, legacy, and user-forged sticky markers for safe idempotent updates
- document the App credentials and token split

## Verification

- 227 tests pass; Python compile and workflow YAML checks pass
- branch workflow smoke test successfully minted an installation token, completed Tier-0/Tier-1/RAG on #5834, preserved the legacy sticky, and attributed label mutations to `musicassistant-bot[bot]`
