### PR TITLE
Index more posts + store as base64 int8

### DIFF
--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -381,7 +381,22 @@ BM25_K1 = 1.5
 BM25_B = 0.75
 
 # Indexing caps / cost guards.
-INDEX_MAX_POSTS = _env_int("TRIAGE_INDEX_MAX_POSTS", 500)
+#
+# Issues and discussions are capped separately. Under one shared cap the two
+# compete for slots by recency, so a busy stretch of discussions evicts the older
+# issues duplicate detection depends on.
+#
+# The ceiling that matters is on-disk size rather than post count: the index is
+# committed to git and rewritten whole on every new post. At ~0.7 KB per
+# quantised vector (see `retrieval.encode_vec`) these caps cost ~2 MB; under the
+# previous JSON-float encoding the same would have been ~30 MB.
+INDEX_MAX_ISSUES = _env_int("TRIAGE_INDEX_MAX_ISSUES", 2500)
+INDEX_MAX_DISCUSSIONS = _env_int("TRIAGE_INDEX_MAX_DISCUSSIONS", 500)
+# Bounds how much is *fetched* before trimming; the per-kind caps above decide
+# what is kept.
+INDEX_MAX_POSTS = _env_int(
+    "TRIAGE_INDEX_MAX_POSTS", INDEX_MAX_ISSUES + INDEX_MAX_DISCUSSIONS
+)
 DOCS_CHUNK_MAX_CHARS = _env_int("TRIAGE_DOCS_CHUNK_MAX_CHARS", 2000)
 MAX_POST_EMBED_CHARS = 6000  # bound the text embedded per post / query
 MAX_DOC_ANSWER_CHARS = 1200  # cap the judge's answer echoed into the comment

--- a/.github/scripts/ma_triage/embeddings.py
+++ b/.github/scripts/ma_triage/embeddings.py
@@ -26,8 +26,13 @@ import requests
 from . import config, docs
 from .gh import GitHubClient, log
 from .models import DocChunk
+from .retrieval import decode_vec, encode_vec
 
-_SCHEMA = 1
+# Bumped to 2 when embeddings moved from JSON float arrays to base64 int8
+# (`retrieval.encode_vec`). An index written by an older schema is discarded and
+# rebuilt rather than read: the loaders below treat schema the same way they
+# already treat a model or dimension change.
+_SCHEMA = 2
 
 
 def _now_iso() -> str:
@@ -122,8 +127,12 @@ def load_docs_chunks(gh: GitHubClient) -> list[DocChunk]:
     index = load_index(gh, config.DOCS_INDEX_PATH)
     if not index:
         return []
-    if index.get("model") != config.EMBED_MODEL or index.get("dim") != config.EMBED_DIM:
-        log("Docs index model/dim mismatch; ignoring index")
+    if (
+        index.get("schema") != _SCHEMA
+        or index.get("model") != config.EMBED_MODEL
+        or index.get("dim") != config.EMBED_DIM
+    ):
+        log("Docs index schema/model/dim mismatch; ignoring index")
         return []
     chunks: list[DocChunk] = []
     for raw in index.get("chunks", []) or []:
@@ -139,7 +148,7 @@ def load_docs_chunks(gh: GitHubClient) -> list[DocChunk]:
                 text=str(raw.get("text", "")),
                 breadcrumbs=list(raw.get("breadcrumbs", []) or []),
                 sha=str(raw.get("sha", "")),
-                embedding=[float(x) for x in raw.get("embedding", [])],
+                embedding=decode_vec(raw.get("embedding")),
             )
         )
     return chunks
@@ -150,7 +159,12 @@ def load_posts(gh: GitHubClient) -> list[dict[str, Any]]:
     index = load_index(gh, config.POSTS_INDEX_PATH)
     if not index:
         return []
-    if index.get("model") != config.EMBED_MODEL or index.get("dim") != config.EMBED_DIM:
+    if (
+        index.get("schema") != _SCHEMA
+        or index.get("model") != config.EMBED_MODEL
+        or index.get("dim") != config.EMBED_DIM
+    ):
+        log("Posts index schema/model/dim mismatch; ignoring index")
         return []
     posts = index.get("posts")
     return [p for p in posts if isinstance(p, dict) and p.get("embedding")] if isinstance(posts, list) else []
@@ -175,7 +189,7 @@ def _chunk_to_dict(chunk: DocChunk) -> dict[str, Any]:
         "text": chunk.text,
         "breadcrumbs": chunk.breadcrumbs,
         "sha": chunk.sha,
-        "embedding": chunk.embedding,
+        "embedding": encode_vec(chunk.embedding),
     }
 
 
@@ -203,6 +217,7 @@ def build_docs_index(
     prev_by_id: dict[str, dict[str, Any]] = {}
     if (
         previous
+        and previous.get("schema") == _SCHEMA
         and previous.get("model") == config.EMBED_MODEL
         and previous.get("dim") == config.EMBED_DIM
     ):
@@ -214,7 +229,7 @@ def build_docs_index(
     for i, chunk in enumerate(chunks):
         cached = prev_by_id.get(chunk.id)
         if cached and cached.get("sha") == chunk.sha and cached.get("embedding"):
-            chunk.embedding = [float(x) for x in cached["embedding"]]
+            chunk.embedding = decode_vec(cached["embedding"])
         else:
             to_embed.append(i)
 
@@ -258,8 +273,33 @@ def _post_record(post: dict[str, Any], embedding: list[float]) -> dict[str, Any]
         ),
         "excerpt": str(post.get("body", ""))[: config.RELATED_EXCERPT_CHARS],
         "sha": post_sha(str(post.get("title", "")), str(post.get("body", ""))),
-        "embedding": embedding,
+        "embedding": encode_vec(embedding),
     }
+
+
+def trim_by_kind(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Keep the newest records per kind, up to each kind's own cap.
+
+    Trimming the combined list by a single cap lets whichever kind is busier
+    evict the other; issues and discussions are retained independently so
+    duplicate detection's issue history does not depend on discussion volume.
+    Input order is preserved, so callers control what "newest" means.
+    """
+    caps = {
+        "issue": config.INDEX_MAX_ISSUES,
+        "discussion": config.INDEX_MAX_DISCUSSIONS,
+    }
+    seen: dict[str, int] = {}
+    kept: list[dict[str, Any]] = []
+    for record in records:
+        kind = str(record.get("kind", "issue"))
+        cap = caps.get(kind, config.INDEX_MAX_ISSUES)
+        if seen.get(kind, 0) >= cap:
+            continue
+        seen[kind] = seen.get(kind, 0) + 1
+        kept.append(record)
+    return kept
 
 
 def _empty_posts_index() -> dict[str, Any]:
@@ -283,6 +323,7 @@ def build_posts_index(
     prev_by_key: dict[tuple[str, int], dict[str, Any]] = {}
     if (
         previous
+        and previous.get("schema") == _SCHEMA
         and previous.get("model") == config.EMBED_MODEL
         and previous.get("dim") == config.EMBED_DIM
     ):
@@ -294,7 +335,7 @@ def build_posts_index(
     to_embed: list[dict[str, Any]] = []
     embed_targets: list[str] = []
     metadata_changed = False
-    for post in posts[: config.INDEX_MAX_POSTS]:
+    for post in trim_by_kind(posts):
         key = (post.get("kind", "issue"), int(post.get("number", 0)))
         sha = post_sha(str(post.get("title", "")), str(post.get("body", "")))
         cached = prev_by_key.get(key)
@@ -363,7 +404,7 @@ def append_post(
     ]
     kept.append(record)
     kept.sort(key=lambda r: int(r.get("number", 0)), reverse=True)
-    kept = kept[: config.INDEX_MAX_POSTS]
+    kept = trim_by_kind(kept)
     index = _empty_posts_index()
     index["posts"] = kept
     return index, True

--- a/.github/scripts/ma_triage/retrieval.py
+++ b/.github/scripts/ma_triage/retrieval.py
@@ -13,6 +13,7 @@ plain lists are fast enough and keep the dependency footprint at zero).
 
 from __future__ import annotations
 
+import base64
 import math
 import re
 from collections import Counter
@@ -37,6 +38,63 @@ def tokenize(text: str | None) -> list[str]:
         if "_" in raw:
             tokens.extend(part for part in raw.split("_") if part)
     return tokens
+
+
+class VectorFormatError(ValueError):
+    """A stored embedding could not be decoded."""
+
+
+def encode_vec(vec: list[float]) -> str:
+    """
+    Pack an embedding into base64 int8 for storage in the index.
+
+    The index is committed to git and rewritten in full on every new post, so its
+    on-disk size decides how many posts can be indexed at all. JSON float arrays
+    cost ~9.7 KB per vector; this costs ~0.7 KB.
+
+    Each component is scaled by the vector's own maximum magnitude before being
+    rounded to a signed byte, and **that scale is not stored**. Decoded vectors
+    are therefore only valid for direction-based comparison — :func:`cosine`
+    normalises both operands, so the per-vector constant cancels. They are *not*
+    valid for anything reading magnitude: dot-product scoring, Euclidean
+    distance, or an absolute-distance threshold will all be wrong. Store the
+    scale alongside if that is ever needed.
+
+    Round-trip error measured on the live index is ~0.001 cosine, against a
+    ~0.03 gap between the weakest confirmed duplicate and the strongest noise.
+    """
+    if not vec:
+        return ""
+    scale = max(abs(float(x)) for x in vec) or 1.0
+    packed = bytes(
+        max(-127, min(127, round(float(x) / scale * 127))) & 0xFF for x in vec
+    )
+    return base64.b64encode(packed).decode("ascii")
+
+
+def decode_vec(raw: str | None) -> list[float]:
+    """
+    Unpack an embedding written by :func:`encode_vec`.
+
+    Raises :class:`VectorFormatError` on anything unreadable rather than
+    returning an empty vector. An empty vector scores 0.0 against every
+    candidate, so swallowing the error would silently drop that post out of
+    duplicate detection — the exact failure this encoding exists to fix, made
+    invisible. Callers that must not fail hard already degrade at a higher
+    level (see :func:`rag.answer`).
+
+    Indexes written by an older schema are rejected wholesale at load time
+    (``embeddings._SCHEMA``), so this never has to interpret a legacy format.
+    """
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, str):
+        raise VectorFormatError(f"expected a base64 string, got {type(raw).__name__}")
+    try:
+        data = base64.b64decode(raw, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise VectorFormatError("embedding is not valid base64") from exc
+    return [float(byte - 256 if byte > 127 else byte) for byte in data]
 
 
 def cosine(a: list[float], b: list[float]) -> float:

--- a/.github/scripts/ma_triage/similar.py
+++ b/.github/scripts/ma_triage/similar.py
@@ -21,7 +21,7 @@ from . import config
 from .gh import GitHubClient, log
 from .models import RelatedPost
 from .providers import detect_provider_labels_from_text
-from .retrieval import cosine
+from .retrieval import cosine, decode_vec
 
 _RE_WORD = re.compile(r"[A-Za-z0-9]+")
 
@@ -70,7 +70,7 @@ def related_from_index(
         if key in seen:
             continue
         seen.add(key)
-        score = cosine(query_vec, [float(x) for x in post.get("embedding", [])])
+        score = cosine(query_vec, decode_vec(post.get("embedding")))
         if score >= threshold:
             scored.append((score, post))
 

--- a/.github/scripts/tests/test_config.py
+++ b/.github/scripts/tests/test_config.py
@@ -51,7 +51,10 @@ def test_empty_env_vars_fall_back_to_defaults(monkeypatch):
     assert config.ANSWER_HI == 0.75
     assert config.ANSWER_LO == 0.45
     assert config.RELATED_POSTS == 3
-    assert config.INDEX_MAX_POSTS == 500
+    assert config.INDEX_MAX_ISSUES == 2500
+    assert config.INDEX_MAX_DISCUSSIONS == 500
+    # The fetch bound defaults to the sum of the two per-kind caps.
+    assert config.INDEX_MAX_POSTS == 3000
     assert config.EMBED_MODEL == "openai/text-embedding-3-small"
     assert config.ANSWER_MODEL == "openai/gpt-4o"
     assert config.INDEX_BRANCH == "triage-index"

--- a/.github/scripts/tests/test_discussion.py
+++ b/.github/scripts/tests/test_discussion.py
@@ -7,6 +7,7 @@ import pytest
 from conftest import FakeGH, fake_embedding
 
 from ma_triage import __main__ as main
+from ma_triage.retrieval import encode_vec
 from ma_triage import config, similar
 from ma_triage.gh import GitHubClient
 from ma_triage.models import DocAnswer, DocChunk, RagResult, RelatedPost
@@ -411,9 +412,9 @@ def test_related_index_excludes_self_discussion_keeps_same_number_issue():
     vec = fake_embedding("group sonos speakers")
     posts = [
         {"kind": "discussion", "number": 7, "title": "group sonos speakers",
-         "url": "d7", "state": "open", "embedding": fake_embedding("group sonos speakers")},
+         "url": "d7", "state": "open", "embedding": encode_vec(fake_embedding("group sonos speakers"))},
         {"kind": "issue", "number": 7, "title": "group sonos speakers",
-         "url": "i7", "state": "open", "embedding": fake_embedding("group sonos speakers")},
+         "url": "i7", "state": "open", "embedding": encode_vec(fake_embedding("group sonos speakers"))},
     ]
     out = similar.related_from_index(
         vec, posts, exclude_number=7, exclude_kind="discussion", min_score=0.0

--- a/.github/scripts/tests/test_embeddings.py
+++ b/.github/scripts/tests/test_embeddings.py
@@ -6,6 +6,7 @@ import pytest
 
 from conftest import FAKE_DIM, FakeGH, fake_embedding
 from ma_triage import config, embeddings
+from ma_triage.retrieval import encode_vec
 from ma_triage.models import DocChunk
 
 
@@ -145,7 +146,7 @@ def test_load_index_absent_and_malformed():
 def test_load_docs_chunks_model_mismatch_ignored(monkeypatch):
     monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
     bad = {"model": "other/model", "dim": FAKE_DIM, "chunks": [
-        {"id": "a", "embedding": [1.0] * FAKE_DIM}]}
+        {"id": "a", "embedding": encode_vec([1.0] * FAKE_DIM)}]}
     gh = FakeGH(index_files={config.DOCS_INDEX_PATH: json.dumps(bad)})
     assert embeddings.load_docs_chunks(gh) == []
 

--- a/.github/scripts/tests/test_similar.py
+++ b/.github/scripts/tests/test_similar.py
@@ -2,13 +2,14 @@
 
 from conftest import FAKE_DIM, fake_embedding
 from ma_triage import config, similar
+from ma_triage.retrieval import encode_vec
 
 
 def _post(number, text, kind="issue", state="open", providers=None):
     return {
         "kind": kind, "number": number, "title": text, "url": f"https://x/{number}",
         "state": state, "providers": providers or [],
-        "embedding": fake_embedding(text),
+        "embedding": encode_vec(fake_embedding(text)),
     }
 
 
@@ -17,7 +18,7 @@ def test_related_from_index_ranks_and_thresholds():
     posts = [
         _post(1, "sonos speaker grouping problem"),
         {"kind": "issue", "number": 2, "title": "unrelated", "url": "https://x/2",
-         "state": "open", "embedding": [0.0] * FAKE_DIM},
+         "state": "open", "embedding": encode_vec([0.0] * FAKE_DIM)},
     ]
     hits = similar.related_from_index(query, posts, exclude_number=99)
     assert [h.number for h in hits] == [1]  # #2 (zero vector) below the threshold
@@ -91,7 +92,7 @@ def test_find_related_no_search_fallback_when_index_rejects_everything(
     # A usable index that scored nothing above the floor is a decision, not a
     # failure: the unscored keyword search must not re-add what it rejected.
     posts = [{"kind": "issue", "number": 1, "title": "x", "url": "u",
-              "state": "open", "embedding": [0.0] * FAKE_DIM}]
+              "state": "open", "embedding": encode_vec([0.0] * FAKE_DIM)}]
     hits = similar.find_related(
         fake_gh, query_vec=fake_embedding("sonos grouping"),
         title="sonos grouping", posts=posts, exclude_number=99,
@@ -118,7 +119,7 @@ def test_find_related_uses_index_when_available(fake_gh):
     query = fake_embedding("sonos speaker grouping")
     posts = [{"kind": "issue", "number": 3, "title": "sonos speaker grouping",
               "url": "u3", "state": "open",
-              "embedding": fake_embedding("sonos speaker grouping")}]
+              "embedding": encode_vec(fake_embedding("sonos speaker grouping"))}]
     hits = similar.find_related(
         fake_gh, query_vec=query, title="sonos speaker grouping", posts=posts,
         exclude_number=99,

--- a/.github/scripts/tests/test_vector_codec.py
+++ b/.github/scripts/tests/test_vector_codec.py
@@ -1,0 +1,96 @@
+"""Tests for the stored-embedding codec and the per-kind index trim."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from ma_triage import config, embeddings
+from ma_triage.retrieval import VectorFormatError, cosine, decode_vec, encode_vec
+
+
+def _vec(seed: int, dim: int = 64) -> list[float]:
+    """A deterministic pseudo-embedding with both signs and a non-unit scale."""
+    return [math.sin(seed * (i + 1) * 0.7) * 0.31 for i in range(dim)]
+
+
+# --- codec ------------------------------------------------------------------ #
+def test_round_trip_preserves_direction():
+    original = _vec(1)
+    restored = decode_vec(encode_vec(original))
+    assert len(restored) == len(original)
+    # The scale is intentionally discarded, so compare direction, not values.
+    assert cosine(original, restored) == pytest.approx(1.0, abs=1e-3)
+
+
+def test_pairwise_similarity_survives_quantisation():
+    a, b = _vec(2), _vec(3)
+    before = cosine(a, b)
+    after = cosine(decode_vec(encode_vec(a)), decode_vec(encode_vec(b)))
+    assert after == pytest.approx(before, abs=5e-3)
+
+
+def test_scale_is_not_stored_so_magnitude_is_not_preserved():
+    """Documents the contract: decoded vectors are for cosine only."""
+    small = [0.001, 0.002, -0.001]
+    large = [1000.0, 2000.0, -1000.0]
+    # Same direction, wildly different magnitude -> identical encoding.
+    assert encode_vec(small) == encode_vec(large)
+
+
+def test_empty_vector_round_trips_to_empty():
+    assert encode_vec([]) == ""
+    assert decode_vec("") == []
+    assert decode_vec(None) == []
+
+
+@pytest.mark.parametrize("bad", ["not base64!!", "@@@@", 12345, ["a", "b"], {"x": 1}])
+def test_unreadable_embedding_raises_rather_than_scoring_zero(bad):
+    """A silent [] would score 0.0 against everything and hide the post."""
+    with pytest.raises(VectorFormatError):
+        decode_vec(bad)
+
+
+def test_encoding_is_substantially_smaller_than_json():
+    import json
+
+    vec = _vec(4, dim=512)
+    assert len(encode_vec(vec)) * 4 < len(json.dumps(vec))
+
+
+# --- per-kind trim ---------------------------------------------------------- #
+def test_trim_keeps_each_kind_up_to_its_own_cap(monkeypatch):
+    monkeypatch.setattr(config, "INDEX_MAX_ISSUES", 2)
+    monkeypatch.setattr(config, "INDEX_MAX_DISCUSSIONS", 1)
+    records = [
+        {"kind": "issue", "number": 5},
+        {"kind": "discussion", "number": 4},
+        {"kind": "issue", "number": 3},
+        {"kind": "discussion", "number": 2},
+        {"kind": "issue", "number": 1},
+    ]
+    kept = embeddings.trim_by_kind(records)
+    assert [(r["kind"], r["number"]) for r in kept] == [
+        ("issue", 5),
+        ("discussion", 4),
+        ("issue", 3),
+    ]
+
+
+def test_discussions_cannot_evict_issues(monkeypatch):
+    """The regression that motivated per-kind caps: a burst of discussions
+    previously pushed older issues out of a single shared budget."""
+    monkeypatch.setattr(config, "INDEX_MAX_ISSUES", 3)
+    monkeypatch.setattr(config, "INDEX_MAX_DISCUSSIONS", 3)
+    records = [{"kind": "discussion", "number": n} for n in range(100, 90, -1)]
+    records += [{"kind": "issue", "number": n} for n in range(3, 0, -1)]
+    kept = embeddings.trim_by_kind(records)
+    assert sum(1 for r in kept if r["kind"] == "issue") == 3
+    assert sum(1 for r in kept if r["kind"] == "discussion") == 3
+
+
+def test_unknown_kind_falls_back_to_the_issue_cap(monkeypatch):
+    monkeypatch.setattr(config, "INDEX_MAX_ISSUES", 1)
+    kept = embeddings.trim_by_kind([{"kind": "wat", "number": 2}, {"kind": "wat", "number": 1}])
+    assert len(kept) == 1


### PR DESCRIPTION
Duplicate detection misses because the index cannot see the duplicate, not because it scores it badly. Of 34 issues closed as duplicates where a maintainer named the original, 30 have a target absent from posts.json entirely. The retriever never had a candidate to rank.

INDEX_MAX_POSTS caps issues and discussions together at 500, so the two compete by recency; the live index held 324 issues and 176 discussions. Raising that cap was not affordable: posts.json is committed to the triage-index branch and rewritten whole on every new post, and at ~9.7 KB per JSON float array 3000 posts would re-commit ~30 MB per filed issue.

So store vectors as base64 int8 rather than JSON floats. Each component is scaled by the vector's own maximum before rounding to a signed byte, and that scale is discarded: cosine normalises both operands, so a per-vector constant cancels. Measured on the live index, this is 14.5x smaller (4.97 MB -> 0.34 MB) for a round-trip cosine error of at most 0.00107. The four confirmed duplicate pairs currently in range move by <= 0.00027, against a ~0.03 gap between the weakest of them and the strongest noise.

Decoded vectors are valid for direction only. Anything reading magnitude — dot product, Euclidean distance, an absolute threshold — would be silently wrong, so encode_vec documents that contract and a test pins it.

decode_vec raises rather than returning an empty vector on bad input. An empty vector scores 0.0 against every candidate, which would drop that post out of duplicate detection without a trace: the failure this change exists to fix, made invisible. rag.answer already degrades at a higher level.

With the smaller encoding the caps become per-kind and affordable at ~2 MB: 2500 issues, 500 discussions. Discussions can no longer evict issue history.

The schema field goes to 2. Both loaders already discard an index whose model or dimension has moved; schema now joins that check, so the old format is rebuilt rather than read and no dual-format reader is needed.

Eviction stays recency-based, so this is a large improvement rather than a complete fix — duplicate targets skew old, and some predate any workable cap. Threshold tuning (RELATED_MIN_SCORE, RELATED_POSTS) is deliberately left out: tuning against an index that cannot see most duplicates would optimise the wrong variable.