### PR TITLE
Fail the index build when no index was produced

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -41,7 +41,7 @@ from .attachments import (
     has_media_attachment,
 )
 from .diagnostics import try_parse
-from .gh import GitHubClient, log, summary
+from .gh import GitHubClient, error, log, summary
 from .models import TriageResult
 from .providers import (
     detect_reported_provider_labels,
@@ -393,20 +393,25 @@ def cmd_sweep(gh: GitHubClient) -> int:
 # --------------------------------------------------------------------------- #
 # RAG index build (Phase 2)
 # --------------------------------------------------------------------------- #
-def _build_docs_index(gh: GitHubClient, token: str) -> None:
+def _build_docs_index(gh: GitHubClient, token: str) -> bool:
+    """Build and persist the docs index. False when it could not be built."""
     prev = embeddings.load_index(gh, config.DOCS_INDEX_PATH)
     index, changed = embeddings.build_docs_index(gh, token=token, previous=prev)
     if index is None:
-        summary("- docs: build skipped (embeddings unavailable / rate limited)")
-        return
+        error(
+            "docs: build FAILED — the embeddings provider returned no vectors. "
+            "The committed index is now stale and retrieval is degraded."
+        )
+        return False
     count = len(index.get("chunks", []))
     if not changed:
         summary(f"- docs: unchanged ({count} chunks); no commit")
-        return
+        return True
     embeddings.save_index(
         gh, config.DOCS_INDEX_PATH, index, message=f"Update docs index ({count} chunks)"
     )
     summary(f"- docs: {count} chunks indexed")
+    return True
 
 
 def _collect_posts(gh: GitHubClient) -> list[dict[str, Any]]:
@@ -449,34 +454,52 @@ def _collect_posts(gh: GitHubClient) -> list[dict[str, Any]]:
     return posts
 
 
-def _build_posts_index(gh: GitHubClient, token: str) -> None:
+def _build_posts_index(gh: GitHubClient, token: str) -> bool:
+    """Build and persist the posts index. False when it could not be built."""
     prev = embeddings.load_index(gh, config.POSTS_INDEX_PATH)
     posts = _collect_posts(gh)
     index, changed = embeddings.build_posts_index(
         gh, posts, token=token, previous=prev
     )
     if index is None:
-        summary("- posts: build skipped (embeddings unavailable / rate limited)")
-        return
+        error(
+            "posts: build FAILED — the embeddings provider returned no vectors. "
+            "Duplicate detection is running against a stale index."
+        )
+        return False
     count = len(index.get("posts", []))
     if not changed:
         summary(f"- posts: unchanged ({count} posts); no commit")
-        return
+        return True
     embeddings.save_index(
         gh, config.POSTS_INDEX_PATH, index, message=f"Update posts index ({count} posts)"
     )
     summary(f"- posts: {count} posts indexed")
+    return True
 
 
 def cmd_index(gh: GitHubClient, token: str, target: str = "all") -> int:
+    """
+    Build the requested indexes. Non-zero when any of them could not be built.
+
+    Unlike triage — which deliberately degrades so an unreachable model never
+    leaves an issue unlabelled — producing the index *is* this command's only
+    job, so failing to produce one is a failure. Returning 0 here hid a dead
+    embeddings provider behind a green nightly build for sixteen days while the
+    committed index silently went stale.
+    """
     summary(f"## RAG index build ({target})\n")
     if target not in ("docs", "posts", "all"):
         log(f"unknown index target: {target} (use docs|posts|all)")
         return 2
+    built = True
     if target in ("docs", "all"):
-        _build_docs_index(gh, token)
+        built &= _build_docs_index(gh, token)
     if target in ("posts", "all"):
-        _build_posts_index(gh, token)
+        built &= _build_posts_index(gh, token)
+    if not built:
+        error(f"RAG index build ({target}) did not produce an index.")
+        return 1
     return 0
 
 
@@ -502,7 +525,13 @@ def cmd_index_append(gh: GitHubClient, token: str) -> int:
     }
     index, _changed = embeddings.append_post(gh, post, token=token)
     if index is None:
-        summary(f"#{number}: append skipped (embeddings unavailable).")
+        # Annotate but exit 0 on purpose: this runs inside per-issue triage, and
+        # failing here would mark every incoming issue's workflow red for a
+        # provider outage the scheduled build already reports as a failure.
+        error(
+            f"#{number}: not appended — the embeddings provider returned no "
+            "vectors. The posts index is no longer keeping up with new posts."
+        )
         return 0
     embeddings.save_index(
         gh,
@@ -632,7 +661,13 @@ def cmd_discussion_append(gh: GitHubClient, token: str) -> int:
     }
     index, _changed = embeddings.append_post(gh, post, token=token)
     if index is None:
-        summary(f"#{number}: append skipped (embeddings unavailable).")
+        # Annotate but exit 0 on purpose: this runs inside per-issue triage, and
+        # failing here would mark every incoming issue's workflow red for a
+        # provider outage the scheduled build already reports as a failure.
+        error(
+            f"#{number}: not appended — the embeddings provider returned no "
+            "vectors. The posts index is no longer keeping up with new posts."
+        )
         return 0
     embeddings.save_index(
         gh,

--- a/.github/scripts/ma_triage/gh.py
+++ b/.github/scripts/ma_triage/gh.py
@@ -40,6 +40,17 @@ def summary(msg: str) -> None:
     log(msg)
 
 
+def error(msg: str) -> None:
+    """
+    Surface a failure as a GitHub Actions error annotation.
+
+    Annotations show against the run in the UI, so a degraded step is visible
+    without anyone opening the log. Outside Actions the ``::error::`` prefix is
+    inert and this is an ordinary summary line.
+    """
+    summary(f"::error::{msg}")
+
+
 class GitHubClient:
     """Minimal GitHub API wrapper with retries and dry-run support."""
 

--- a/.github/scripts/tests/test_index_cmd.py
+++ b/.github/scripts/tests/test_index_cmd.py
@@ -45,6 +45,63 @@ def test_cmd_index_unknown_target():
     assert main.cmd_index(FakeGH(), "t", "bogus") == 2
 
 
+# --- the provider is unreachable -------------------------------------------- #
+#
+# GitHub Models was retired on 2026-07-30. Every nightly build for the sixteen
+# days that followed reported success while writing nothing, because an
+# unavailable embedder was treated as an acceptable outcome. Producing an index
+# is this command's only job, so it must now say when it did not.
+def _no_embeddings(monkeypatch):
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+
+
+def test_cmd_index_fails_when_embeddings_are_unavailable(ai_on, monkeypatch):
+    monkeypatch.setattr(embeddings.docs, "build_chunks", lambda gh: [_chunk("a#x", "t")])
+    _no_embeddings(monkeypatch)
+    gh = FakeGH()
+    assert main.cmd_index(gh, "t", "docs") == 1
+    assert config.DOCS_INDEX_PATH not in gh._index_files
+
+
+def test_cmd_index_posts_fails_when_embeddings_are_unavailable(ai_on, monkeypatch):
+    _no_embeddings(monkeypatch)
+    gh = FakeGH(
+        issues=[{"number": 1, "title": "bug", "body": "b", "html_url": "u1",
+                 "state": "open", "updated_at": "2024-01-01"}],
+    )
+    assert main.cmd_index(gh, "t", "posts") == 1
+    assert config.POSTS_INDEX_PATH not in gh._index_files
+
+
+def test_cmd_index_all_fails_if_either_target_fails(ai_on, monkeypatch):
+    monkeypatch.setattr(embeddings.docs, "build_chunks", lambda gh: [_chunk("a#x", "t")])
+    _no_embeddings(monkeypatch)
+    assert main.cmd_index(FakeGH(), "t", "all") == 1
+
+
+def test_cmd_index_annotates_the_failure(ai_on, monkeypatch, capsys):
+    monkeypatch.setattr(embeddings.docs, "build_chunks", lambda gh: [_chunk("a#x", "t")])
+    _no_embeddings(monkeypatch)
+    main.cmd_index(FakeGH(), "t", "docs")
+    assert "::error::" in capsys.readouterr().err
+
+
+def test_cmd_index_append_annotates_but_does_not_fail_triage(ai_on, monkeypatch, capsys):
+    """A provider outage must not mark every incoming issue's workflow red."""
+    monkeypatch.setenv("ISSUE_NUMBER", "123")
+    _no_embeddings(monkeypatch)
+    gh = FakeGH()
+    monkeypatch.setattr(
+        gh, "get_issue",
+        lambda n: {"number": n, "title": "t", "body": "b", "html_url": "u",
+                   "state": "open"},
+        raising=False,
+    )
+    assert main.cmd_index_append(gh, "t") == 0
+    assert "::error::" in capsys.readouterr().err
+    assert config.POSTS_INDEX_PATH not in gh._index_files
+
+
 def test_cmd_index_append(ai_on, monkeypatch):
     monkeypatch.setenv("ISSUE_NUMBER", "123")
     monkeypatch.setenv("ISSUE_TITLE", "sonos grouping bug")


### PR DESCRIPTION
GitHub Models was retired on 2026-07-30. Every scheduled index build since has reported success while writing nothing: the embeddings call returns 410, build_docs_index and build_posts_index return None, and cmd_index reported that as a normal outcome and exited 0. Sixteen days of green checkmarks over a committed index frozen at the moment the provider went away, and a retrieval layer quietly running on it.

Producing an index is this command's only job, so failing to produce one is a failure and now exits non-zero. Triage keeps its existing behaviour on purpose: an unreachable model must never leave a reporter's issue unlabelled, so the graceful degradation in embed_texts stays exactly where it is. The distinction is between a command whose output is optional and one whose output is the point.

index-append annotates but still exits 0. It runs inside per-issue triage, and a provider outage should not mark every incoming issue's workflow red when the scheduled build already reports it.

Adds gh.error() for GitHub Actions error annotations, so a degraded run is visible against the run itself rather than only to whoever opens the log.

The failure path had no test, which is why exiting 0 on it survived. There are now five, covering docs, posts, all, the annotation, and append's deliberate exit 0.