### PR TITLE
Keep related-post detection working when embeddings are unavailable

### DIFF
--- a/.github/scripts/ma_triage/rag.py
+++ b/.github/scripts/ma_triage/rag.py
@@ -8,7 +8,7 @@ the deterministic Tier-0/Tier-1 triage completely untouched.
 Pipeline (≤ 1 embedding + ≤ 1 judge chat per post):
 
 1. embed the post once,
-2. hybrid-retrieve doc chunks (dense + BM25 + RRF),
+2. hybrid-retrieve doc chunks (dense + BM25 + RRF; skipped without a vector),
 3. ask the judge whether the docs answer it,
 4. route to a confidence tier (HIGH / MEDIUM / LOW),
 5. find related past posts (dense, or search fallback),
@@ -68,7 +68,7 @@ def _resolve_cited(answer: DocAnswer, doc_hits: list[DocHit]) -> list[DocChunk]:
     return [hit.chunk for hit in doc_hits[: config.DOCS_LINKS_SHOWN]]
 
 
-def _best_dense(query_vec: list[float], doc_hits: list[DocHit]) -> float:
+def _best_dense(query_vec: list[float] | None, doc_hits: list[DocHit]) -> float:
     if not query_vec or not doc_hits:
         return 0.0
     return max(cosine(query_vec, hit.chunk.embedding) for hit in doc_hits)
@@ -134,20 +134,23 @@ def answer(
     try:
         query_text = f"{title}\n\n{body}".strip()
         query_vec = embeddings.embed_text(query_text, token=token)
-        if query_vec is None:
-            # Pinned notices are deterministic and remain useful if Models is
-            # temporarily unavailable.
-            result = RagResult(pinned_posts=pinned)
-            return result if result.has_output else None
 
-        chunks = embeddings.load_docs_chunks(gh)
-        doc_hits = retrieve_docs(query_vec, query_text, chunks)
-        doc_hits = _promote_provider_docs(
-            query_vec,
-            chunks,
-            doc_hits,
-            provider_docs or [],
-        )
+        # A docs answer needs the query vector. Without one `retrieve_docs`
+        # ranks on its BM25 leg alone, and the judge would then be paid to
+        # grade candidates nothing dense ever scored. Related posts carry no
+        # such requirement, so they are still resolved below: pinned notices
+        # and duplicate detection both stay useful while the embeddings
+        # provider is unavailable.
+        doc_hits: list[DocHit] = []
+        if query_vec is not None:
+            chunks = embeddings.load_docs_chunks(gh)
+            doc_hits = retrieve_docs(query_vec, query_text, chunks)
+            doc_hits = _promote_provider_docs(
+                query_vec,
+                chunks,
+                doc_hits,
+                provider_docs or [],
+            )
 
         judge: DocAnswer | None = None
         if doc_hits and not duplicates_only:

--- a/.github/scripts/ma_triage/similar.py
+++ b/.github/scripts/ma_triage/similar.py
@@ -6,8 +6,9 @@ duplicate. Two paths:
 
 * **primary** — dense cosine over the ``posts.json`` embeddings index (semantic,
   free, catches rewordings),
-* **fallback** — when the index is absent/empty, degrade gracefully to GitHub's
-  own issue search over the report's title keywords.
+* **fallback** — when the index is absent/empty *or the query embedding is
+  unavailable*, degrade gracefully to GitHub's own issue search over the
+  report's title keywords.
 
 The incoming post's own number is always excluded, and results are de-duplicated
 and thresholded so the comment only ever shows genuinely-relevant links.
@@ -162,8 +163,11 @@ def find_related(
             exclude_kind=exclude_kind,
             provider_labels=provider_labels,
         )
-    # If the report names a provider, an unscoped text-search fallback can only
-    # reintroduce the noisy cross-provider matches this filter is meant to stop.
+    # Below here the only candidate source is GitHub's issue search, which
+    # cannot be scoped to a provider. A report that names one would therefore
+    # get back exactly the cross-provider matches `related_from_index` filters
+    # out, so it gets nothing instead (the index path applies the same filter
+    # and keeps its results).
     if provider_labels:
         return []
     return related_from_search(

--- a/.github/scripts/tests/test_rag.py
+++ b/.github/scripts/tests/test_rag.py
@@ -73,9 +73,27 @@ def test_answer_returns_none_when_nothing_to_show(ai_on):
 
 
 def test_answer_none_on_embed_failure(ai_on, monkeypatch):
+    # No search items either, so the fallback finds nothing and the result
+    # stays None — see the test below for the case where it does find one.
     monkeypatch.setattr(embeddings, "embed_text", lambda text, *, token: None)
     gh = _gh_with_indexes()
     assert rag.answer(gh, title="sonos mdns", body="", number=1, token="t") is None
+
+
+def test_answer_still_finds_related_posts_on_embed_failure(ai_on, monkeypatch):
+    # The search fallback exists for exactly this outage, so it has to be
+    # reachable when the embeddings call is the thing that failed: pinned
+    # notices alone are not the expected output here.
+    monkeypatch.setattr(embeddings, "embed_text", lambda text, *, token: None)
+    gh = FakeGH(
+        search_items=[
+            {"number": 42, "title": "sonos mdns discovery", "html_url": "u42",
+             "state": "open"}
+        ]
+    )
+    result = rag.answer(gh, title="sonos mdns", body="", number=1, token="t")
+    assert result is not None
+    assert [post.number for post in result.related_posts] == [42]
 
 
 def test_answer_keeps_provider_matched_pinned_notice_on_embed_failure(

--- a/.github/scripts/tests/test_similar.py
+++ b/.github/scripts/tests/test_similar.py
@@ -115,6 +115,28 @@ def test_find_related_does_not_use_unscoped_fallback_for_provider(fake_gh):
     assert hits == []
 
 
+def test_find_related_search_branch_is_gated_by_provider(fake_gh):
+    # Exercises the gate itself. `test_find_related_does_not_use_unscoped_
+    # fallback_for_provider` reaches `[]` through the index provider filter and
+    # never gets this far; here there is no index and no vector, so GitHub
+    # search is the only candidate source and it cannot be scoped to a provider.
+    fake_gh._search_items = [
+        {"number": 42, "title": "chromecast dropouts", "html_url": "u42",
+         "state": "open"}
+    ]
+    assert (
+        similar.find_related(
+            fake_gh, query_vec=None, title="deezer flow", posts=[],
+            exclude_number=99, provider_labels={"deezer"},
+        )
+        == []
+    )
+    hits = similar.find_related(
+        fake_gh, query_vec=None, title="deezer flow", posts=[], exclude_number=99,
+    )
+    assert [hit.number for hit in hits] == [42]
+
+
 def test_find_related_uses_index_when_available(fake_gh):
     query = fake_embedding("sonos speaker grouping")
     posts = [{"kind": "issue", "number": 3, "title": "sonos speaker grouping",


### PR DESCRIPTION
## Why

Duplicate/related-post detection has produced nothing since 2026-07-30. Every RAG comment posted since then has been a pinned notice and nothing else.

This is an availability problem, not a ranking problem. `rag.answer` returned as soon as `embeddings.embed_text` came back `None`, and `rag.answer` is the only caller of `similar.find_related`. The keyword-search fallback in `find_related` was written for exactly this outage and could never be reached, because the function that would reach it had already returned.

Two details worth knowing before reviewing:

* The medium tier was only surviving a missing vector by accident. `_best_dense` returns `0.0` for an absent vector, which happens to fail the `>= DOCS_MIN_DENSE` check — the right outcome by luck, not by design. The docs half is now skipped explicitly instead.
* Separately, the committed posts index on `triage-index` is schema 1 while `embeddings._SCHEMA` is 2, so `load_posts` discards it and returns `[]` regardless of anything in this PR. **This change makes the search fallback live; the dense index path stays dark until the index is rebuilt.**

## What changes

* `ma_triage/rag.py` — drop the early return on a missing query vector. The docs half (`load_docs_chunks` / `retrieve_docs` / `_promote_provider_docs` and the judge chat) is now guarded so it is skipped entirely without a vector rather than run on its BM25 leg alone. `doc_hits` initialises to `[]`, so the tier, suppression and rendering logic below is untouched.
* `ma_triage/similar.py` — no logic change. The provider gate in front of `related_from_search` stays exactly where it was; only its comment changed, to scope the restriction to the search branch (GitHub search cannot be filtered by provider) rather than to related posts in general. The file is in this PR because the new test below documents that gate.
* Tests for both.

## Behaviour

**Vector present (the normal path): no change at all.** Same retrieval, same judge call, same tier ladder, same suppression, same rendering.

**Vector missing (the outage path):** no docs section and no judge call — so no chat spend — but pinned notices and related posts are now both resolved. Related posts come from the GitHub issue-search fallback, and only when the report names no provider (search cannot be scoped, so a provider-specific report would get back exactly the cross-provider matches the index path filters out).

Three consequences to be aware of:

* Search-fallback hits carry `score=0.0`, so they always render inside the collapsed "Possibly related past reports" block — never expanded as likely duplicates.
* For issues this only adds a section to a comment that was already being posted. For discussions, comment creation is gated on `rag_result.has_output`, so a discussion can now get a comment during an outage where it previously got silence. That comment is the collapsed weak-match block.
* One extra GitHub search API call per post while embeddings are unavailable.

## Not in this PR

Deliberately deferred so this stays reviewable as one change: the text-only posts loader, BM25F ranking, and score semantics for search-fallback hits.

## Testing

`268 passed` locally on Python 3.12-compatible code (the workflows pin 3.12 for the runtime; no workflow runs the suite, so this is not CI-verified).

`test_answer_still_finds_related_posts_on_embed_failure` is a genuine regression test — it fails with `assert None is not None` against the previous `rag.py` and passes with this one.

`test_find_related_search_branch_is_gated_by_provider` covers the provider gate directly. The existing `test_find_related_does_not_use_unscoped_fallback_for_provider` returns `[]` via the index filter and never reaches the gate; this one passes `query_vec=None, posts=[]` so the gate actually executes, and asserts the ungated case still returns the search hit.
