### PR TITLE
Keep indexing posts when the embeddings provider is unavailable

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -455,26 +455,37 @@ def _collect_posts(gh: GitHubClient) -> list[dict[str, Any]]:
 
 
 def _build_posts_index(gh: GitHubClient, token: str) -> bool:
-    """Build and persist the posts index. False when it could not be built."""
+    """Build and persist the posts index. False when vectors are missing.
+
+    The index is committed either way. A post can only lack a vector because
+    the provider refused one, so a shortfall is the failure signal — but the
+    records themselves are still worth writing, since everything that ranks on
+    text rather than vectors keeps working from them.
+    """
     prev = embeddings.load_index(gh, config.POSTS_INDEX_PATH)
     posts = _collect_posts(gh)
     index, changed = embeddings.build_posts_index(
         gh, posts, token=token, previous=prev
     )
-    if index is None:
+    count = len(index.get("posts", []))
+    vectors = int(index.get("vectors", 0))
+    if changed:
+        embeddings.save_index(
+            gh,
+            config.POSTS_INDEX_PATH,
+            index,
+            message=f"Update posts index ({count} posts)",
+        )
+        summary(f"- posts: {count} posts indexed ({vectors} with vectors)")
+    else:
+        summary(f"- posts: unchanged ({count} posts); no commit")
+    if vectors < count:
         error(
-            "posts: build FAILED — the embeddings provider returned no vectors. "
-            "Duplicate detection is running against a stale index."
+            f"posts: build INCOMPLETE — {count - vectors} of {count} posts have "
+            "no vector because the embeddings provider returned none. Their text "
+            "is indexed, but dense duplicate detection cannot see them."
         )
         return False
-    count = len(index.get("posts", []))
-    if not changed:
-        summary(f"- posts: unchanged ({count} posts); no commit")
-        return True
-    embeddings.save_index(
-        gh, config.POSTS_INDEX_PATH, index, message=f"Update posts index ({count} posts)"
-    )
-    summary(f"- posts: {count} posts indexed")
     return True
 
 
@@ -487,6 +498,13 @@ def cmd_index(gh: GitHubClient, token: str, target: str = "all") -> int:
     job, so failing to produce one is a failure. Returning 0 here hid a dead
     embeddings provider behind a green nightly build for sixteen days while the
     committed index silently went stale.
+
+    A failing run still commits what it managed to build. The exit code and the
+    artifact answer different questions: the code reports that vectors are
+    missing, the artifact keeps the text those posts do have so retrieval that
+    needs no vector survives the outage. Committing nothing is what left
+    duplicate detection with no fallback in the first place — so do not
+    "simplify" this into skipping the commit when the run fails.
     """
     summary(f"## RAG index build ({target})\n")
     if target not in ("docs", "posts", "all"):
@@ -523,16 +541,18 @@ def cmd_index_append(gh: GitHubClient, token: str) -> int:
         "state": issue.get("state"),
         "updated_at": issue.get("updated_at"),
     }
-    index, _changed = embeddings.append_post(gh, post, token=token)
-    if index is None:
+    index, embedded = embeddings.append_post(gh, post, token=token)
+    if not embedded:
         # Annotate but exit 0 on purpose: this runs inside per-issue triage, and
         # failing here would mark every incoming issue's workflow red for a
-        # provider outage the scheduled build already reports as a failure.
+        # provider outage the scheduled build already reports as a failure. The
+        # post is still appended with its text, so it stays findable by anything
+        # that does not rank on vectors.
         error(
-            f"#{number}: not appended — the embeddings provider returned no "
-            "vectors. The posts index is no longer keeping up with new posts."
+            f"#{number}: appended without a vector — the embeddings provider "
+            "returned none. It is not visible to dense duplicate detection "
+            "until the next successful index build."
         )
-        return 0
     embeddings.save_index(
         gh,
         config.POSTS_INDEX_PATH,
@@ -659,16 +679,18 @@ def cmd_discussion_append(gh: GitHubClient, token: str) -> int:
         "state": "open",
         "updated_at": _now_iso(),
     }
-    index, _changed = embeddings.append_post(gh, post, token=token)
-    if index is None:
+    index, embedded = embeddings.append_post(gh, post, token=token)
+    if not embedded:
         # Annotate but exit 0 on purpose: this runs inside per-issue triage, and
         # failing here would mark every incoming issue's workflow red for a
-        # provider outage the scheduled build already reports as a failure.
+        # provider outage the scheduled build already reports as a failure. The
+        # post is still appended with its text, so it stays findable by anything
+        # that does not rank on vectors.
         error(
-            f"#{number}: not appended — the embeddings provider returned no "
-            "vectors. The posts index is no longer keeping up with new posts."
+            f"#{number}: appended without a vector — the embeddings provider "
+            "returned none. It is not visible to dense duplicate detection "
+            "until the next successful index build."
         )
-        return 0
     embeddings.save_index(
         gh,
         config.POSTS_INDEX_PATH,

--- a/.github/scripts/ma_triage/embeddings.py
+++ b/.github/scripts/ma_triage/embeddings.py
@@ -255,8 +255,28 @@ def build_docs_index(
     return index, changed
 
 
-def _post_record(post: dict[str, Any], embedding: list[float]) -> dict[str, Any]:
-    return {
+def reusable_vector(cached: dict[str, Any] | None, sha: str) -> bool:
+    """Whether ``cached`` already holds a vector computed from this exact text.
+
+    The sha check is what keeps a vector paired with the text it was computed
+    from; an edited post fails it and must be re-embedded before its vector can
+    be trusted again.
+    """
+    return bool(cached and cached.get("sha") == sha and cached.get("embedding"))
+
+
+def _post_record(
+    post: dict[str, Any], embedding: list[float] | None
+) -> dict[str, Any]:
+    """One index record. ``embedding`` is ``None`` when the provider was down.
+
+    The key is then omitted rather than written empty: ``encode_vec([])`` also
+    produces ``""``, so an empty string would merge "the encoder produced
+    nothing" with "we never asked". Readers filter on the key's presence, so an
+    absent vector removes the record from dense retrieval and leaves it
+    available to everything that only needs its text.
+    """
+    record = {
         "kind": post.get("kind", "issue"),
         "number": int(post.get("number", 0)),
         "title": str(post.get("title", "")),
@@ -273,8 +293,10 @@ def _post_record(post: dict[str, Any], embedding: list[float]) -> dict[str, Any]
         ),
         "excerpt": str(post.get("body", ""))[: config.RELATED_EXCERPT_CHARS],
         "sha": post_sha(str(post.get("title", "")), str(post.get("body", ""))),
-        "embedding": encode_vec(embedding),
     }
+    if embedding:
+        record["embedding"] = encode_vec(embedding)
+    return record
 
 
 def trim_by_kind(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -318,8 +340,13 @@ def build_posts_index(
     *,
     token: str,
     previous: dict[str, Any] | None = None,
-) -> tuple[dict[str, Any] | None, bool]:
-    """Build the posts index from ``{kind,number,title,body,url,state,...}`` dicts."""
+) -> tuple[dict[str, Any], bool]:
+    """Build the posts index from ``{kind,number,title,body,url,state,...}`` dicts.
+
+    Always returns an index. A provider outage costs individual records their
+    vectors, not the whole build — ``index["vectors"]`` reports how many
+    records carry one, which is what tells the caller the run fell short.
+    """
     prev_by_key: dict[tuple[str, int], dict[str, Any]] = {}
     if (
         previous
@@ -339,7 +366,7 @@ def build_posts_index(
         key = (post.get("kind", "issue"), int(post.get("number", 0)))
         sha = post_sha(str(post.get("title", "")), str(post.get("body", "")))
         cached = prev_by_key.get(key)
-        if cached and cached.get("sha") == sha and cached.get("embedding"):
+        if reusable_vector(cached, sha):
             record = dict(cached)
             providers = sorted(
                 {
@@ -368,46 +395,82 @@ def build_posts_index(
             )
 
     if to_embed:
+        # A dead provider costs this run its *new* vectors, not the index. Every
+        # post whose text is unchanged keeps the vector cached above, and the
+        # rest are still written with their text so retrieval that needs no
+        # vector keeps working. `cmd_index` reports the shortfall and still
+        # exits non-zero; leaving no index at all is what left duplicate
+        # detection with nothing to fall back on.
         vectors = embed_texts(embed_targets, token=token)
-        if vectors is None:
-            return None, False
-        for post, vector in zip(to_embed, vectors):
-            records.append(_post_record(post, vector))
+        for i, post in enumerate(to_embed):
+            records.append(_post_record(post, vectors[i] if vectors else None))
 
     changed = bool(to_embed) or metadata_changed or {
         (r.get("kind", "issue"), int(r.get("number", 0))) for r in records
     } != set(prev_by_key)
 
     records.sort(key=lambda r: int(r.get("number", 0)), reverse=True)
+    if changed and previous and previous.get("posts") == records:
+        # A post with no vector is never satisfied by the cache, so `to_embed`
+        # stays non-empty for every night of an outage. Without this the build
+        # would commit an index identical to yesterday's but for its timestamp,
+        # once a night, for as long as the provider stays down.
+        changed = False
+
     index = _empty_posts_index()
     index["posts"] = records
+    index["vectors"] = sum(1 for r in records if r.get("embedding"))
     return index, changed
 
 
 def append_post(
     gh: GitHubClient, post: dict[str, Any], *, token: str
-) -> tuple[dict[str, Any] | None, bool]:
-    """Embed a single new post and upsert it into the posts index."""
+) -> tuple[dict[str, Any], bool]:
+    """Embed a single new post and upsert it into the posts index.
+
+    Returns the index and whether the upserted record carries a vector, so the
+    caller can report a provider outage without having to inspect the record.
+
+    Between nightly builds this is the only path that admits new posts, so it
+    writes the record whether or not a vector could be obtained. Unlike the
+    nightly build there is no cache to fall back on here, so an existing vector
+    for unchanged text is kept rather than overwritten with a vectorless
+    record — a post edited during a provider outage would otherwise lose a good
+    vector it could not get back until the next successful build.
+    """
     previous = load_index(gh, config.POSTS_INDEX_PATH) or _empty_posts_index()
     vector = embed_text(
         f"{post.get('title', '')}\n\n{post.get('body', '')}", token=token
     )
-    if vector is None:
-        return None, False
+    previous_posts = [
+        p for p in previous.get("posts", []) or [] if isinstance(p, dict)
+    ]
     record = _post_record(post, vector)
     key = (record["kind"], record["number"])
+    if vector is None:
+        cached = next(
+            (
+                p
+                for p in previous_posts
+                if (p.get("kind", "issue"), int(p.get("number", 0))) == key
+            ),
+            None,
+        )
+        if reusable_vector(cached, record["sha"]):
+            record["embedding"] = cached["embedding"]
+
     kept = [
         p
-        for p in previous.get("posts", []) or []
-        if isinstance(p, dict)
-        and (p.get("kind", "issue"), int(p.get("number", 0))) != key
+        for p in previous_posts
+        if (p.get("kind", "issue"), int(p.get("number", 0))) != key
     ]
     kept.append(record)
     kept.sort(key=lambda r: int(r.get("number", 0)), reverse=True)
     kept = trim_by_kind(kept)
     index = _empty_posts_index()
     index["posts"] = kept
-    return index, True
+    index["vectors"] = sum(1 for r in kept if r.get("embedding"))
+    return index, bool(record.get("embedding"))
 
 
 def save_index(

--- a/.github/scripts/tests/test_embeddings.py
+++ b/.github/scripts/tests/test_embeddings.py
@@ -205,14 +205,52 @@ def test_build_posts_index_truncates_long_body(monkeypatch):
     assert all(len(t) <= config.MAX_POST_EMBED_CHARS for t in captured["texts"])
 
 
-def test_append_post_skip_on_embed_failure(monkeypatch):
+def test_append_post_writes_the_text_when_embedding_fails(monkeypatch):
     monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
     monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
     gh = FakeGH()
-    index, changed = embeddings.append_post(
+    index, embedded = embeddings.append_post(
         gh, {"kind": "issue", "number": 5, "title": "x", "body": "y"}, token="t"
     )
-    assert index is None and changed is False
+    assert embedded is False
+    record = index["posts"][0]
+    assert record["number"] == 5 and record["excerpt"] == "y"
+    # Absent, never empty: `encode_vec([])` is also "", so an empty string would
+    # merge "the encoder produced nothing" with "we never asked".
+    assert "embedding" not in record
+    assert index["vectors"] == 0
+
+
+def test_append_post_keeps_an_existing_vector_when_embedding_fails(
+    ai_on, monkeypatch
+):
+    """An edit during an outage must not cost a post the vector it already had."""
+    gh = FakeGH()
+    post = {"kind": "issue", "number": 5, "title": "x", "body": "y"}
+    index, embedded = embeddings.append_post(gh, post, token="t")
+    assert embedded is True
+    embeddings.save_index(gh, config.POSTS_INDEX_PATH, index, message="seed")
+
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    index, embedded = embeddings.append_post(gh, post, token="t")
+    assert embedded is True  # carried forward, not re-embedded
+    assert index["posts"][0]["embedding"]
+
+
+def test_append_post_drops_a_stale_vector_when_the_text_changed(ai_on, monkeypatch):
+    """A vector may only travel with the text it was computed from."""
+    gh = FakeGH()
+    index, _ = embeddings.append_post(
+        gh, {"kind": "issue", "number": 5, "title": "x", "body": "y"}, token="t"
+    )
+    embeddings.save_index(gh, config.POSTS_INDEX_PATH, index, message="seed")
+
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    index, embedded = embeddings.append_post(
+        gh, {"kind": "issue", "number": 5, "title": "x", "body": "EDITED"}, token="t"
+    )
+    assert embedded is False
+    assert "embedding" not in index["posts"][0]
 
 
 def test_build_posts_index_refreshes_provider_metadata_without_reembedding(

--- a/.github/scripts/tests/test_index_cmd.py
+++ b/.github/scripts/tests/test_index_cmd.py
@@ -1,5 +1,7 @@
 """Tests for the `index` and `index-append` subcommands."""
 
+import json
+
 from conftest import FakeGH
 from ma_triage import __main__ as main
 from ma_triage import config, embeddings
@@ -63,14 +65,42 @@ def test_cmd_index_fails_when_embeddings_are_unavailable(ai_on, monkeypatch):
     assert config.DOCS_INDEX_PATH not in gh._index_files
 
 
-def test_cmd_index_posts_fails_when_embeddings_are_unavailable(ai_on, monkeypatch):
+def test_cmd_index_posts_fails_but_still_commits_the_text(ai_on, monkeypatch):
+    """The exit code and the artifact answer different questions.
+
+    The run must go red so a dead provider cannot hide behind a green build
+    (the contract this command exists to keep), *and* must still commit the
+    text it has, so retrieval that does not rank on vectors survives the
+    outage. Withholding the artifact is what left the fallback with nothing.
+    """
     _no_embeddings(monkeypatch)
     gh = FakeGH(
         issues=[{"number": 1, "title": "bug", "body": "b", "html_url": "u1",
                  "state": "open", "updated_at": "2024-01-01"}],
     )
     assert main.cmd_index(gh, "t", "posts") == 1
-    assert config.POSTS_INDEX_PATH not in gh._index_files
+    written = json.loads(gh._index_files[config.POSTS_INDEX_PATH])
+    assert written["vectors"] == 0
+    assert [p["number"] for p in written["posts"]] == [1]
+    assert "embedding" not in written["posts"][0]
+
+
+def test_cmd_index_posts_committed_text_is_invisible_to_dense_retrieval(
+    ai_on, monkeypatch
+):
+    """2a must not change what retrieval sees — only what gets written.
+
+    `load_posts` filters vectorless records, so `related_from_index` never
+    ranks them and no weak lexical result can shadow the search fallback until
+    a reader is taught to use them.
+    """
+    _no_embeddings(monkeypatch)
+    gh = FakeGH(
+        issues=[{"number": 1, "title": "bug", "body": "b", "html_url": "u1",
+                 "state": "open", "updated_at": "2024-01-01"}],
+    )
+    main.cmd_index(gh, "t", "posts")
+    assert embeddings.load_posts(gh) == []
 
 
 def test_cmd_index_all_fails_if_either_target_fails(ai_on, monkeypatch):
@@ -99,7 +129,11 @@ def test_cmd_index_append_annotates_but_does_not_fail_triage(ai_on, monkeypatch,
     )
     assert main.cmd_index_append(gh, "t") == 0
     assert "::error::" in capsys.readouterr().err
-    assert config.POSTS_INDEX_PATH not in gh._index_files
+    # Appended anyway: between nightlies this is the only path that admits new
+    # posts, so skipping it would freeze the index for the whole outage.
+    written = json.loads(gh._index_files[config.POSTS_INDEX_PATH])
+    assert [p["number"] for p in written["posts"]] == [123]
+    assert written["vectors"] == 0
 
 
 def test_cmd_index_append(ai_on, monkeypatch):
@@ -150,3 +184,22 @@ def test_collect_posts_excludes_translation_discussions():
     assert ("issue", 1) in keys
     assert ("discussion", 2) in keys
     assert ("discussion", 3) not in keys  # translation category excluded
+
+
+def test_cmd_index_posts_does_not_recommit_an_unchanged_outage_index(
+    ai_on, monkeypatch
+):
+    """A long outage must not commit a new timestamp over identical records.
+
+    A vectorless post is never satisfied by the sha cache, so every night of an
+    outage re-enters it into `to_embed` and would otherwise look like a change.
+    """
+    _no_embeddings(monkeypatch)
+    gh = FakeGH(
+        issues=[{"number": 1, "title": "bug", "body": "b", "html_url": "u1",
+                 "state": "open", "updated_at": "2024-01-01"}],
+    )
+    assert main.cmd_index(gh, "t", "posts") == 1
+    assert _commit_count(gh, config.POSTS_INDEX_PATH) == 1
+    assert main.cmd_index(gh, "t", "posts") == 1
+    assert _commit_count(gh, config.POSTS_INDEX_PATH) == 1


### PR DESCRIPTION
## Why

`build_posts_index` returned `None` as soon as `embed_texts` failed, so a provider outage produced **no index at all** — not even the text half. That is why #6096's fallback had nothing to fall back on: the artifact it needed was never written.

This is the writer-side half of making duplicate detection survive an outage. It changes only what gets committed, not what anything reads.

## What changes

* `embeddings.build_posts_index` always returns an index. Records are written whether or not a vector could be obtained, and `index["vectors"]` reports how many carry one.
* `embeddings.append_post` gets the same treatment — between nightly builds it is the only path that admits new posts, so skipping it would freeze the index for the whole outage. It has no sha cache to fall back on, so it carries an existing vector forward when the text is unchanged, rather than replacing a good vector with a vectorless record for a post edited mid-outage.
* `_post_record` omits the `embedding` key rather than writing it empty. `encode_vec([])` also produces `""`, so an empty string would merge "the encoder produced nothing" with "we never asked".
* `cmd_index` still exits non-zero. A post can only lack a vector because the provider refused one, so a shortfall against the post count is the failure signal, and the annotation now says how many records are affected rather than describing the index as wholly stale.

## The contract this preserves

#6095 exists so a dead provider cannot hide behind a green nightly build. That is untouched: the run still goes red and still annotates.

What changes is that the exit code and the artifact now answer different questions. The code reports that vectors are missing; the artifact keeps the text those posts do have. Committing nothing on failure is precisely what left duplicate detection with no fallback, so `cmd_index`'s docstring records the reasoning to stop it being "simplified" back.

There is a regression test for exactly this: `test_cmd_index_posts_fails_but_still_commits_the_text` asserts both halves at once.

## Read-neutral by design

`load_posts` already filters on the `embedding` key, so vectorless records never reach `related_from_index`, and `find_related`'s `if posts and query_vec` guard is unaffected. Nothing that reads the index behaves differently — `test_cmd_index_posts_committed_text_is_invisible_to_dense_retrieval` pins that.

This matters because a follow-up will teach a reader to rank on those records. Doing it in this PR would risk a weak lexical result shadowing the GitHub search fallback, which currently queries the whole repo live. Splitting the writer from the reader keeps that impossible for now.

## Self-healing

The cache branch requires `cached.get("embedding")`, so a vectorless record fails it and re-enters `to_embed` on the next build. The first successful run after a provider returns re-embeds the accumulated backlog automatically — no migration, no backfill command.

The header keeps writing `model` and `dim` from config for the same reason: `load_posts` discards the whole index on a mismatch, so blanking them would throw away the vectors that *were* carried forward and force a full re-embed instead of a backlog-sized one.

## Behaviour during a long outage

Vectorless records are never satisfied by the sha cache, so `to_embed` stays non-empty every night. Without a guard the build would commit an index identical to yesterday's but for its timestamp, once a night, for as long as the provider stayed down. `changed` is now suppressed when the records are byte-identical to the previous index; `test_cmd_index_posts_does_not_recommit_an_unchanged_outage_index` covers it.

## Known limitation

A post *edited* during an outage loses its vector, because a vector may only travel with the text it was computed from — the sha check that guarantees that is the same one that prevents carrying the old one forward. Keeping it would need `sha` split into a separate `embed_sha`, which is a schema-shaped change for a narrow case. The record's text is still indexed and it self-heals on the next successful build. `test_append_post_drops_a_stale_vector_when_the_text_changed` documents the choice.

## Not in this PR

* The docs index has the identical shape at `build_docs_index`. It is left alone deliberately: `load_docs_chunks` also filters on `embedding`, so a partial docs index would be inert until that reader changes. It should land together with its reader.
* `"dim"` being written from config rather than from the observed vector width. Fixing it changes the recorded header value, which trips the mismatch guard and forces a full re-embed — worth doing deliberately, on its own, while the provider is healthy.
* `append_post` does not validate `previous`'s schema/model/dim before merging, unlike `build_posts_index`. Pre-existing and unrelated, but worth a follow-up now that this PR widens the variety of record shapes it merges.

## Testing

`272 passed` locally. No workflow runs the suite, so this is not CI-verified.
