### PR TITLE
Rank the index text when no query embedding is available

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -94,8 +94,15 @@ The live bot adds a **retrieval-augmented** layer on top of the analysis:
   judge call that returns `{answers_question, confidence, answer, cited_sections}`.
 - **Similar past reports.** The issue embedding is compared (dense cosine) to an
   index of past issues + discussions to surface likely duplicates / prior answers.
-  When a provider is known, candidates must match that provider exactly; weak
-  matches stay collapsed, while only strong matches render expanded. Pinned
+  When the embedding is unavailable the same index is ranked lexically instead
+  (BM25F over the stored title + excerpt), and only when no index is readable at
+  all does it fall back to GitHub's issue search. When a provider is known,
+  candidates must match that provider exactly — except on the search path, which
+  cannot be scoped and is therefore skipped entirely for provider-specific
+  reports. Weak matches stay collapsed, and only a strong *dense* match renders
+  expanded: BM25 scores are corpus-relative, so a lexical hit is never treated
+  as an assertion of duplication.
+  Pinned
   support notices that mention the provider are surfaced separately and Feature
   Polls are ignored. Translation-category discussions are excluded from the
   index. New/edited Discussions use the same RAG path when

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -315,6 +315,7 @@ def apply_triage(
                 "judge_conf": result.rag.judge_confidence,
                 "judge_answered": result.rag.judge_answered,
                 "scores": [p.score for p in result.rag.related_posts],
+                "sources": [p.source for p in result.rag.related_posts],
             }
         body = comment.build_body(result)
         comment.upsert(gh, number, body, state)
@@ -640,6 +641,7 @@ def cmd_discussion(gh: GitHubClient, token: str) -> int:
             "judge_conf": rag_result.judge_confidence,
             "judge_answered": rag_result.judge_answered,
             "scores": [p.score for p in rag_result.related_posts],
+            "sources": [p.source for p in rag_result.related_posts],
         },
     }
     comment.upsert_discussion(

--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -187,9 +187,17 @@ def _assessment_evidence(
     if rag_result is not None and rag_result.related_posts:
         lines = []
         for post in rag_result.related_posts[:3]:
+            # Only a dense match has a similarity to report. Lexical and
+            # search hits carry 0.0 by construction, and printing that would
+            # tell the model the best available match is maximally dissimilar.
+            how = (
+                f"similarity {post.score:.4f}"
+                if post.source == "dense"
+                else f"match={post.source}"
+            )
             lines.append(
                 f"- RELATED #{post.number}: {inline(post.title, max_len=180)} "
-                f"(similarity {post.score:.4f}, state={inline(post.state)})\n"
+                f"({how}, state={inline(post.state)})\n"
                 f"{fenced(post.excerpt, max_len=500)}"
             )
         parts.append("PROVIDER-MATCHED REPORTS (not necessarily duplicates):\n" + "\n".join(lines))

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -311,7 +311,11 @@ def _render_rag(rag: RagResult | None) -> str:
     if rag.related_posts and rag.duplicates_only:
         parts.extend(_render_duplicates(rag.related_posts))
     elif rag.related_posts:
-        if max(post.score for post in rag.related_posts) >= config.RELATED_EXPAND_SCORE:
+        # Only a dense cosine can justify expanding. Sources never mix within
+        # one result set — `find_related` picks a single path — so the full
+        # list is rendered either way once that decision is made.
+        dense = [post for post in rag.related_posts if post.source == "dense"]
+        if dense and max(post.score for post in dense) >= config.RELATED_EXPAND_SCORE:
             parts.append("\n" + config.RELATED_POSTS_HEADING)
             parts.append(config.RELATED_POSTS_INTRO)
             parts.extend(_post_link(post) for post in rag.related_posts)

--- a/.github/scripts/ma_triage/embeddings.py
+++ b/.github/scripts/ma_triage/embeddings.py
@@ -170,6 +170,50 @@ def load_posts(gh: GitHubClient) -> list[dict[str, Any]]:
     return [p for p in posts if isinstance(p, dict) and p.get("embedding")] if isinstance(posts, list) else []
 
 
+# Schema versions whose *text* layout this code understands. `_SCHEMA` tracks
+# how a vector is encoded (2 = base64 int8), which is irrelevant to a reader
+# that never looks at one — but it is enumerated rather than ignored, so a
+# future layout change to the record itself still has to be considered here
+# instead of being silently accepted.
+_TEXT_COMPATIBLE_SCHEMAS = (1, 2)
+
+
+def load_posts_text(gh: GitHubClient) -> list[dict[str, Any]]:
+    """Load ``posts.json`` records for retrieval that ranks on text alone.
+
+    Unlike :func:`load_posts` this ignores ``model`` and ``dim``: those guard
+    vector compatibility, and a reader that scores tokens does not care which
+    embedder produced a file it will not read vectors from. It also keeps
+    records that have no vector at all, which is the whole point — those are
+    the posts indexed while the provider was unavailable.
+
+    ``embedding`` is stripped from every record returned. A schema-1 record
+    holds a raw float list rather than base64, and :func:`retrieval.decode_vec`
+    raises on that by design; letting one through would put a hard failure
+    inside the path that exists to survive failure.
+
+    Schema-1 records may predate ``excerpt``. Those still rank, on their title
+    alone — worse, but not a failure.
+    """
+    index = load_index(gh, config.POSTS_INDEX_PATH)
+    if not index:
+        return []
+    if index.get("schema") not in _TEXT_COMPATIBLE_SCHEMAS:
+        log(
+            f"Posts index schema {index.get('schema')} has no known text layout; "
+            "ignoring index"
+        )
+        return []
+    posts = index.get("posts")
+    if not isinstance(posts, list):
+        return []
+    return [
+        {key: value for key, value in post.items() if key != "embedding"}
+        for post in posts
+        if isinstance(post, dict)
+    ]
+
+
 def load_suppress(gh: GitHubClient) -> list[dict[str, Any]]:
     """Load the downvoted-answer fingerprints from ``suppress.json``."""
     index = load_index(gh, config.SUPPRESS_INDEX_PATH)

--- a/.github/scripts/ma_triage/models.py
+++ b/.github/scripts/ma_triage/models.py
@@ -166,15 +166,25 @@ class DocAnswer:
 
 @dataclass
 class RelatedPost:
-    """A similar past issue or discussion surfaced from the posts index."""
+    """A similar past issue or discussion surfaced from the posts index.
+
+    ``source`` records how the match was made, because callers must treat the
+    four differently and ``score`` cannot tell them apart. Only a dense cosine
+    is a bounded, corpus-independent number; BM25 is neither, so a lexical or
+    keyword-search hit carries ``0.0``. A pinned notice carries ``1.0`` from an
+    exact provider-name match, which is not a similarity at all. Renderers
+    branch on ``source`` rather than inferring provenance from a float that
+    means four different things depending on where it came from.
+    """
 
     kind: str  # "issue" | "discussion"
     number: int
     title: str
     url: str
-    score: float = 0.0
+    score: float = 0.0  # only comparable within one ``source``
     state: str | None = None  # "open" | "closed"
     excerpt: str = ""
+    source: str = "dense"  # "dense" | "lexical" | "search" | "pinned"
 
 
 @dataclass

--- a/.github/scripts/ma_triage/rag.py
+++ b/.github/scripts/ma_triage/rag.py
@@ -189,12 +189,14 @@ def answer(
 
         # Related posts are independent of the docs tier (dupes may post even
         # when the docs answer is LOW).
-        posts = embeddings.load_posts(gh)
+        posts = embeddings.load_posts(gh) if query_vec else []
         related = similar.find_related(
             gh,
             query_vec=query_vec,
             title=title,
+            body=body,
             posts=posts,
+            text_posts=embeddings.load_posts_text(gh) if not posts else None,
             exclude_number=number,
             exclude_kind=kind,
             provider_labels=provider_labels,
@@ -202,10 +204,15 @@ def answer(
         if duplicates_only:
             # Only likely duplicates justify commenting on these categories, so
             # apply the same bar the comment uses to render a match expanded.
+            # Only a dense cosine can clear this bar. A lexical or search hit
+            # carries 0.0 by construction, so the `source` check is what makes
+            # the intent explicit rather than leaving it to a sentinel: nothing
+            # but semantic similarity may assert a duplicate on its own.
             related = [
                 post
                 for post in related
-                if post.score >= config.RELATED_EXPAND_SCORE
+                if post.source == "dense"
+                and post.score >= config.RELATED_EXPAND_SCORE
             ]
 
         result = RagResult(

--- a/.github/scripts/ma_triage/retrieval.py
+++ b/.github/scripts/ma_triage/retrieval.py
@@ -1,4 +1,4 @@
-"""Local hybrid retrieval — dense cosine + BM25, fused with RRF.
+"""Local hybrid retrieval — dense cosine + BM25/BM25F, fused with RRF.
 
 No model cost: the incoming post is embedded **once** by the caller; everything
 here is pure Python over the in-memory index (a few thousand vectors at most, so
@@ -83,8 +83,11 @@ def decode_vec(raw: str | None) -> list[float]:
     invisible. Callers that must not fail hard already degrade at a higher
     level (see :func:`rag.answer`).
 
-    Indexes written by an older schema are rejected wholesale at load time
-    (``embeddings._SCHEMA``), so this never has to interpret a legacy format.
+    Indexes written by an older schema are rejected wholesale by the vector
+    load path (``embeddings._SCHEMA``), so this never has to interpret a legacy
+    format. :func:`embeddings.load_posts_text` accepts older schemas for their
+    text, and strips ``embedding`` from what it returns precisely so nothing it
+    hands out can reach here.
     """
     if raw is None or raw == "":
         return []
@@ -163,6 +166,67 @@ def rank_by_bm25(query_tokens: list[str], docs_tokens: list[list[str]]) -> list[
     scores = bm25_scores(query_tokens, docs_tokens)
     order = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
     return [i for i in order if scores[i] > 0.0]
+
+
+def bm25f_scores(
+    query_tokens: list[str],
+    fields: dict[str, list[list[str]]],
+    weights: dict[str, float],
+) -> list[float]:
+    """Fielded BM25 (BM25F) over documents split into named fields.
+
+    Each field is length-normalised against its own average before the weights
+    apply, so a short title keeps its pull against a long body instead of being
+    swamped by it. That is what separates this from scoring a concatenation
+    with the title repeated: field weight 2, 3 and 5 all measured the same,
+    because the normalisation — not the multiplier — is doing the work.
+
+    Saturation is applied once to the combined weighted frequency rather than
+    per field, which is what makes that claim true; summing per-field BM25
+    would not. :func:`bm25_scores` is the single-field, weight-1 case up to a
+    constant factor — kept separate because merging them would rewrite the docs
+    retrieval path for no gain here.
+
+    Every field must supply one token list per document.
+    """
+    names = [name for name in fields if fields[name]]
+    if not names or not query_tokens:
+        n = next((len(docs) for docs in fields.values() if docs), 0)
+        return [0.0] * n
+
+    n = len(fields[names[0]])
+    counts = {name: [Counter(doc) for doc in fields[name]] for name in names}
+    norm: dict[str, list[float]] = {}
+    for name in names:
+        lengths = [sum(c.values()) for c in counts[name]]
+        avg = sum(lengths) / n if n else 0.0
+        norm[name] = [
+            1 - config.BM25_B + config.BM25_B * (length / avg if avg else 0.0)
+            for length in lengths
+        ]
+
+    df: Counter[str] = Counter()
+    for i in range(n):
+        seen: set[str] = set()
+        for name in names:
+            seen |= set(counts[name][i])
+        df.update(seen)
+
+    scores = [0.0] * n
+    for term in set(query_tokens):
+        n_qi = df.get(term, 0)
+        if not n_qi:
+            continue
+        idf = math.log(1 + (n - n_qi + 0.5) / (n_qi + 0.5))
+        for i in range(n):
+            weighted = 0.0
+            for name in names:
+                freq = counts[name][i].get(term, 0)
+                if freq:
+                    weighted += weights.get(name, 1.0) * freq / norm[name][i]
+            if weighted:
+                scores[i] += idf * weighted / (config.BM25_K1 + weighted)
+    return scores
 
 
 def rrf(rank_lists: list[list[int]], *, k: int | None = None) -> dict[int, float]:

--- a/.github/scripts/ma_triage/similar.py
+++ b/.github/scripts/ma_triage/similar.py
@@ -6,9 +6,10 @@ duplicate. Two paths:
 
 * **primary** — dense cosine over the ``posts.json`` embeddings index (semantic,
   free, catches rewordings),
-* **fallback** — when the index is absent/empty *or the query embedding is
-  unavailable*, degrade gracefully to GitHub's own issue search over the
-  report's title keywords.
+* **lexical** — BM25F over the title and excerpt the same index stores, for when
+  the query embedding is unavailable but the index text is still readable,
+* **last resort** — GitHub's own issue search over the report's title keywords,
+  when there is no readable index at all.
 
 The incoming post's own number is always excluded, and results are de-duplicated
 and thresholded so the comment only ever shows genuinely-relevant links.
@@ -22,7 +23,7 @@ from . import config
 from .gh import GitHubClient, log
 from .models import RelatedPost
 from .providers import detect_provider_labels_from_text
-from .retrieval import cosine, decode_vec
+from .retrieval import bm25f_scores, cosine, decode_vec, tokenize
 
 _RE_WORD = re.compile(r"[A-Za-z0-9]+")
 
@@ -92,6 +93,91 @@ def related_from_index(
     return results
 
 
+def related_from_lexical(
+    query_title: str,
+    query_body: str,
+    posts: list[dict],
+    *,
+    exclude_number: int,
+    exclude_kind: str = "issue",
+    provider_labels: set[str] | None = None,
+    k: int | None = None,
+) -> list[RelatedPost]:
+    """BM25F related posts from the index text, with no embedding involved.
+
+    Ranked on the same ``title`` + ``excerpt`` the index already stores, so this
+    works against a file built while the embeddings provider was down. Recall@3
+    over the mined duplicate pairs is 29% on 34 strong pairs and 28% on 110 weak
+    ones, against 21% for the GitHub keyword search it displaces — but the
+    reason to prefer it is reach, not ranking: the search path cannot be
+    filtered by provider, so it is skipped entirely for the 56% of reports that
+    name one.
+
+    Results carry ``score=0.0``. BM25 is unbounded and corpus-relative, so its
+    value is not comparable to the cosine every other consumer of that field
+    expects; ``source`` is what callers branch on.
+
+    There is deliberately no score threshold here. Measured against hard
+    negatives — the other candidates returned for a query whose true duplicate
+    is known — a raw BM25F score barely separates them (AUC 0.62), as an
+    unbounded cross-query score should be expected not to. The best feature
+    found was the top hit's lead over the runner-up (AUC 0.76), and gating on
+    it at 1.10 lifts precision on that top hit from 21% to 42%. That is enough
+    for a collapsed suggestion and not enough to assert a duplicate, which is
+    why these never render expanded and why no constant is exposed.
+    """
+    top_k = config.RELATED_POSTS if k is None else k
+    if not posts:
+        return []
+    required_providers = _provider_keys(provider_labels)
+
+    candidates: list[dict] = []
+    seen: set[tuple[str, int]] = set()
+    for post in posts:
+        number = int(post.get("number", 0))
+        kind = post.get("kind", "issue")
+        if kind == exclude_kind and number == exclude_number:
+            continue
+        if required_providers and not (required_providers & _post_provider_keys(post)):
+            continue
+        key = (kind, number)
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append(post)
+    if not candidates:
+        return []
+
+    titles = [tokenize(post.get("title")) for post in candidates]
+    bodies = [tokenize(post.get("excerpt")) for post in candidates]
+    query = tokenize(f"{query_title}\n\n{query_body}")
+    scores = bm25f_scores(
+        query,
+        {"title": titles, "body": bodies},
+        # Title weighted over body. 2, 3 and 5 all measured identically over 110
+        # mined pairs, so this is the middle of a flat region rather than a tuned
+        # optimum — BM25F's per-field length normalisation is doing the work.
+        {"title": 3.0, "body": 1.0},
+    )
+    ranked = sorted(
+        (i for i, score in enumerate(scores) if score > 0.0),
+        key=lambda i: -scores[i],
+    )[:top_k]
+    return [
+        RelatedPost(
+            kind=candidates[i].get("kind", "issue"),
+            number=int(candidates[i].get("number", 0)),
+            title=str(candidates[i].get("title", "")),
+            url=str(candidates[i].get("url", "")),
+            score=0.0,
+            state=candidates[i].get("state"),
+            excerpt=str(candidates[i].get("excerpt", "")),
+            source="lexical",
+        )
+        for i in ranked
+    ]
+
+
 def _title_query(title: str) -> str:
     """Reduce a (untrusted) title to plain keywords for a search query."""
     words = _RE_WORD.findall(title or "")
@@ -134,6 +220,7 @@ def related_from_search(
                 score=0.0,
                 state=item.get("state"),
                 excerpt=str(item.get("body", ""))[: config.RELATED_EXCERPT_CHARS],
+                source="search",
             )
         )
         if len(results) >= top_k:
@@ -148,10 +235,22 @@ def find_related(
     title: str,
     posts: list[dict],
     exclude_number: int,
+    body: str = "",
+    text_posts: list[dict] | None = None,
     exclude_kind: str = "issue",
     provider_labels: set[str] | None = None,
 ) -> list[RelatedPost]:
-    """Related posts from the index when available, else the search fallback."""
+    """Related posts, in descending order of what the available inputs support.
+
+    Dense cosine when there is a query vector and vectors to compare it to,
+    BM25F over the index text when there is not, and GitHub's issue search only
+    when there is no readable index at all.
+
+    The choice is made once for the whole request, not per record: a partially
+    vectorless index (what a build during a provider outage produces) still
+    takes the dense path, and its vectorless records are simply not candidates.
+    Ranking the two together is fusion, which is a separate change.
+    """
     if posts and query_vec:
         # The index is usable, so its verdict stands — including a verdict of
         # "nothing scored highly enough". Falling through to the keyword search
@@ -159,6 +258,18 @@ def find_related(
         return related_from_index(
             query_vec,
             posts,
+            exclude_number=exclude_number,
+            exclude_kind=exclude_kind,
+            provider_labels=provider_labels,
+        )
+    if text_posts:
+        # No vector, but the index text is readable — and unlike the search
+        # below it can be filtered by provider, so this runs for every report
+        # rather than only the ones naming no provider.
+        return related_from_lexical(
+            title,
+            body,
+            text_posts,
             exclude_number=exclude_number,
             exclude_kind=exclude_kind,
             provider_labels=provider_labels,
@@ -208,6 +319,7 @@ def find_pinned(
                 url=str(discussion.get("url", "")),
                 score=1.0,
                 state="closed" if discussion.get("closed") else "open",
+                source="pinned",
                 excerpt=str(discussion.get("body", ""))[
                     : config.RELATED_EXCERPT_CHARS
                 ],

--- a/.github/scripts/tests/test_comment_rag.py
+++ b/.github/scripts/tests/test_comment_rag.py
@@ -176,3 +176,23 @@ def test_judge_answer_cannot_publish_markdown_or_bare_links():
     assert (
         "](https://www.music-assistant.io/faq/net/#mdns)" in body
     )
+
+
+def test_build_body_never_expands_a_lexical_match():
+    """Only a dense cosine may assert a duplicate.
+
+    Measured over the mined pairs, the best available gate on a lexical top hit
+    reaches ~40% precision — fine for a collapsed suggestion, not enough to
+    claim a duplicate in an expanded block on someone's issue.
+    """
+    rag = RagResult(
+        tier="low",
+        related_posts=[
+            RelatedPost("issue", 7, "playback stops", "https://x/7",
+                        score=0.0, source="lexical")
+        ],
+    )
+    body = comment.build_body(TriageResult(form_kind="main", rag=rag))
+    assert config.RELATED_POSTS_WEAK_SUMMARY in body
+    assert config.RELATED_POSTS_HEADING not in body
+    assert "#7: playback stops" in body

--- a/.github/scripts/tests/test_embeddings.py
+++ b/.github/scripts/tests/test_embeddings.py
@@ -281,3 +281,51 @@ def test_build_posts_index_refreshes_provider_metadata_without_reembedding(
     assert calls == []
     assert updated["posts"][0]["providers"] == ["subsonic"]
     assert updated["posts"][0]["excerpt"] == "404"
+
+
+# --- text-only loading (schema-tolerant, vector-free) ------------------------ #
+def test_load_posts_text_accepts_a_legacy_schema_and_strips_vectors():
+    """Schema 1 stored raw float lists, which `decode_vec` raises on by design.
+
+    The text loader accepts those records for their text and removes the key,
+    so nothing it returns can reach the decoder — a hard failure inside the
+    path that exists to survive failure is the thing being avoided.
+    """
+    legacy = {"schema": 1, "model": "other/model", "dim": 999, "posts": [
+        {"kind": "issue", "number": 1, "title": "sonos", "excerpt": "e",
+         "embedding": [0.1, 0.2, 0.3]}]}
+    gh = FakeGH(index_files={config.POSTS_INDEX_PATH: json.dumps(legacy)})
+    posts = embeddings.load_posts_text(gh)
+    assert [p["number"] for p in posts] == [1]
+    assert "embedding" not in posts[0]
+    # The vector path still rejects it, unchanged.
+    assert embeddings.load_posts(gh) == []
+
+
+def test_load_posts_text_keeps_records_with_no_vector(monkeypatch):
+    """Posts indexed during an outage are exactly what this loader is for."""
+    monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    gh = FakeGH()
+    index, _ = embeddings.append_post(
+        gh, {"kind": "issue", "number": 5, "title": "x", "body": "y"}, token="t"
+    )
+    embeddings.save_index(gh, config.POSTS_INDEX_PATH, index, message="m")
+    assert [p["number"] for p in embeddings.load_posts_text(gh)] == [5]
+    assert embeddings.load_posts(gh) == []
+
+
+def test_load_posts_text_rejects_an_unknown_schema():
+    future = {"schema": 99, "posts": [{"kind": "issue", "number": 1, "title": "t"}]}
+    gh = FakeGH(index_files={config.POSTS_INDEX_PATH: json.dumps(future)})
+    assert embeddings.load_posts_text(gh) == []
+
+
+def test_current_schema_has_a_known_text_layout():
+    """Bumping `_SCHEMA` must be a decision about the text loader too.
+
+    The lexical fallback reads the index through `_TEXT_COMPATIBLE_SCHEMAS`. If
+    a bump forgets that list, the fallback goes silent at exactly the moment it
+    is the only path left.
+    """
+    assert embeddings._SCHEMA in embeddings._TEXT_COMPATIBLE_SCHEMAS

--- a/.github/scripts/tests/test_rag.py
+++ b/.github/scripts/tests/test_rag.py
@@ -72,12 +72,21 @@ def test_answer_returns_none_when_nothing_to_show(ai_on):
     assert rag.answer(gh, title="random topic", body="text", number=1, token="t") is None
 
 
-def test_answer_none_on_embed_failure(ai_on, monkeypatch):
-    # No search items either, so the fallback finds nothing and the result
-    # stays None — see the test below for the case where it does find one.
+def test_answer_ranks_the_index_text_when_embedding_fails(ai_on, monkeypatch):
+    """No vector, but the index text is readable — so BM25F, not GitHub search.
+
+    This is the case the search fallback could never serve well: it needs no
+    network call and, unlike search, can be filtered by provider.
+    """
     monkeypatch.setattr(embeddings, "embed_text", lambda text, *, token: None)
     gh = _gh_with_indexes()
-    assert rag.answer(gh, title="sonos mdns", body="", number=1, token="t") is None
+    result = rag.answer(gh, title="sonos mdns", body="", number=1, token="t")
+    assert result is not None
+    assert [post.number for post in result.related_posts] == [50]
+    assert result.related_posts[0].source == "lexical"
+    # BM25 is unbounded and corpus-relative, so it must not reach the field
+    # every other consumer reads as a cosine.
+    assert result.related_posts[0].score == 0.0
 
 
 def test_answer_still_finds_related_posts_on_embed_failure(ai_on, monkeypatch):

--- a/.github/scripts/tests/test_retrieval.py
+++ b/.github/scripts/tests/test_retrieval.py
@@ -115,3 +115,40 @@ def test_retrieve_docs_cap_never_returns_fewer_than_available(monkeypatch):
 
 def test_retrieve_docs_empty():
     assert retrieval.retrieve_docs([1.0], "q", []) == []
+
+
+# --- BM25F ------------------------------------------------------------------ #
+def test_bm25f_keeps_a_short_title_from_being_swamped_by_a_long_body():
+    """The claim that earns BM25F its place over a weighted concatenation.
+
+    Both documents mention the term once. The first says it in a two-word
+    title; the second buries it in a long body. Per-field length normalisation
+    is what puts the first ahead.
+    """
+    titles = [retrieval.tokenize("sonos grouping"), retrieval.tokenize("unrelated")]
+    bodies = [
+        retrieval.tokenize("nothing to see here"),
+        retrieval.tokenize("padding " * 200 + "grouping"),
+    ]
+    scores = retrieval.bm25f_scores(
+        retrieval.tokenize("grouping"),
+        {"title": titles, "body": bodies},
+        {"title": 3.0, "body": 1.0},
+    )
+    assert scores[0] > scores[1]
+
+
+def test_bm25f_returns_one_score_per_document_for_an_empty_query():
+    """The contract holds even when the first field is the empty one."""
+    scores = retrieval.bm25f_scores(
+        [], {"title": [], "body": [["a"], ["b"], ["c"]]}, {"title": 1.0}
+    )
+    assert scores == [0.0, 0.0, 0.0]
+
+
+def test_bm25f_ignores_a_term_no_document_carries():
+    titles = [retrieval.tokenize("alpha"), retrieval.tokenize("beta")]
+    scores = retrieval.bm25f_scores(
+        retrieval.tokenize("gamma"), {"title": titles}, {"title": 1.0}
+    )
+    assert scores == [0.0, 0.0]

--- a/.github/scripts/tests/test_similar.py
+++ b/.github/scripts/tests/test_similar.py
@@ -193,3 +193,59 @@ def test_find_pinned_skips_catch_all_status_notice():
         ]
     )
     assert similar.find_pinned(gh, {"spotify"}) == []
+
+
+# --- lexical (BM25F over the index text, no embedding involved) -------------- #
+def _text_post(number, title, excerpt="", providers=None):
+    return {"kind": "issue", "number": number, "title": title,
+            "url": f"https://x/{number}", "state": "open", "excerpt": excerpt,
+            "providers": providers or []}
+
+
+def test_related_from_lexical_ranks_on_shared_wording():
+    posts = [
+        _text_post(1, "sonos players stop after a while", "playback stops"),
+        _text_post(2, "spotify login loop", "cannot authenticate"),
+    ]
+    hits = similar.related_from_lexical(
+        "sonos players stop", "playback stops after a while", posts,
+        exclude_number=99,
+    )
+    assert [h.number for h in hits] == [1]
+    assert hits[0].source == "lexical" and hits[0].score == 0.0
+
+
+def test_related_from_lexical_applies_the_provider_filter():
+    """The reason to prefer this over GitHub search: it can be scoped.
+
+    `related_from_search` cannot filter by provider, which is why a report
+    naming one gets nothing from it at all.
+    """
+    posts = [
+        _text_post(1, "playback stops", "stops", providers=["Chromecast"]),
+        _text_post(2, "playback stops", "stops", providers=["Deezer"]),
+    ]
+    hits = similar.related_from_lexical(
+        "playback stops", "stops", posts, exclude_number=99,
+        provider_labels={"deezer"},
+    )
+    assert [h.number for h in hits] == [2]
+
+
+def test_related_from_lexical_excludes_self():
+    posts = [_text_post(7, "sonos grouping", "grouping fails")]
+    assert similar.related_from_lexical(
+        "sonos grouping", "grouping fails", posts, exclude_number=7
+    ) == []
+
+
+def test_find_related_prefers_lexical_over_search_without_a_vector(fake_gh):
+    fake_gh._search_items = [
+        {"number": 42, "title": "from search", "html_url": "u42", "state": "open"}
+    ]
+    hits = similar.find_related(
+        fake_gh, query_vec=None, title="sonos grouping", body="grouping fails",
+        posts=[], text_posts=[_text_post(8, "sonos grouping", "grouping fails")],
+        exclude_number=99,
+    )
+    assert [h.number for h in hits] == [8]  # not 42


### PR DESCRIPTION
## Why

Duplicate detection had two states: dense cosine, or GitHub's issue search. There was nothing in between, and the gap matters — the search cannot be scoped to a provider, so `find_related` skips it entirely for any report that names one. That is **56% of issues** in a 2000-issue sample (65% of confirmed duplicate pairs). During an embeddings outage those reports get nothing at all.

#6098 made the index buildable without a provider. This teaches a reader to use it.

## What changes

* `retrieval.py` gains `bm25f_scores`, beside the `bm25_scores`/`rrf` the docs path already uses. Fielded BM25 length-normalises each field against its own average, so a short title keeps its pull against a long body. Not a new module: `retrieval.py`'s docstring already claims ownership of local ranking, and a second BM25 implementation would be duplicated logic.
* `embeddings.load_posts_text` reads the index for retrieval that ranks on text. It ignores `model`/`dim` — those guard *vector* compatibility, which a token-scoring reader does not care about — and keeps records with no vector, which is the point. Schema versions are enumerated in `_TEXT_COMPATIBLE_SCHEMAS` rather than ignored, so a future record-layout change still has to be considered.
* `similar.related_from_lexical` ranks the stored `title` + `excerpt`, reusing the existing `_provider_keys`/`_post_provider_keys` filter.
* `find_related` now degrades dense → lexical → search.
* `rag.py` supplies the index text when there is no vector; `comment.py` and `rag.py`'s duplicates-only gate branch on provenance.
* `ai.py`'s assessment evidence no longer prints `similarity 0.0000` for a non-dense match. It rendered every related post's score as a similarity, so a lexical hit would have told the assessment model that the best available match was maximally dissimilar — latent for the search path, but this change makes it the common case.
* `find_pinned` results carry `source="pinned"`. They score `1.0` from an exact provider-name match, which is not a similarity, and that would have been the next thing to trip over a `source == "dense"` check.
* The sticky state block persists `sources` alongside `scores`, so a lexical run stays distinguishable after the fact from a dense run that scored zero.

## Measured

Recall@3 over the mined duplicate pairs, run through the **shipped** `related_from_lexical` rather than a prototype:

| path | strong (n=34) | weak (n=110) |
| --- | --- | --- |
| GitHub keyword search (what it displaces) | 21% | — |
| **BM25F over title + excerpt** | **29%** | **28%** |
| dense cosine, for reference | 38% | 43% |

Field weight is not tuned: 2, 3 and 5 measured identically, so 3.0 sits in the middle of a flat region — the per-field length normalisation is doing the work, not the multiplier.

Bigrams were tried and **dropped**. They looked like a clear win over the full body (29% → 36% weak), but over the 1200-char excerpt the index actually stores they are a wash: +3 points on the 34-pair strong set, −3 on the better-powered 110-pair weak set. Not worth the extra representation, and worth revisiting only alongside the excerpt-size decision below.

**The caveat, up front:** 34 strong pairs means a few points is one or two pairs. The 110-pair weak set is the better-powered check and moves the same way. And recall@3 measures neither of the two things that actually motivate this — availability and provider coverage — so the 21% → 29% delta is not the argument. The argument is that the 56% of reports naming a provider go from nothing to something.

## Why lexical hits never render expanded

`RelatedPost` gains `source`. BM25 is unbounded and corpus-relative, so its value cannot go in `score`, which is read as a cosine in four places — most sharply `rag.py`'s duplicates-only gate, where it is the only check. Lexical hits carry `0.0` and callers branch on `source` instead of inferring provenance from a float that would otherwise mean four different things.

Whether a lexical hit could ever be *expanded* was measured rather than assumed. Two gate designs were tested against hard negatives (the other candidates from the same result lists, so they cannot be secretly positive):

* raw BM25F score: AUC 0.62 — as the IR literature predicts, cross-query scores are not comparable
* lead over the runner-up (`score[0]/score[1]`): AUC 0.76, the best single feature

Gating on lead ≥ 1.10 roughly doubles precision on the top hit, from 21% to **42%**. That is a fine bar for a collapsed suggestion and not enough to assert a duplicate in an expanded block on someone's issue, so lexical hits stay collapsed. The ratio is recorded here rather than implemented; if fusion with dense retrieval lifts precision later, `source` is the branch point that makes revisiting it a one-line change.

## Behaviour

**Vector present: unchanged.** Dense cosine, same thresholds, same rendering.

**Vector missing, index readable:** BM25F over the index text, provider filter applied, results collapsed under "Possibly related past reports". No network call.

**No readable index:** the GitHub search fallback, exactly as before, still skipped for provider-specific reports.

RAG runs live in this repo with `TRIAGE_DRY_RUN=false`, so this changes real comment output during an outage — it adds a collapsed weak-match block where reports naming a provider previously got nothing. `TRIAGE_RAG_ENABLED` remains the kill switch; no new flag.

## Not in this PR

* RRF fusion of lexical and dense. Measured at 47% strong recall against 38% for dense alone, but the fusion weighting should be tuned against whichever embedder actually gets deployed, not a reference one.
* Raising `RELATED_EXCERPT_CHARS`. BM25F over the full body scores 38%/36% against 29%/28% over the committed 1200-char excerpt, so there are ~8 points sitting behind an index-size decision that deserves its own measurement.

## Testing

`284 passed` locally. No workflow runs the suite, so this is not CI-verified.
