### PR TITLE
Send both chat calls through one transport helper

### DIFF
--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -266,22 +266,10 @@ def assess(
         "temperature": 0.2,
         "response_format": {"type": "json_schema", "json_schema": _OUTPUT_SCHEMA},
     }
+    data = _chat(payload, token=token, what="AI assessment")
+    if data is None:
+        return None
     try:
-        resp = requests.post(
-            config.AI_ENDPOINT,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-            },
-            json=payload,
-            timeout=60,
-        )
-        if resp.status_code >= 400:
-            print(f"AI assessment skipped: HTTP {resp.status_code}: {resp.text[:200]}")
-            return None
-        content = resp.json()["choices"][0]["message"]["content"]
-        data = json.loads(content)
         result = _coerce(data)
         if candidate_labels is not None:
             allowed = {label.lower(): label for label in candidate_labels}
@@ -393,6 +381,42 @@ def judge_answer(
         "response_format": {"type": "json_schema", "json_schema": _ANSWER_SCHEMA},
     }
     valid_ids = {hit.chunk.id for hit in doc_hits}
+    data = _chat(payload, token=token, what="Doc-answer judge")
+    if data is None:
+        return None
+    try:
+        return _coerce_answer(data, valid_ids)
+    except Exception as exc:  # noqa: BLE001 — never let AI break triage
+        print(f"Doc-answer judge skipped: {exc}")
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Chat transport
+# --------------------------------------------------------------------------- #
+def _strip_fence(content: str) -> str:
+    """Unwrap a ```json ... ``` block if the model wrapped its answer in one.
+
+    ``response_format`` makes this unnecessary against an API that honours it,
+    but it costs nothing and it is what lets the same parse survive a backend
+    that returns prose-with-JSON rather than JSON.
+    """
+    text = content.strip()
+    if not text.startswith("```"):
+        return text
+    body = text.split("\n", 1)[1] if "\n" in text else ""
+    return body.rsplit("```", 1)[0].strip()
+
+
+def _chat(payload: dict[str, Any], *, token: str, what: str) -> dict[str, Any] | None:
+    """One chat completion, decoded to the object the caller asked the model for.
+
+    ``None`` on any failure, with the reason printed: every caller treats that
+    as "skip the AI part", which is what keeps an unreachable model from
+    breaking triage. ``what`` names the caller in that message, because a
+    silent or mislabelled failure here is what hid a dead provider behind a
+    green build for sixteen days.
+    """
     try:
         resp = requests.post(
             config.AI_ENDPOINT,
@@ -405,11 +429,11 @@ def judge_answer(
             timeout=60,
         )
         if resp.status_code >= 400:
-            print(f"Doc-answer judge skipped: HTTP {resp.status_code}: {resp.text[:200]}")
+            print(f"{what} skipped: HTTP {resp.status_code}: {resp.text[:200]}")
             return None
         content = resp.json()["choices"][0]["message"]["content"]
-        data = json.loads(content)
-        return _coerce_answer(data, valid_ids)
+        data = json.loads(_strip_fence(content))
+        return data if isinstance(data, dict) else None
     except Exception as exc:  # noqa: BLE001 — never let AI break triage
-        print(f"Doc-answer judge skipped: {exc}")
+        print(f"{what} skipped: {exc}")
         return None

--- a/.github/scripts/tests/test_ai.py
+++ b/.github/scripts/tests/test_ai.py
@@ -158,3 +158,31 @@ def test_coerce_clamps_category(sample_raw, monkeypatch):
     assert result.category == "unknown"        # unknown enum → clamped
     assert result.confidence == 1.0            # clamped into [0,1]
     assert result.suggested_labels == []       # non-list → empty
+
+
+# --- chat transport --------------------------------------------------------- #
+def test_strip_fence_unwraps_a_fenced_json_block():
+    """A backend without `response_format` tends to fence its answer."""
+    assert ai._strip_fence('```json\n{"a": 1}\n```') == '{"a": 1}'
+    assert ai._strip_fence('```\n{"a": 1}\n```') == '{"a": 1}'
+    assert ai._strip_fence('{"a": 1}') == '{"a": 1}'
+    assert ai._strip_fence('  {"a": 1}  ') == '{"a": 1}'
+
+
+def test_chat_returns_none_and_names_the_caller_on_failure(monkeypatch, capsys):
+    """A silent or mislabelled skip is what hid a dead provider for 16 days."""
+    monkeypatch.setattr(
+        ai.requests, "post", lambda *a, **k: _Resp({"error": "nope"}, status=503)
+    )
+    assert ai._chat({}, token="t", what="Doc-answer judge") is None
+    assert "Doc-answer judge skipped: HTTP 503" in capsys.readouterr().out
+
+
+def test_chat_rejects_a_non_object_response(monkeypatch):
+    """Callers index the result like a mapping; a bare list must not reach them."""
+    monkeypatch.setattr(
+        ai.requests,
+        "post",
+        lambda *a, **k: _Resp({"choices": [{"message": {"content": "[1, 2]"}}]}),
+    )
+    assert ai._chat({}, token="t", what="AI assessment") is None


### PR DESCRIPTION
## Why

`assess` and `judge_answer` duplicated their entire request block — headers, status check, `choices[0].message.content`, `json.loads`, and the `except` that turns any failure into a skip. Only the coercion differs.

Extracting it is worth doing on its own merits, and it is also the prerequisite for adding a second chat backend without duplicating the transport a third time.

## What changes

* New private `_chat(payload, *, token, what)` returning the decoded object or `None`. `what` names the caller in the skip message — a mislabelled failure here is what hid a dead provider behind a green build for sixteen days, so the message has to say which call gave up.
* `_strip_fence` unwraps a ```json block if one is present. Unnecessary against an API honouring `response_format`, but it costs nothing and keeps the same parse working against one that does not.
* `_chat` returns `None` for a non-object response. Both callers index the result like a mapping, so a bare list must not reach them.

## Behaviour

**No change.** Same endpoint, same headers, same timeout, same payloads, same skip-on-failure semantics, same messages. The only new outcome is that a fenced or non-object response is now handled rather than raising into the caller's `except` — which produced the same `None` anyway.

## Testing

`287 passed` locally. Three new tests cover fence-stripping, the named skip message, and the non-object rejection. No workflow runs the suite, so this is not CI-verified.