### PR TITLE
Fix outdated diagnostics instructions

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -4,13 +4,13 @@ Autonomous, AI-assisted triage for issues and Discussions in
 `music-assistant/support`.
 
 The bot reads the **diagnostics file** that reporters attach (produced by
-_Settings → Download diagnostics_ in Music Assistant), or falls back to scanning
-an attached **raw log file** (for older versions without the diagnostics
-feature), posts a single sticky summary comment, applies setup/provider labels,
-involves community provider maintainers, surfaces docs-grounded answers and
-similar past reports, and manages the issue's response state. New/edited
-Discussions receive the same docs-grounded help without issue-specific
-diagnostics or label handling.
+_Settings → System → Diagnostics → Download diagnostics_ in Music Assistant), or
+falls back to scanning an attached **raw log file** (for older versions without
+the diagnostics feature), posts a single sticky summary comment, applies
+setup/provider labels, involves community provider maintainers, surfaces
+docs-grounded answers and similar past reports, and manages the issue's response
+state. New/edited Discussions receive the same docs-grounded help without
+issue-specific diagnostics or label handling.
 
 > **Live configuration in this repository:** deterministic triage, AI assessment,
 > RAG and Discussion triage are all enabled; dry-run is off. The code retains

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -27,12 +27,12 @@ _SEVERITY_ICON = {
 }
 
 _DIAGNOSTICS_HOWTO = (
-    "Grab it from **Settings → System → Diagnostics → Download diagnostics** and "
-    "attach the `music-assistant-diagnostics-*.json` file. If you don't see the "
-    "button, your Music Assistant server is likely outdated. Update it first, or "
-    "attach your **server log file** instead. Diagnostics are privacy-sanitized "
-    "(paths, tokens, emails and non-local IPs are removed) and let us understand "
-    "your setup at a glance."
+    f"Grab it from **{config.DIAGNOSTICS_SETTINGS_PATH}** and attach the "
+    "`music-assistant-diagnostics-*.json` file. If you don't see the button, your "
+    "Music Assistant server is likely outdated. Update it first, or attach your "
+    "**server log file** instead. Diagnostics are privacy-sanitized (paths, tokens, "
+    "emails and non-local IPs are removed) and let us understand your setup at a "
+    "glance."
 )
 
 

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -27,13 +27,12 @@ _SEVERITY_ICON = {
 }
 
 _DIAGNOSTICS_HOWTO = (
-    "On Music Assistant **2.10 or newer**, grab it from **Settings → Download "
-    "diagnostics** and attach the `music-assistant-diagnostics-*.json` file. On "
-    "**2.9.6–2.9.x** you can open `/diagnostics?include_log_tail=true` and save "
-    "the JSON. On **older versions** (no diagnostics feature yet), attach your "
-    "**server log file** instead. Diagnostics are privacy-sanitized (paths, "
-    "tokens, emails and non-local IPs are removed) and let us understand your "
-    "setup at a glance."
+    "Grab it from **Settings → System → Diagnostics → Download diagnostics** and "
+    "attach the `music-assistant-diagnostics-*.json` file. If you don't see the "
+    "button, your Music Assistant server is likely outdated. Update it first, or "
+    "attach your **server log file** instead. Diagnostics are privacy-sanitized "
+    "(paths, tokens, emails and non-local IPs are removed) and let us understand "
+    "your setup at a glance."
 )
 
 

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -446,14 +446,18 @@ AUTO_CLOSE_MESSAGE = (
 # genuine user activity.
 REMINDER_MARKER = "<!-- ma-triage-reminder -->"
 
+DIAGNOSTICS_SETTINGS_PATH = (
+    "Settings → System → Diagnostics → Download diagnostics"
+)
+
 # Note added when the analysis came from a raw log file rather than a diagnostics
 # report (older MA versions). We only ever show redacted, derived facts from logs.
 LOG_FALLBACK_NOTE = (
     "ℹ️ I analysed the **attached log file** (no diagnostics report was found). "
     "Logs give me less to go on than a diagnostics report, and I only surface "
     "redacted, derived facts from them. If you're on Music Assistant 2.9.6 or "
-    "newer, a diagnostics report would help us a lot more — see **Settings → "
-    "Download diagnostics**."
+    "newer, a diagnostics report would help us a lot more — see "
+    f"**{DIAGNOSTICS_SETTINGS_PATH}**."
 )
 
 # Note added when the reporter selected the unsupported install method.

--- a/.github/scripts/tests/test_comment.py
+++ b/.github/scripts/tests/test_comment.py
@@ -81,6 +81,7 @@ def test_build_body_log_source_note(sample_log, fake_gh):
     body = comment.build_body(result)
     assert "attached log file" in body  # log-fallback note present
     assert "attached log" in body  # findings section wording
+    assert f"**{config.DIAGNOSTICS_SETTINGS_PATH}**" in body
     # No raw secret leaks through the rendered comment.
     assert "/home/frank" not in body
     assert "sk-abcdef0123456789ABCDEF" not in body

--- a/.github/scripts/tests/test_comment.py
+++ b/.github/scripts/tests/test_comment.py
@@ -54,6 +54,10 @@ def test_build_body_no_attachment_no_screenshot():
     result = TriageResult(form_kind="main", missing_attachment=True)
     body = comment.build_body(result)
     assert "diagnostics report or log file" in body
+    assert "Settings → System → Diagnostics → Download diagnostics" in body
+    assert "Update it first, or attach your **server log file** instead" in body
+    assert "/diagnostics?include_log_tail=true" not in body
+    assert "2.10 or newer" not in body
     assert "screenshot" not in body.lower()
 
 


### PR DESCRIPTION
## Bugfix

The triage bot still told MA 2.9 users to download diagnostics through a manual URL, even though the download button was backported to 2.9.6.

- Point users to **Settings → System → Diagnostics → Download diagnostics**.
- Suggest updating MA or attaching the server log when the button is unavailable.
- Keep the obsolete version-specific instructions from returning.