### PR TITLE
Record the width the index actually stores, and keep partial batches

### DIFF
--- a/.github/scripts/ma_triage/embeddings.py
+++ b/.github/scripts/ma_triage/embeddings.py
@@ -70,31 +70,41 @@ def _request_embeddings(inputs: list[str], token: str) -> list[list[float]]:
     return [list(item["embedding"]) for item in ordered]
 
 
-def embed_texts(texts: list[str], *, token: str) -> list[list[float]] | None:
-    """Embed a list of texts (batched). Returns ``None`` on any failure."""
+def embed_texts(texts: list[str], *, token: str) -> list[list[float] | None]:
+    """Embed a list of texts, batched. One entry per input, ``None`` where the
+    provider did not return a vector.
+
+    A failing batch costs only its own inputs. Collapsing every batch into a
+    single ``None`` meant one timed-out request near the end of a long backfill
+    discarded thousands of vectors that had already been computed — and because
+    a vectorless record is never satisfied by the sha cache, the next run
+    retried the whole backlog and could fail the same way indefinitely. Partial
+    progress is written instead, so each run advances the cache.
+    """
     if not texts:
         return []
-    vectors: list[list[float]] = []
+    vectors: list[list[float] | None] = []
     batch = max(1, config.EMBED_BATCH)
-    try:
-        for start in range(0, len(texts), batch):
-            chunk = texts[start : start + batch]
-            vectors.extend(_request_embeddings(chunk, token))
-    except Exception as exc:  # noqa: BLE001 — never let embeddings break triage
-        log(f"Embeddings skipped: {exc}")
-        return None
-    if len(vectors) != len(texts):
-        log("Embeddings response count mismatch; skipping")
-        return None
+    for start in range(0, len(texts), batch):
+        chunk = texts[start : start + batch]
+        try:
+            result = _request_embeddings(chunk, token)
+        except Exception as exc:  # noqa: BLE001 — never let embeddings break triage
+            log(f"Embeddings skipped for {len(chunk)} of {len(texts)}: {exc}")
+            vectors.extend([None] * len(chunk))
+            continue
+        if len(result) != len(chunk):
+            log(f"Embeddings response count mismatch for {len(chunk)}; skipping")
+            vectors.extend([None] * len(chunk))
+            continue
+        vectors.extend(result)
     return vectors
 
 
 def embed_text(text: str, *, token: str) -> list[float] | None:
     """Embed a single text; ``None`` on failure."""
     result = embed_texts([text[: config.MAX_POST_EMBED_CHARS]], token=token)
-    if not result:
-        return None
-    return result[0]
+    return result[0] if result else None
 
 
 def _chunk_embed_input(chunk: DocChunk) -> str:
@@ -122,6 +132,24 @@ def load_index(gh: GitHubClient, path: str) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+def dim_matches(index: dict[str, Any]) -> bool:
+    """Whether an index's stored vector width is usable with the current config.
+
+    ``dim`` records the width the vectors in the file actually have, not the
+    width that was requested. When ``EMBED_DIM`` asks for a specific width the
+    file has to match it; when it asks for nothing (0), whatever the provider
+    natively returned is fine. Recording the request instead would let a
+    provider that ignores the ``dimensions`` parameter produce a header that
+    does not describe the file — and `cosine` scores mismatched widths as 0.0,
+    so that disagreement would surface as duplicate detection quietly finding
+    nothing rather than as an error.
+    """
+    stored = index.get("dim")
+    if config.EMBED_DIM > 0:
+        return stored == config.EMBED_DIM
+    return isinstance(stored, int) and stored > 0
+
+
 def load_docs_chunks(gh: GitHubClient) -> list[DocChunk]:
     """Load ``docs.json`` into :class:`DocChunk` objects (with embeddings)."""
     index = load_index(gh, config.DOCS_INDEX_PATH)
@@ -130,7 +158,7 @@ def load_docs_chunks(gh: GitHubClient) -> list[DocChunk]:
     if (
         index.get("schema") != _SCHEMA
         or index.get("model") != config.EMBED_MODEL
-        or index.get("dim") != config.EMBED_DIM
+        or not dim_matches(index)
     ):
         log("Docs index schema/model/dim mismatch; ignoring index")
         return []
@@ -162,7 +190,7 @@ def load_posts(gh: GitHubClient) -> list[dict[str, Any]]:
     if (
         index.get("schema") != _SCHEMA
         or index.get("model") != config.EMBED_MODEL
-        or index.get("dim") != config.EMBED_DIM
+        or not dim_matches(index)
     ):
         log("Posts index schema/model/dim mismatch; ignoring index")
         return []
@@ -263,7 +291,7 @@ def build_docs_index(
         previous
         and previous.get("schema") == _SCHEMA
         and previous.get("model") == config.EMBED_MODEL
-        and previous.get("dim") == config.EMBED_DIM
+        and dim_matches(previous)
     ):
         for raw in previous.get("chunks", []) or []:
             if isinstance(raw, dict) and raw.get("id"):
@@ -281,10 +309,11 @@ def build_docs_index(
         vectors = embed_texts(
             [_chunk_embed_input(chunks[i]) for i in to_embed], token=token
         )
-        if vectors is None:
+        if not any(vector is not None for vector in vectors):
             return None, False
         for i, vector in zip(to_embed, vectors):
-            chunks[i].embedding = vector
+            if vector is not None:
+                chunks[i].embedding = vector
 
     new_ids = {c.id for c in chunks}
     changed = bool(to_embed) or new_ids != set(prev_by_id)
@@ -292,7 +321,7 @@ def build_docs_index(
     index = {
         "schema": _SCHEMA,
         "model": config.EMBED_MODEL,
-        "dim": config.EMBED_DIM,
+        "dim": next((len(c.embedding) for c in chunks if c.embedding), 0),
         "built_at": _now_iso(),
         "chunks": [_chunk_to_dict(c) for c in chunks],
     }
@@ -368,11 +397,20 @@ def trim_by_kind(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return kept
 
 
+def _observed_dim(records: list[dict[str, Any]]) -> int:
+    """Width of the vectors actually stored, or 0 when none are."""
+    for record in records:
+        raw = record.get("embedding")
+        if raw:
+            return len(decode_vec(raw))
+    return 0
+
+
 def _empty_posts_index() -> dict[str, Any]:
     return {
         "schema": _SCHEMA,
         "model": config.EMBED_MODEL,
-        "dim": config.EMBED_DIM,
+        "dim": 0,  # replaced with the observed width once vectors exist
         "built_at": _now_iso(),
         "posts": [],
     }
@@ -396,7 +434,7 @@ def build_posts_index(
         previous
         and previous.get("schema") == _SCHEMA
         and previous.get("model") == config.EMBED_MODEL
-        and previous.get("dim") == config.EMBED_DIM
+        and dim_matches(previous)
     ):
         for raw in previous.get("posts", []) or []:
             if isinstance(raw, dict) and raw.get("number") is not None:
@@ -447,7 +485,7 @@ def build_posts_index(
         # detection with nothing to fall back on.
         vectors = embed_texts(embed_targets, token=token)
         for i, post in enumerate(to_embed):
-            records.append(_post_record(post, vectors[i] if vectors else None))
+            records.append(_post_record(post, vectors[i] if i < len(vectors) else None))
 
     changed = bool(to_embed) or metadata_changed or {
         (r.get("kind", "issue"), int(r.get("number", 0))) for r in records
@@ -464,6 +502,7 @@ def build_posts_index(
     index = _empty_posts_index()
     index["posts"] = records
     index["vectors"] = sum(1 for r in records if r.get("embedding"))
+    index["dim"] = _observed_dim(records)
     return index, changed
 
 
@@ -514,6 +553,7 @@ def append_post(
     index = _empty_posts_index()
     index["posts"] = kept
     index["vectors"] = sum(1 for r in kept if r.get("embedding"))
+    index["dim"] = _observed_dim(kept)
     return index, bool(record.get("embedding"))
 
 

--- a/.github/scripts/tests/test_embeddings.py
+++ b/.github/scripts/tests/test_embeddings.py
@@ -47,18 +47,41 @@ def test_embed_texts_happy(monkeypatch):
     assert embeddings.embed_texts(["a", "b"], token="x") == [[1.0, 2.0], [3.0, 4.0]]
 
 
-def test_embed_texts_http_error_returns_none(monkeypatch):
+def test_embed_texts_http_error_yields_none_per_input(monkeypatch):
     monkeypatch.setattr(
         embeddings.requests, "post", lambda *a, **k: _Resp({"error": "no"}, status=429)
     )
-    assert embeddings.embed_texts(["a"], token="x") is None
+    assert embeddings.embed_texts(["a"], token="x") == [None]
 
 
-def test_embed_texts_count_mismatch_returns_none(monkeypatch):
+def test_embed_texts_count_mismatch_yields_none_per_input(monkeypatch):
     monkeypatch.setattr(
         embeddings.requests, "post", lambda *a, **k: _Resp(_emb_payload([[1.0]]))
     )
-    assert embeddings.embed_texts(["a", "b"], token="x") is None
+    assert embeddings.embed_texts(["a", "b"], token="x") == [None, None]
+
+
+def test_embed_texts_keeps_the_batches_that_succeeded(monkeypatch):
+    """One failing batch must not discard the vectors already computed.
+
+    A long backfill sends many batches. Collapsing them all into a single
+    failure meant the last request timing out threw away everything before it,
+    and since a vectorless record never satisfies the sha cache, the next run
+    retried the whole backlog and could fail identically forever.
+    """
+    monkeypatch.setattr(config, "EMBED_BATCH", 1)
+    calls = {"n": 0}
+
+    def flaky(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            return _Resp({"error": "timeout"}, status=504)
+        return _Resp(_emb_payload([[float(calls["n"])]]))
+
+    monkeypatch.setattr(embeddings.requests, "post", flaky)
+    assert embeddings.embed_texts(["a", "b", "c"], token="x") == [
+        [1.0], None, [3.0]
+    ]
 
 
 def test_embed_text_single(monkeypatch):
@@ -121,7 +144,7 @@ def test_build_docs_index_sha_cache(monkeypatch):
 
 def test_build_docs_index_skip_on_limit(monkeypatch):
     monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
-    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: [None] * len(texts))
     gh = FakeGH()
     index, changed = embeddings.build_docs_index(
         gh, token="t", chunks=[_chunk("a#x", "alpha")]
@@ -207,7 +230,7 @@ def test_build_posts_index_truncates_long_body(monkeypatch):
 
 def test_append_post_writes_the_text_when_embedding_fails(monkeypatch):
     monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
-    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: [None] * len(texts))
     gh = FakeGH()
     index, embedded = embeddings.append_post(
         gh, {"kind": "issue", "number": 5, "title": "x", "body": "y"}, token="t"
@@ -231,7 +254,7 @@ def test_append_post_keeps_an_existing_vector_when_embedding_fails(
     assert embedded is True
     embeddings.save_index(gh, config.POSTS_INDEX_PATH, index, message="seed")
 
-    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: [None] * len(texts))
     index, embedded = embeddings.append_post(gh, post, token="t")
     assert embedded is True  # carried forward, not re-embedded
     assert index["posts"][0]["embedding"]
@@ -245,7 +268,7 @@ def test_append_post_drops_a_stale_vector_when_the_text_changed(ai_on, monkeypat
     )
     embeddings.save_index(gh, config.POSTS_INDEX_PATH, index, message="seed")
 
-    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: [None] * len(texts))
     index, embedded = embeddings.append_post(
         gh, {"kind": "issue", "number": 5, "title": "x", "body": "EDITED"}, token="t"
     )
@@ -305,7 +328,7 @@ def test_load_posts_text_accepts_a_legacy_schema_and_strips_vectors():
 def test_load_posts_text_keeps_records_with_no_vector(monkeypatch):
     """Posts indexed during an outage are exactly what this loader is for."""
     monkeypatch.setattr(config, "EMBED_DIM", FAKE_DIM)
-    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: [None] * len(texts))
     gh = FakeGH()
     index, _ = embeddings.append_post(
         gh, {"kind": "issue", "number": 5, "title": "x", "body": "y"}, token="t"
@@ -329,3 +352,39 @@ def test_current_schema_has_a_known_text_layout():
     is the only path left.
     """
     assert embeddings._SCHEMA in embeddings._TEXT_COMPATIBLE_SCHEMAS
+
+
+# --- the index header describes the file, not the request -------------------- #
+def test_index_records_the_width_actually_stored(ai_on, monkeypatch):
+    """A provider free to ignore `dimensions` must not produce a lying header.
+
+    `cosine` scores mismatched widths as 0.0, so a header that disagrees with
+    its vectors shows up as duplicate detection quietly finding nothing.
+    """
+    monkeypatch.setattr(config, "EMBED_DIM", 0)  # request no particular width
+    monkeypatch.setattr(
+        embeddings, "embed_texts",
+        lambda texts, *, token: [[0.5] * 7 for _ in texts],  # provider returns 7
+    )
+    gh = FakeGH()
+    index, _ = embeddings.build_posts_index(
+        gh, [{"kind": "issue", "number": 1, "title": "t", "body": "b",
+              "url": "u", "state": "open"}], token="t",
+    )
+    assert index["dim"] == 7
+
+
+def test_dim_matches_requires_the_requested_width_when_one_is_asked_for(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_DIM", 512)
+    assert embeddings.dim_matches({"dim": 512})
+    assert not embeddings.dim_matches({"dim": 1024})
+    assert not embeddings.dim_matches({"dim": 0})
+
+
+def test_dim_matches_accepts_any_real_width_when_none_is_requested(monkeypatch):
+    monkeypatch.setattr(config, "EMBED_DIM", 0)
+    assert embeddings.dim_matches({"dim": 1024})
+    assert embeddings.dim_matches({"dim": 384})
+    # 0 means no vectors were stored, so there is nothing to rank against.
+    assert not embeddings.dim_matches({"dim": 0})
+    assert not embeddings.dim_matches({})

--- a/.github/scripts/tests/test_index_cmd.py
+++ b/.github/scripts/tests/test_index_cmd.py
@@ -54,7 +54,7 @@ def test_cmd_index_unknown_target():
 # unavailable embedder was treated as an acceptable outcome. Producing an index
 # is this command's only job, so it must now say when it did not.
 def _no_embeddings(monkeypatch):
-    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: None)
+    monkeypatch.setattr(embeddings, "embed_texts", lambda texts, *, token: [None] * len(texts))
 
 
 def test_cmd_index_fails_when_embeddings_are_unavailable(ai_on, monkeypatch):


### PR DESCRIPTION
## Why

Groundwork for moving embeddings off GitHub Models. Both of these are latent today and become live failures under any provider that behaves differently from the retired one — and both are cheapest to fix *now*, while the committed index is already stale and there is nothing to invalidate.

## `dim` described the request, not the file

`"dim"` was written from `config.EMBED_DIM` rather than from the vectors. A provider that ignores the OpenAI `dimensions` parameter — which a local or self-hosted one will, since it serves its native width — then produces a header that does not describe its own contents.

That matters because `retrieval.cosine` returns `0.0` for mismatched widths. A disagreement between header and vectors does not raise; it shows up as duplicate detection quietly finding nothing.

The header now records the observed width. `dim_matches` reads it with the semantics the field always implied:

* `EMBED_DIM > 0` — a specific width was requested, so the file has to match it exactly
* `EMBED_DIM = 0` — nothing was requested, so whatever the provider natively returned is fine
* `dim = 0` — no vectors are stored, so there is nothing to rank against either way

## One failing batch discarded the whole backlog

`embed_texts` collapsed every batch into a single `None` on any failure, and `build_posts_index` sends the entire backlog through one call.

So a request timing out near the end of a long backfill threw away every vector computed before it. And because a vectorless record never satisfies the sha cache, the next run retried the same backlog and could fail in exactly the same place — indefinitely, with no progress and no accumulating cache.

Failures are now scoped to the batch that caused them. `embed_texts` returns one entry per input, `None` where no vector came back, so each run advances the cache by whatever it managed.

This is a contract change: `list[list[float] | None]` rather than `list[list[float]] | None`. Callers already handled a missing vector — `_post_record` omits the key, `build_docs_index` fails only when nothing at all came back — so the change is confined to the client and its tests.

## Behaviour

No change against a provider that honours `dimensions` and answers every batch. `EMBED_DIM` stays at its current value, so the recorded width equals the requested one and every guard behaves as before.

## Testing

`291 passed` locally, including a test that a flaky middle batch keeps the vectors either side of it, and that a provider returning an unrequested width is recorded honestly. No workflow runs the suite, so this is not CI-verified.
