### PR TITLE
Embed on the issue path, and name the model that produced the vectors

### DIFF
--- a/.github/actions/start-embeddings/action.yml
+++ b/.github/actions/start-embeddings/action.yml
@@ -1,0 +1,95 @@
+name: Start local embeddings
+description: >-
+  Serve the triage bot's embedding model from this runner on an OpenAI-shaped
+  endpoint, and export TRIAGE_EMBED_* so the bot uses it.
+
+# GitHub Models was retired 2026-07-30 and nothing GitHub-hosted replaced its
+# embeddings endpoint. Every job that needs a vector runs the model itself.
+#
+# Never fails the calling job. An unreachable endpoint is indistinguishable
+# from an unreachable provider to the bot: it logs, produces no vectors, and
+# each caller already decides for itself whether that is fatal — `cmd_index`
+# exits non-zero, per-issue triage degrades to lexical matching and carries on.
+
+inputs:
+  port:
+    description: Port for the local endpoint
+    default: "11435"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: "22"
+
+    # Two caches: the dependency tree moves with the lockfile, the weights only
+    # when the model does. One shared key would re-download 600MB for a bump.
+    - name: Cache embeddings dependencies
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .github/embeddings/node_modules
+        key: embed-deps-${{ runner.os }}-${{ hashFiles('.github/embeddings/package-lock.json') }}
+    - name: Cache embedding model weights
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/ma-triage-embeddings
+        key: embed-model-${{ hashFiles('.github/embeddings/server.mjs') }}
+
+    - name: Install embeddings shim
+      shell: bash
+      working-directory: .github/embeddings
+      # --ignore-scripts: nothing here needs a native postinstall, and these
+      # jobs process user-authored issue text.
+      run: npm ci --ignore-scripts
+
+    - name: Start the embeddings server
+      shell: bash
+      working-directory: .github/embeddings
+      env:
+        MODEL_CACHE_DIR: ~/.cache/ma-triage-embeddings
+        PORT: ${{ inputs.port }}
+      run: |
+        node server.mjs "${PORT}" > "${RUNNER_TEMP}/embeddings.log" 2>&1 &
+        echo "$!" > "${RUNNER_TEMP}/embeddings.pid"
+        # The server listens only once the model has loaded, so an open port is
+        # the readiness signal. Give up the moment the process dies rather than
+        # burning the whole budget on a corpse; a cold cache fetches ~600MB.
+        for _ in $(seq 1 180); do
+          if curl -sf -m 3 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+            echo "ready"; exit 0
+          fi
+          if ! kill -0 "$(cat "${RUNNER_TEMP}/embeddings.pid")" 2>/dev/null; then
+            echo "::warning::embeddings server exited before becoming ready"
+            tail -20 "${RUNNER_TEMP}/embeddings.log"; exit 0
+          fi
+          sleep 5
+        done
+        echo "::warning::embeddings server did not become ready in time"
+        tail -20 "${RUNNER_TEMP}/embeddings.log"
+
+    - name: Point the bot at the local endpoint
+      shell: bash
+      env:
+        PORT: ${{ inputs.port }}
+      # DIM 0 because the server serves the model's native width and ignores
+      # the OpenAI `dimensions` parameter; the index records the width it
+      # actually stores. BATCH 4 keeps each request inside the client's 60s
+      # timeout, since the server embeds one input at a time to bound memory.
+      run: |
+        # The model identifier comes from the server, so server.mjs stays the
+        # single place a model change has to be made. It lands in the index's
+        # `model` field, which the loaders treat as a compatibility key: if it
+        # did not change with the weights, a stale index would be accepted.
+        model=$(curl -sf -m 5 "http://127.0.0.1:${PORT}/health" \
+          | python3 -c 'import json,sys; print(json.load(sys.stdin)["embedModel"])' \
+          2>/dev/null || true)
+        {
+          echo "TRIAGE_EMBED_ENDPOINT=http://127.0.0.1:${PORT}/v1/embeddings"
+          echo "TRIAGE_EMBED_DIM=0"
+          echo "TRIAGE_EMBED_BATCH=4"
+          # Empty when the server never came up. The bot then keeps its
+          # configured model string and finds no endpoint to call, which is the
+          # same degraded state as an unreachable provider.
+          [ -n "$model" ] && echo "TRIAGE_EMBED_MODEL=$model"
+        } >> "$GITHUB_ENV"

--- a/.github/embeddings/server.mjs
+++ b/.github/embeddings/server.mjs
@@ -80,7 +80,17 @@ function send(res, status, body) {
 
 const server = createServer((req, res) => {
 	if (req.method === "GET" && req.url === "/health") {
-		return send(res, 200, { status: "ok", model: MODEL, dtype: MODEL_DTYPE });
+		return send(res, 200, {
+			status: "ok",
+			model: MODEL,
+			revision: MODEL_REVISION,
+			dtype: MODEL_DTYPE,
+			// The identifier the bot records in the index header. It carries the
+			// revision and dtype because the index's `model` field is a
+			// compatibility key: anything that would change the vectors has to
+			// change this string, or a stale index is silently accepted.
+			embedModel: `${MODEL}@${MODEL_REVISION.slice(0, 12)}@${MODEL_DTYPE}`,
+		});
 	}
 	if (req.method !== "POST" || !req.url.endsWith("/embeddings")) {
 		return send(res, 404, { error: { message: "not found" } });

--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Install dependencies
         working-directory: .github/scripts
         run: pip install -r requirements.txt
+      - uses: ./.github/actions/start-embeddings
       - name: Triage discussion
         working-directory: .github/scripts
         env:
@@ -66,7 +67,6 @@ jobs:
           TRIAGE_AI_ENABLED: ${{ vars.TRIAGE_AI_ENABLED }}
           TRIAGE_DISCUSSIONS_ENABLED: ${{ vars.TRIAGE_DISCUSSIONS_ENABLED }}
           TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
-          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
           TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
           TRIAGE_ANSWER_MODEL: ${{ vars.TRIAGE_ANSWER_MODEL }}
           TRIAGE_ANSWER_HI: ${{ vars.TRIAGE_ANSWER_HI }}
@@ -103,7 +103,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: write # commit the posts index to the triage-index branch
-      models: read # embeddings
+
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -112,6 +112,7 @@ jobs:
       - name: Install dependencies
         working-directory: .github/scripts
         run: pip install -r requirements.txt
+      - uses: ./.github/actions/start-embeddings
       - name: Append discussion to posts index
         working-directory: .github/scripts
         env:
@@ -122,10 +123,8 @@ jobs:
           TRIAGE_AI_ENABLED: ${{ vars.TRIAGE_AI_ENABLED }}
           TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
           TRIAGE_DISCUSSIONS_ENABLED: ${{ vars.TRIAGE_DISCUSSIONS_ENABLED }}
-          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
           TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
           TRIAGE_INDEX_MAX_POSTS: ${{ vars.TRIAGE_INDEX_MAX_POSTS }}
           TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES: ${{ vars.TRIAGE_DISCUSSION_EXCLUDE_CATEGORIES }}
-          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
         run: python -m ma_triage discussion-append

--- a/.github/workflows/docs_embeddings.yml
+++ b/.github/workflows/docs_embeddings.yml
@@ -55,53 +55,7 @@ jobs:
         working-directory: .github/scripts
         run: pip install -r requirements.txt
 
-      # Two caches, because the two things change on different schedules: the
-      # dependency tree when the lockfile moves, the weights only when the
-      # model does. Sharing one key would re-download 600MB for a lockfile bump.
-      - name: Cache embeddings dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .github/embeddings/node_modules
-          key: embed-deps-${{ runner.os }}-${{ hashFiles('.github/embeddings/package-lock.json') }}
-      - name: Cache embedding model weights
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ma-triage-embeddings
-          key: embed-model-${{ hashFiles('.github/embeddings/server.mjs') }}
-      - name: Install embeddings shim
-        working-directory: .github/embeddings
-        # --ignore-scripts: no package here needs a native postinstall, and this
-        # job holds `contents: write` while processing user-authored issue text.
-        run: npm ci --ignore-scripts
-
-      - name: Start the embeddings server
-        working-directory: .github/embeddings
-        env:
-          MODEL_CACHE_DIR: ~/.cache/ma-triage-embeddings
-        run: |
-          node server.mjs 11435 > "${RUNNER_TEMP}/embeddings.log" 2>&1 &
-          echo "$!" > "${RUNNER_TEMP}/embeddings.pid"
-          # The server listens only once the model is loaded, so an open port is
-          # the readiness signal. Poll for it, but give up the moment the process
-          # dies rather than burning the whole timeout on a corpse — a cold cache
-          # downloads ~600MB, so the budget has to be generous.
-          for _ in $(seq 1 180); do
-            if curl -sf -m 3 http://127.0.0.1:11435/health >/dev/null 2>&1; then
-              echo "ready"; exit 0
-            fi
-            if ! kill -0 "$(cat "${RUNNER_TEMP}/embeddings.pid")" 2>/dev/null; then
-              echo "::warning::embeddings server exited before becoming ready"
-              tail -20 "${RUNNER_TEMP}/embeddings.log"
-              exit 0
-            fi
-            sleep 5
-          done
-          echo "::warning::embeddings server did not become ready in time"
-          tail -20 "${RUNNER_TEMP}/embeddings.log"
-        # Never fail the job here. An unreachable endpoint already looks like an
-        # unreachable provider to the Python: it logs, returns no vectors, and
-        # `cmd_index` reports the shortfall and exits non-zero on its own.
-        continue-on-error: true
+      - uses: ./.github/actions/start-embeddings
 
       - name: Build RAG indexes
         working-directory: .github/scripts
@@ -114,21 +68,9 @@ jobs:
           TRIAGE_DRY_RUN: ${{ vars.TRIAGE_DRY_RUN }}
           TRIAGE_AI_ENABLED: ${{ vars.TRIAGE_AI_ENABLED }}
           TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
-          # Local endpoint. It serves the model's native width and ignores the
-          # OpenAI `dimensions` parameter, so no width is requested and the
-          # index records the width it actually stores.
-          TRIAGE_EMBED_ENDPOINT: http://127.0.0.1:11435/v1/embeddings
-          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
-          TRIAGE_EMBED_DIM: "0"
-          # Small batches keep each request well inside the client's 60s
-          # timeout: the server embeds one input at a time to bound memory.
-          TRIAGE_EMBED_BATCH: "4"
           TRIAGE_DOCS_REPO: ${{ vars.TRIAGE_DOCS_REPO }}
           TRIAGE_DOCS_SITE: ${{ vars.TRIAGE_DOCS_SITE }}
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
           TRIAGE_INDEX_MAX_POSTS: ${{ vars.TRIAGE_INDEX_MAX_POSTS }}
         run: python -m ma_triage index "$INDEX_TARGET"
 
-      - name: Stop the embeddings server
-        if: always()
-        run: kill "$(cat "${RUNNER_TEMP}/embeddings.pid")" 2>/dev/null || true

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Install dependencies
         working-directory: .github/scripts
         run: pip install -r requirements.txt
+      - uses: ./.github/actions/start-embeddings
       - name: Triage issue
         working-directory: .github/scripts
         env:
@@ -75,7 +76,6 @@ jobs:
           TRIAGE_SCAN_LOGS: ${{ vars.TRIAGE_SCAN_LOGS }}
           # RAG layer (Phase 2) — only active when TRIAGE_AI_ENABLED is true.
           TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
-          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
           TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
           TRIAGE_ANSWER_MODEL: ${{ vars.TRIAGE_ANSWER_MODEL }}
           TRIAGE_ANSWER_HI: ${{ vars.TRIAGE_ANSWER_HI }}
@@ -151,7 +151,6 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: write # commit the posts index to the triage-index branch
-      models: read # embeddings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -160,6 +159,7 @@ jobs:
       - name: Install dependencies
         working-directory: .github/scripts
         run: pip install -r requirements.txt
+      - uses: ./.github/actions/start-embeddings
       - name: Append issue to posts index
         working-directory: .github/scripts
         env:
@@ -169,9 +169,7 @@ jobs:
           TRIAGE_DRY_RUN: ${{ vars.TRIAGE_DRY_RUN }}
           TRIAGE_AI_ENABLED: ${{ vars.TRIAGE_AI_ENABLED }}
           TRIAGE_RAG_ENABLED: ${{ vars.TRIAGE_RAG_ENABLED }}
-          TRIAGE_EMBED_MODEL: ${{ vars.TRIAGE_EMBED_MODEL }}
           TRIAGE_EMBED_DIM: ${{ vars.TRIAGE_EMBED_DIM }}
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
           TRIAGE_INDEX_MAX_POSTS: ${{ vars.TRIAGE_INDEX_MAX_POSTS }}
-          GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
         run: python -m ma_triage index-append


### PR DESCRIPTION
## Why

#6121 put the embedding model on the runner for the nightly index build. That alone leaves the per-issue path without a query vector — and that vector does not only feed duplicate detection.

`rag.answer` gates **all** of docs retrieval on it:

```python
doc_hits: list[DocHit] = []
if query_vec is not None:
    chunks = embeddings.load_docs_chunks(gh)
    doc_hits = retrieve_docs(query_vec, query_text, chunks)
```

With no vector, `doc_hits` stays empty, the tier is forced to `low`, and the docs-grounded answer never fires. Unlike a duplicate link — which the nightly can backfill — a missing docs answer cannot be, because the comment has already been posted.

## Cost, measured rather than estimated

From #6121's run on a real runner:

```
 1s  Install dependencies
 0s  Cache embeddings dependencies   (cold — nothing to restore)
 1s  Cache embedding model weights   (cold)
 4s  Install embeddings shim         (npm ci)
30s  Start the embeddings server     (592MB download + load + readiness)
```

**~40 seconds cold**, less once the caches are warm. The per-issue path embeds a *single* document, so the nightly's throughput never applied to it — that was the number #6121 existed to establish, and it turned out to be the wrong number for this question.

## What changes

The server block moves into a composite action rather than being pasted into five jobs, and is added to every job that needs a vector:

| job | embeddings | why |
| --- | --- | --- |
| `docs_embeddings` / build | yes | the nightly index build |
| `triage` / analyze | yes | query vector for docs retrieval and duplicates |
| `triage` / index-append | yes | see below |
| `triage` / respond | **no** | comment handling embeds nothing |
| `discussions` / answer | yes | docs-grounded answer |
| `discussions` / index-append | yes | see below |

**On the append jobs.** These are the one place the vector is genuinely deferrable — `_post_record` omits the key without one and the nightly refills it. I have included them anyway. A report filed this afternoon should be comparable against one filed this morning, and the same-day burst after a regression ships is precisely the case duplicate detection most needs to catch. The alternative also needed a code change to avoid annotating every incoming issue with an expected failure; this way there is no Python diff at all.

The jobs are not merged to share one server. Their permission split — `contents: write` for the index branch versus `issues: write` for commenting — is a stated safety property.

## The model string was wrong, and would have been silently wrong

`TRIAGE_EMBED_MODEL` was passed from a repo variable that **is not set**, so the bot fell back to its configured default and would have recorded `openai/text-embedding-3-small` against vectors Qwen produced.

That field is a compatibility key: `load_posts` and `load_docs_chunks` both discard an index whose `model` disagrees with the current config. If it does not change when the weights change, a stale index is accepted in silence — the same class of failure as the `dim` header fixed in #6117.

It now comes from the server's own `/health`, so `server.mjs` is the only place a model change is made:

```
"embedModel": "onnx-community/Qwen3-Embedding-0.6B-ONNX@c25a394dd583@q8"
```

Model, revision and dtype, so anything that would change a vector changes the key.

## Least privilege

`models: read` and `GH_MODELS_TOKEN` are dropped from both append jobs — they no longer call GitHub Models at all. `analyze` and `discussions/answer` keep them, because the chat judge still runs there.

## Failure behaviour

Unchanged, and deliberately so. The action never fails its caller. An unreachable local endpoint is indistinguishable from an unreachable provider: the bot logs, gets no vectors, and each caller already decides whether that is fatal — `cmd_index` exits non-zero, per-issue triage degrades to the lexical path from #6099 and carries on. The readiness poll gives up as soon as the process dies rather than burning its full budget.

## Testing

`291 passed` locally — no Python changed. Workflow and action YAML validated. The composite action is exercised by #6121's run, which reached readiness on a cold cache from this same code.

Worth reviewing with that in mind: this adds ~40s to every issue-triage run, at roughly 2.4 new issues a day.
