### PR TITLE
Run the triage bot's tests in CI

### DIFF
--- a/.github/workflows/ci_scripts.yml
+++ b/.github/workflows/ci_scripts.yml
@@ -1,0 +1,40 @@
+# Runs the triage bot's own test suite.
+#
+# The suite existed and passed for a long time without anything running it, so
+# every change to the bot merged on the author's word. It is also the only place
+# the code is exercised at the Python version the bot actually runs: the tests
+# were being run locally on whatever the author had installed, while every
+# workflow pins 3.12.
+name: CI - triage scripts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/ci_scripts.yml"
+  pull_request:
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/ci_scripts.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test ma_triage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          # Match the version every other workflow runs the bot on, so a syntax
+          # or stdlib difference cannot pass here and fail in production.
+          python-version: "3.12"
+      - name: Install dependencies
+        working-directory: .github/scripts
+        run: pip install -r requirements.txt pytest
+      - name: Run tests
+        working-directory: .github/scripts
+        run: python -m pytest tests/ -q


### PR DESCRIPTION
## Why

The suite has never gated a merge. Every change to the bot — including nine PRs in the last few days — landed on the author's assertion that the tests passed.

It also ran on whatever Python the author happened to have installed, while **every workflow runs the bot on 3.12**. A stdlib or syntax difference could pass locally and fail in production, and nothing would catch it.

`esphome/esphome` already does exactly this for its own `.github/scripts` (`ci-github-scripts.yml`), so this is the same shape with pytest instead of npm.

## What it does

Path-filtered to `.github/scripts/**`, so it runs only when the bot changes. `contents: read` only. Checkout and setup-python SHA-pinned like the rest of the workflows here, and pinned to **3.12** deliberately — matching the version the bot actually runs on is most of the value.

## Note

This PR is its own first test: the `pull_request` path filter includes the workflow file, so the run on this PR is the evidence it works.

If it comes back red, that is a genuine finding rather than a problem with the PR — it would mean something in the suite depends on a newer Python than the bot runs on.
