### PR TITLE
Run the chat calls through the Copilot CLI

### DIFF
--- a/.github/actions/setup-copilot/action.yml
+++ b/.github/actions/setup-copilot/action.yml
@@ -1,0 +1,28 @@
+name: Set up Copilot chat
+description: Install the pinned GitHub Copilot CLI, which `ai._chat` shells out to.
+
+# GitHub Models was retired 2026-07-30, taking the chat model with it. Copilot
+# replaces it at no new spend, but it is a command rather than an endpoint, so
+# `ai._chat` runs it as a subprocess instead of POSTing to a URL. The presence
+# of COPILOT_GITHUB_TOKEN in the environment is what selects that path, and
+# callers pass that alongside their other credentials rather than through here:
+# a secret does not belong in GITHUB_ENV, where later steps could echo it.
+#
+# HOW TO STOP USING A PERSONAL TOKEN. The org has Copilot policies enabled but
+# no seats assigned, so the org-billed route (`copilot-requests: write` with the
+# built-in GITHUB_TOKEN) is refused with "Access denied by policy settings".
+# Until seats exist this runs on a maintainer's own fine-grained PAT. Callers
+# pass `${{ secrets.COPILOT_PAT || secrets.GITHUB_TOKEN }}`, so once seats are
+# assigned, deleting that secret switches to org billing with no code change.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: "22"
+    - name: Install the Copilot CLI
+      shell: bash
+      # Pinned: this runs in jobs that process user-authored issue text, so the
+      # version is not allowed to drift.
+      run: npm install -g @github/copilot@1.0.80

--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -1,7 +1,9 @@
-"""Tier 1 — optional GitHub Models assessment.
+"""Tier 1 — optional chat-model assessment.
 
 Sends a **bounded, sanitized** summary of the diagnostics and the issue text to
-the GitHub Models inference API and asks for a small, strictly-typed JSON verdict.
+a chat model and asks for a small, strictly-typed JSON verdict. The model is
+reached either over an OpenAI-compatible endpoint or, when a Copilot token is
+present, by running the Copilot CLI — see :func:`_chat`.
 
 This tier is entirely optional and defensive:
 * gated behind ``config.AI_ENABLED`` (repo variable ``TRIAGE_AI_ENABLED``),
@@ -13,6 +15,8 @@ This tier is entirely optional and defensive:
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from typing import Any
 
 import requests
@@ -408,6 +412,70 @@ def _strip_fence(content: str) -> str:
     return body.rsplit("```", 1)[0].strip()
 
 
+def _prompt_from(payload: dict[str, Any]) -> str:
+    """Flatten a chat payload into the single prompt a CLI backend accepts.
+
+    The schema travels as instructions because there is nothing else to carry
+    it: `response_format` is an API feature and the CLI has no equivalent. That
+    downgrades a guarantee to a request, which is survivable only because the
+    callers never trusted the shape anyway — `_coerce` and `_coerce_answer`
+    default every field, clamp confidence, filter the category, and drop
+    citation ids the model was not given. A response that ignores the schema
+    entirely fails to parse and becomes a skip.
+    """
+    system = [
+        str(m.get("content", ""))
+        for m in payload.get("messages", [])
+        if m.get("role") == "system"
+    ]
+    user = [
+        str(m.get("content", ""))
+        for m in payload.get("messages", [])
+        if m.get("role") != "system"
+    ]
+    schema = (
+        (payload.get("response_format") or {}).get("json_schema", {}).get("schema")
+    )
+    parts = [*system]
+    if schema:
+        parts.append(
+            "Reply with a single JSON object and nothing else — no prose, no "
+            "code fence. It must validate against this JSON Schema:\n"
+            + json.dumps(schema, separators=(",", ":"))
+        )
+    parts.extend(user)
+    return "\n\n".join(part for part in parts if part)
+
+
+def _chat_via_cli(payload: dict[str, Any], *, what: str) -> str | None:
+    """Assistant text from the Copilot CLI, or ``None`` with the reason logged.
+
+    The prompt goes in on **stdin**, never argv: it carries issue text written
+    by anyone, and argv is readable from the process table by every other step
+    in the job. The token is passed explicitly because the CLI will otherwise
+    find its own credentials, and a run that silently authenticates as
+    something else is worse than one that fails.
+    """
+    try:
+        completed = subprocess.run(
+            ["copilot", "-s", "--no-ask-user"],
+            input=_prompt_from(payload),
+            capture_output=True,
+            text=True,
+            timeout=config.AI_CLI_TIMEOUT,
+            env={**os.environ, "COPILOT_GITHUB_TOKEN": config.AI_CLI_TOKEN},
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"{what} skipped: {exc}")
+        return None
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()[:200]
+        print(f"{what} skipped: copilot exited {completed.returncode}: {detail}")
+        return None
+    return completed.stdout
+
+
 def _chat(payload: dict[str, Any], *, token: str, what: str) -> dict[str, Any] | None:
     """One chat completion, decoded to the object the caller asked the model for.
 
@@ -417,6 +485,16 @@ def _chat(payload: dict[str, Any], *, token: str, what: str) -> dict[str, Any] |
     silent or mislabelled failure here is what hid a dead provider behind a
     green build for sixteen days.
     """
+    if config.AI_CLI_TOKEN:
+        content = _chat_via_cli(payload, what=what)
+        if content is None:
+            return None
+        try:
+            data = json.loads(_strip_fence(content))
+        except ValueError as exc:
+            print(f"{what} skipped: reply was not JSON: {exc}")
+            return None
+        return data if isinstance(data, dict) else None
     try:
         resp = requests.post(
             config.AI_ENDPOINT,

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -271,6 +271,16 @@ AI_ENABLED = _flag("TRIAGE_AI_ENABLED", False)
 SCAN_LOGS = _flag("TRIAGE_SCAN_LOGS", True)
 AI_MODEL = _env_str("TRIAGE_AI_MODEL", "openai/gpt-4o-mini")
 AI_ENDPOINT = _env_str("TRIAGE_AI_ENDPOINT", "https://models.github.ai/inference/chat/completions")
+# Set by the workflow when GitHub Copilot is available. Its presence selects the
+# CLI backend in `ai._chat` instead of an HTTP endpoint — Copilot is a command,
+# not a URL, so there is nothing for AI_ENDPOINT to point at. Not a TRIAGE_*
+# variable because it is a credential, and the credential is the capability: no
+# token means no CLI to call, which is exactly the condition to branch on.
+AI_CLI_TOKEN = os.environ.get("COPILOT_GITHUB_TOKEN", "")
+# Longer than the HTTP timeout: the CLI starts a process and does its own
+# retries, so it is slower to answer than an endpoint that either responds or
+# does not.
+AI_CLI_TIMEOUT = _env_int("TRIAGE_AI_CLI_TIMEOUT", 180)
 
 # --------------------------------------------------------------------------- #
 # RAG layer (Phase 2) — docs-grounded answers + similar-post detection

--- a/.github/scripts/tests/test_ai.py
+++ b/.github/scripts/tests/test_ai.py
@@ -186,3 +186,85 @@ def test_chat_rejects_a_non_object_response(monkeypatch):
         lambda *a, **k: _Resp({"choices": [{"message": {"content": "[1, 2]"}}]}),
     )
     assert ai._chat({}, token="t", what="AI assessment") is None
+
+
+# --- CLI backend (GitHub Copilot) -------------------------------------------- #
+def _payload(schema=None):
+    p = {"model": "m", "messages": [
+        {"role": "system", "content": "you are a triage assistant"},
+        {"role": "user", "content": "ISSUE BODY --not-a-flag"},
+    ]}
+    if schema:
+        p["response_format"] = {"type": "json_schema",
+                                "json_schema": {"schema": schema}}
+    return p
+
+
+def test_prompt_from_carries_the_schema_as_instructions():
+    """`response_format` has no CLI equivalent, so the schema has to be asked for."""
+    text = ai._prompt_from(_payload({"type": "object", "required": ["summary"]}))
+    assert "you are a triage assistant" in text
+    assert "ISSUE BODY" in text
+    assert "JSON Schema" in text and '"required":["summary"]' in text
+
+
+def test_chat_via_cli_sends_the_prompt_on_stdin_not_argv(monkeypatch):
+    """Issue text is written by anyone, and argv is readable from the process
+    table by every other step in the job."""
+    monkeypatch.setattr(config, "AI_CLI_TOKEN", "tok")
+    seen = {}
+
+    def fake_run(args, **kwargs):
+        seen["args"] = args
+        seen["input"] = kwargs.get("input")
+        seen["env"] = kwargs.get("env")
+        class R:
+            returncode = 0
+            stdout = '```json\n{"answers_question": true}\n```'
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(ai.subprocess, "run", fake_run)
+    assert ai._chat(_payload(), token="unused", what="X") == {"answers_question": True}
+    assert seen["args"] == ["copilot", "-s", "--no-ask-user"]
+    assert not any("ISSUE BODY" in a for a in seen["args"])
+    assert "ISSUE BODY" in seen["input"]
+    # Passed explicitly: the CLI finds its own credentials otherwise, and
+    # authenticating as something else silently is worse than failing.
+    assert seen["env"]["COPILOT_GITHUB_TOKEN"] == "tok"
+
+
+def test_chat_via_cli_skips_on_a_non_zero_exit(monkeypatch, capsys):
+    monkeypatch.setattr(config, "AI_CLI_TOKEN", "tok")
+
+    class R:
+        returncode = 1
+        stdout = ""
+        stderr = "Access denied by policy settings"
+
+    monkeypatch.setattr(ai.subprocess, "run", lambda *a, **k: R())
+    assert ai._chat(_payload(), token="unused", what="Doc-answer judge") is None
+    assert "Access denied by policy settings" in capsys.readouterr().out
+
+
+def test_chat_via_cli_skips_when_the_reply_is_not_json(monkeypatch, capsys):
+    """Losing schema enforcement means prose is possible; it must not raise."""
+    monkeypatch.setattr(config, "AI_CLI_TOKEN", "tok")
+
+    class R:
+        returncode = 0
+        stdout = "I think the issue is probably a network problem."
+        stderr = ""
+
+    monkeypatch.setattr(ai.subprocess, "run", lambda *a, **k: R())
+    assert ai._chat(_payload(), token="unused", what="AI assessment") is None
+    assert "was not JSON" in capsys.readouterr().out
+
+
+def test_chat_uses_http_when_no_cli_token_is_present(monkeypatch):
+    monkeypatch.setattr(config, "AI_CLI_TOKEN", "")
+    monkeypatch.setattr(
+        ai.requests, "post",
+        lambda *a, **k: _Resp({"choices": [{"message": {"content": '{"ok": 1}'}}]}),
+    )
+    assert ai._chat(_payload(), token="t", what="X") == {"ok": 1}

--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -27,6 +27,7 @@ concurrency:
 permissions:
   contents: read
   models: read # docs-grounded answer via GitHub Models (only when AI enabled)
+  copilot-requests: write # used only once org Copilot seats exist
 
 jobs:
   answer:
@@ -53,6 +54,7 @@ jobs:
         working-directory: .github/scripts
         run: pip install -r requirements.txt
       - uses: ./.github/actions/start-embeddings
+      - uses: ./.github/actions/setup-copilot
       - name: Triage discussion
         working-directory: .github/scripts
         env:
@@ -84,6 +86,9 @@ jobs:
           # Optional PAT for GitHub Models (used only when set); falls back to
           # the default token. Lets Models work when the org token can't.
           GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
+          # Falls through to the workflow token once org Copilot seats exist,
+          # so switching off the personal PAT is a secret deletion.
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT || secrets.GITHUB_TOKEN }}
         run: python -m ma_triage discussion
 
   # Separate, least-privilege job: embed a newly-created discussion and append it

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -41,6 +41,7 @@ jobs:
     permissions:
       contents: read
       models: read
+      copilot-requests: write # used only once org Copilot seats exist
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create triage App token
@@ -60,6 +61,7 @@ jobs:
         working-directory: .github/scripts
         run: pip install -r requirements.txt
       - uses: ./.github/actions/start-embeddings
+      - uses: ./.github/actions/setup-copilot
       - name: Triage issue
         working-directory: .github/scripts
         env:
@@ -92,6 +94,9 @@ jobs:
           # Optional PAT for GitHub Models (used only when set); falls back to
           # the default token. Lets Models work when the org token can't.
           GH_MODELS_TOKEN: ${{ secrets.GH_MODELS_TOKEN }}
+          # Falls through to the workflow token once org Copilot seats exist,
+          # so switching off the personal PAT is a secret deletion.
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT || secrets.GITHUB_TOKEN }}
         run: python -m ma_triage triage
 
   respond:


### PR DESCRIPTION
## Why

GitHub Models was retired on 2026-07-30 and took the chat model with it. `ai.assess` (Tier-1 root-cause assessment) and `ai.judge_answer` (grades whether retrieved docs answer the question) have produced nothing since — the last piece still dark after the embeddings work.

Copilot serves chat at no new spend, but it is a **command rather than an endpoint**, so there is nothing for `TRIAGE_AI_ENDPOINT` to point at. `_chat`, extracted in #6100, gains a second backend behind the same seam. Both callers reach it unchanged.

## Selecting the backend

The presence of `COPILOT_GITHUB_TOKEN` selects the CLI path. Not a new `TRIAGE_*` variable, because the credential *is* the capability: no token means no CLI worth calling, which is exactly the condition to branch on. It is documented in `config.py` alongside the other flags, so it is discoverable where maintainers look.

## Two implementation choices worth reviewing

**The prompt goes in on stdin, never argv.** It carries issue text written by anyone, and argv is readable from the process table by every other step in the job. GitHub's own `actions/ai-inference` builds `['-p', fullPrompt, ...]` and ignores stdin — but the CLI does accept stdin, verified:

```
$ printf 'Reply with a single JSON object and nothing else: {"answers_question": true, "confidence": 0.9}' \
    | copilot -s --no-ask-user
{"answers_question": true, "confidence": 0.9}
```

There is a test asserting the prompt is absent from `args` and present in `input`, because that property is easy to regress silently.

**The token is passed explicitly.** The CLI finds its own credentials otherwise — it answered for me with `COPILOT_GITHUB_TOKEN` set empty, using unrelated local auth. A run that silently authenticates as something else is worse than one that fails.

## Losing schema-enforced output

`response_format: {"type":"json_schema", ...}` has no CLI equivalent, so the schema travels as instructions. That downgrades a guarantee to a request.

It is survivable because the callers never trusted the shape. `_coerce` and `_coerce_answer` already default every field, clamp `confidence` to 0–1, filter `category` to `_CATEGORIES`, and drop citation ids the model was never given. #6100's fence-stripping handles a fenced reply. A reply that ignores the schema entirely fails to parse and becomes a skip.

The important consequence is what happens on the risky path. `judge_answer`'s confidence gates whether the bot posts an authoritative-sounding docs answer, so a garbage reply there is the thing worth worrying about — and it **fails closed**: `answers_question` defaults to `False`, which forces `tier` to `low` in `rag.answer`, which renders nothing. The failure mode is silence, not a confident wrong answer.

## Stopping the personal token later

Callers pass `${{ secrets.COPILOT_PAT || secrets.GITHUB_TOKEN }}` and the jobs carry `copilot-requests: write`. The org has Copilot policies enabled but **no seats assigned**, so the org-billed route is currently refused with `Access denied by policy settings`. Once seats are assigned, **deleting the secret** moves this to org billing with no code change and no PR.

Worth stating plainly: until then this runs on one maintainer's personal Copilot entitlement and quota, and that token expires around 2026-08-23. When it lapses the symptom is a logged skip, not an alert.

## Scope

`respond` and both `index-append` jobs are untouched — no chat call happens there. `AI_MODEL` is still the dead `openai/gpt-4o-mini` string; the CLI path passes no model deliberately, because naming one produces `Model ... is not available`, which reads exactly like an auth failure.

## Testing

`296 passed`, and this is the first PR where that is CI-enforced (#6125). Five new tests cover the stdin property, schema-as-instructions, a non-zero exit, a non-JSON reply, and that an absent token still routes over HTTP.

Not yet exercised end to end on a runner — worth a dry-run dispatch against a real issue before relying on it.
