### PR TITLE
Scope traceback code paths to the reported symptom

### DIFF
--- a/.github/scripts/ma_triage/code_context.py
+++ b/.github/scripts/ma_triage/code_context.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 
 from . import config
 from .gh import GitHubClient, log
-from .models import Diagnostics
+from .models import Diagnostics, ExceptionEntry
 from .providers import provider_manifest_domain
 
 _TOKEN = re.compile(r"[A-Za-z][A-Za-z0-9_.\-/]{3,}")
@@ -86,20 +86,17 @@ def _tokens(text: str) -> set[str]:
     }
 
 
-def _terms(title: str, body: str, diag: Diagnostics) -> set[str]:
-    issue_terms = _tokens(f"{title}\n{body}")
+def _exc_text(exc: ExceptionEntry) -> str:
+    return "\n".join(
+        [exc.exc_type, exc.message or "", exc.origin or "", exc.traceback or ""]
+    )
+
+
+def _terms(diag: Diagnostics, issue_terms: set[str]) -> set[str]:
+    """Scoring vocabulary: the report, plus exceptions that corroborate it."""
     terms = set(issue_terms)
     for exc in diag.exceptions:
-        exc_terms = _tokens(
-            "\n".join(
-                [
-                    exc.exc_type,
-                    exc.message or "",
-                    exc.origin or "",
-                    exc.traceback or "",
-                ]
-            )
-        )
+        exc_terms = _tokens(_exc_text(exc))
         # Diagnostics often contain unrelated background exceptions. Only let an
         # exception steer code retrieval when it overlaps the reported symptom.
         if issue_terms & exc_terms:
@@ -109,15 +106,19 @@ def _terms(title: str, body: str, diag: Diagnostics) -> set[str]:
 
 def _origin_paths(
     diag: Diagnostics,
-    terms: set[str],
+    issue_terms: set[str],
     *,
     provider_prefixes: tuple[str, ...],
 ) -> set[str]:
+    """Source paths named by the exceptions, scoped to the reported problem.
+
+    A path inside a reported provider's directory is evidence on its own. With
+    no provider to scope by, the exception earns its place only by overlapping
+    the reporter's own words.
+    """
     paths: set[str] = set()
     for exc in diag.exceptions:
-        exc_text = "\n".join(
-            [exc.exc_type, exc.message or "", exc.origin or "", exc.traceback or ""]
-        )
+        describes_report = bool(issue_terms & _tokens(_exc_text(exc)))
         for value in (exc.origin, exc.traceback):
             if not value:
                 continue
@@ -125,7 +126,7 @@ def _origin_paths(
                 if provider_prefixes:
                     if path.startswith(provider_prefixes):
                         paths.add(path)
-                elif _tokens(exc_text) & terms:
+                elif describes_report:
                     paths.add(path)
     return paths
 
@@ -200,7 +201,8 @@ def build(
     version: str | None,
 ) -> str:
     """Return relevant official-code excerpts, or ``""`` on no useful match."""
-    terms = _terms(title, body, diagnostics)
+    issue_terms = _tokens(f"{title}\n{body}")
+    terms = _terms(diagnostics, issue_terms)
     if not terms:
         return ""
 
@@ -209,7 +211,7 @@ def build(
         for label in sorted(provider_labels, key=str.lower)[:2]
     ]
     prefixes = tuple(f"music_assistant/providers/{domain}/" for domain in domains)
-    paths = _origin_paths(diagnostics, terms, provider_prefixes=prefixes)
+    paths = _origin_paths(diagnostics, issue_terms, provider_prefixes=prefixes)
     for domain in domains:
         root = f"music_assistant/providers/{domain}"
         paths.update(f"{root}/{name}" for name in _PROVIDER_FILES)

--- a/.github/scripts/tests/conftest.py
+++ b/.github/scripts/tests/conftest.py
@@ -61,12 +61,17 @@ class FakeGH:
         self._discussion_obj = discussion
         self._search_items = list(search_items or [])
         self.calls: list[tuple] = []
+        # Paths passed to get_raw_file, so a test can assert what was *not*
+        # fetched. A selector that stops retrieving an irrelevant file has no
+        # other visible effect whenever that file would have scored zero.
+        self.raw_reads: list[str] = []
 
     # reads -----------------------------------------------------------------
     def get_latest_release(self, repo="music-assistant/server"):
         return {"tag_name": self._latest_tag} if self._latest_tag else None
 
     def get_raw_file(self, repo, path, ref="main"):
+        self.raw_reads.append(path)
         if path in self._index_files:
             return self._index_files[path]
         if path in self._raw_files:

--- a/.github/scripts/tests/test_code_context.py
+++ b/.github/scripts/tests/test_code_context.py
@@ -77,3 +77,98 @@ def test_build_uses_diagnostics_origin_path_without_provider():
     )
     assert path in evidence
     assert "AlreadyRegisteredError" in evidence
+
+
+_SONOS = "music_assistant/providers/sonos/player.py"
+_HASS = "music_assistant/providers/hass/__init__.py"
+
+
+def _noisy_diagnostics():
+    """A report-matching exception beside an unrelated background failure.
+
+    The two tracebacks share only frame boilerplate — "File", "line" and a
+    common frame — which is what every Python traceback has in common.
+    """
+    return Diagnostics(
+        schema_version=1,
+        generated_at=None,
+        system=SystemInfo(version="2.9.7"),
+        exceptions=[
+            ExceptionEntry(
+                exc_type="ConnectionError",
+                fingerprint="a",
+                count=5,
+                message="sonos speaker disconnect during playback",
+                origin=f"{_SONOS}:88 in _handle_playback",
+                traceback=(
+                    f'File "{_SONOS}", line 88, in _handle_playback\n'
+                    "    await self._run()"
+                ),
+            ),
+            ExceptionEntry(
+                exc_type="SetupFailedError",
+                fingerprint="b",
+                count=1,
+                message="error loading provider Home Assistant supervisor websocket 502",
+                origin=f"{_HASS}:272 in handle_async_init",
+                traceback=(
+                    f'File "{_HASS}", line 272, in handle_async_init\n'
+                    "    await self._run()"
+                ),
+            ),
+        ],
+    )
+
+
+def _noisy_gh():
+    return FakeGH(
+        raw_files={
+            _SONOS: (
+                "async def _handle_playback(self):\n"
+                "    # Speakers drop out when the subscription lapses.\n"
+                "    raise ConnectionError('sonos speaker disconnect during playback')\n"
+            ),
+            _HASS: (
+                "async def handle_async_init(self):\n"
+                "    # Mirror Home Assistant playback state into the library.\n"
+                "    raise SetupFailedError('supervisor websocket 502')\n"
+            ),
+        }
+    )
+
+
+def test_build_ignores_unrelated_background_exception_paths():
+    """One matching exception must not vouch for the noise beside it."""
+    gh = _noisy_gh()
+
+    evidence = code_context.build(
+        gh,
+        title="Speakers keep dropping out during playback",
+        body="My speakers disconnect mid playback and reappear seconds later.",
+        diagnostics=_noisy_diagnostics(),
+        provider_labels=set(),
+        version="2.9.7",
+    )
+
+    assert _SONOS in evidence
+    assert _HASS not in evidence
+    # The fetch itself is the unconditional cost: an irrelevant file consumes a
+    # request and a slot in the budget even when it later scores zero.
+    assert _HASS not in gh.raw_reads
+
+
+def test_build_keeps_reported_provider_paths_without_shared_vocabulary():
+    """A path under a reported provider stands on the label, not on wording."""
+    gh = _noisy_gh()
+
+    evidence = code_context.build(
+        gh,
+        title="Sonos speakers keep dropping out",
+        body="They disconnect and come back a few seconds later.",
+        diagnostics=_noisy_diagnostics(),
+        provider_labels={"sonos"},
+        version="2.9.7",
+    )
+
+    assert _SONOS in evidence
+    assert _HASS not in evidence


### PR DESCRIPTION
## The bug

`_terms` deliberately folds an exception's vocabulary into the scoring terms
only when that exception overlaps the report — its inline comment says so:
"Only let an exception steer code retrieval when it overlaps the reported
symptom."

`_origin_paths` then weighed each exception against those **merged** terms
rather than against the report, which undoes the intent. The merged vocabulary
has already absorbed the traceback of every exception that matched, and every
Python traceback shares frame boilerplate — `File`, `line`, `self`, `await` — so
any other exception in the diagnostics matches on that alone.

Measured against the real code: a report with no recognised provider label,
whose diagnostics carry both a matching error and an unrelated background
failure, retrieves **both** paths. The unrelated exception shares *zero* tokens
with the reporter's words; it intersects the merged terms only on `{file, line}`.

## Impact

Bounded, and I don't want to oversell it. `_excerpt`'s `score > 0` gate drops
the contaminated file whenever it shares no vocabulary with the report, so this
is not always visible in output. What it costs unconditionally is a wasted
`api.github.com` fetch and a slot in the five-file budget; it leaks the file
into the assessment whenever the unrelated module shares any non-stopword term,
which real provider modules usually do.

Note this only bites when **no provider label was recognised**. With a provider
detected, `_origin_paths` takes the prefix branch and the unrelated path is
already excluded.

## The fix

Weigh each exception against the reporter's own words. `build` computes
`issue_terms` once and passes it to both helpers.

The two gates differ only when the diagnostics hold at least two exceptions and
at least one matches the report. In the dominant case the change narrows
retrieval; where it widens (the `[:60]` term cap can drop short tokens from the
merged set) it widens toward what the reporter actually wrote.

A stop-word entry for `File` and `line` would not do the job: `_TOKEN` admits
any four-character word, so shared frame vocabulary is open-ended — `self`,
`await`, `async`, `raise`, and common module names all qualify. The gate itself
was structurally wrong.

A path inside a reported provider's directory stands on the label rather than on
wording, so that branch is deliberately unchanged, and a second test pins that
decision so a later consistency cleanup cannot quietly tighten it.

## Verification

298 tests pass on Python 3.12, the version `ci_scripts.yml` pins.

`test_build_ignores_unrelated_background_exception_paths` was checked against
the parent commit's version of `code_context.py` and fails there. It asserts the
path was never **fetched** (`gh.raw_reads`), not only that it is absent from the
evidence — the evidence-only assertion passes vacuously if a fixture comment
changes, since it depends on `_excerpt` scoring rather than on selection.
`FakeGH` gained a `raw_reads` list for that; it previously recorded mutations
only.