### PR TITLE
Stop leaving the job token in every checkout

### DIFF
--- a/.github/workflows/ci_scripts.yml
+++ b/.github/workflows/ci_scripts.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           # Match the version every other workflow runs the bot on, so a syntax

--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create triage App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -110,6 +112,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"

--- a/.github/workflows/docs_embeddings.yml
+++ b/.github/workflows/docs_embeddings.yml
@@ -45,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -44,6 +44,8 @@ jobs:
       copilot-requests: write # used only once org Copilot seats exist
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create triage App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -109,6 +111,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create triage App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -157,6 +161,8 @@ jobs:
       contents: write # commit the posts index to the triage-index branch
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"

--- a/.github/workflows/triage_scheduled.yml
+++ b/.github/workflows/triage_scheduled.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Create triage App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
`actions/checkout` defaults to `persist-credentials: true`, which writes the
job's token into `.git/config` as an `http.extraheader` Basic-auth value. Any
step that can read a file in the workspace can read it, regardless of what the
process environment holds — and these workflows run steps whose input is issue
text written by the public.

Nothing in this repo needs the credential to persist. The RAG indexes are
committed through the Git Data API in `GitHubClient.commit_files`, not
`git push`, so no job runs a git operation that would authenticate. I checked
that before touching `index-append`, which is the one job with `contents: write`.

All 8 checkout steps across the 5 workflows that have one are covered; verified
by parsing the YAML rather than by reading the diff.

Found while adding a job that gives a model file-reading tools, where it is a
live concern rather than a latent one. Separated out because it stands on its
own and is worth landing regardless of what happens to that work.