### PR TITLE
Give the Copilot CLI launch one owner

### DIFF
--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -15,13 +15,11 @@ This tier is entirely optional and defensive:
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 from typing import Any
 
 import requests
 
-from . import config
+from . import config, copilot
 from .models import (
     AIResult,
     Diagnostics,
@@ -447,35 +445,6 @@ def _prompt_from(payload: dict[str, Any]) -> str:
     return "\n\n".join(part for part in parts if part)
 
 
-def _chat_via_cli(payload: dict[str, Any], *, what: str) -> str | None:
-    """Assistant text from the Copilot CLI, or ``None`` with the reason logged.
-
-    The prompt goes in on **stdin**, never argv: it carries issue text written
-    by anyone, and argv is readable from the process table by every other step
-    in the job. The token is passed explicitly because the CLI will otherwise
-    find its own credentials, and a run that silently authenticates as
-    something else is worse than one that fails.
-    """
-    try:
-        completed = subprocess.run(
-            ["copilot", "-s", "--no-ask-user"],
-            input=_prompt_from(payload),
-            capture_output=True,
-            text=True,
-            timeout=config.AI_CLI_TIMEOUT,
-            env={**os.environ, "COPILOT_GITHUB_TOKEN": config.AI_CLI_TOKEN},
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        print(f"{what} skipped: {exc}")
-        return None
-    if completed.returncode != 0:
-        detail = (completed.stderr or completed.stdout or "").strip()[:200]
-        print(f"{what} skipped: copilot exited {completed.returncode}: {detail}")
-        return None
-    return completed.stdout
-
-
 def _chat(payload: dict[str, Any], *, token: str, what: str) -> dict[str, Any] | None:
     """One chat completion, decoded to the object the caller asked the model for.
 
@@ -486,7 +455,7 @@ def _chat(payload: dict[str, Any], *, token: str, what: str) -> dict[str, Any] |
     green build for sixteen days.
     """
     if config.AI_CLI_TOKEN:
-        content = _chat_via_cli(payload, what=what)
+        content = copilot.run(_prompt_from(payload), what=what)
         if content is None:
             return None
         try:

--- a/.github/scripts/ma_triage/copilot.py
+++ b/.github/scripts/ma_triage/copilot.py
@@ -1,0 +1,49 @@
+"""One place that runs the GitHub Copilot CLI.
+
+The CLI replaced GitHub Models as the chat backend when Models was retired, so
+it is reached as a subprocess rather than an endpoint. Every rule about how that
+subprocess is launched is a security rule, and they live here so a second caller
+cannot quietly disagree with the first:
+
+* the prompt goes in on **stdin, never argv** — it carries issue text written by
+  anyone, and argv is readable from the process table by every other step in the
+  job;
+* the token is passed **explicitly**, because the CLI will otherwise find its
+  own credentials, and a run that silently authenticates as something else is
+  worse than one that fails;
+* every failure returns ``None`` with the reason printed, naming the caller. A
+  silent or mislabelled failure here is what once hid a dead provider behind a
+  green build for sixteen days.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from . import config
+
+
+def run(prompt: str, *, what: str) -> str | None:
+    """Assistant text for ``prompt``, or ``None`` with the reason logged.
+
+    ``what`` names the caller in that message, so a skipped step says which one.
+    """
+    try:
+        completed = subprocess.run(
+            ["copilot", "-s", "--no-ask-user"],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=config.AI_CLI_TIMEOUT,
+            env={**os.environ, "COPILOT_GITHUB_TOKEN": config.AI_CLI_TOKEN},
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"{what} skipped: {exc}")
+        return None
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()[:200]
+        print(f"{what} skipped: copilot exited {completed.returncode}: {detail}")
+        return None
+    return completed.stdout

--- a/.github/scripts/tests/test_ai.py
+++ b/.github/scripts/tests/test_ai.py
@@ -208,55 +208,35 @@ def test_prompt_from_carries_the_schema_as_instructions():
     assert "JSON Schema" in text and '"required":["summary"]' in text
 
 
-def test_chat_via_cli_sends_the_prompt_on_stdin_not_argv(monkeypatch):
-    """Issue text is written by anyone, and argv is readable from the process
-    table by every other step in the job."""
+def test_chat_decodes_a_fenced_reply_from_the_cli(monkeypatch):
+    """The CLI has no `response_format`, so a fence has to survive the parse."""
     monkeypatch.setattr(config, "AI_CLI_TOKEN", "tok")
     seen = {}
 
-    def fake_run(args, **kwargs):
-        seen["args"] = args
-        seen["input"] = kwargs.get("input")
-        seen["env"] = kwargs.get("env")
-        class R:
-            returncode = 0
-            stdout = '```json\n{"answers_question": true}\n```'
-            stderr = ""
-        return R()
+    def fake_run(prompt, *, what):
+        seen["prompt"] = prompt
+        return '```json\n{"answers_question": true}\n```'
 
-    monkeypatch.setattr(ai.subprocess, "run", fake_run)
+    monkeypatch.setattr(ai.copilot, "run", fake_run)
+
     assert ai._chat(_payload(), token="unused", what="X") == {"answers_question": True}
-    assert seen["args"] == ["copilot", "-s", "--no-ask-user"]
-    assert not any("ISSUE BODY" in a for a in seen["args"])
-    assert "ISSUE BODY" in seen["input"]
-    # Passed explicitly: the CLI finds its own credentials otherwise, and
-    # authenticating as something else silently is worse than failing.
-    assert seen["env"]["COPILOT_GITHUB_TOKEN"] == "tok"
+    assert "ISSUE BODY" in seen["prompt"]
 
 
-def test_chat_via_cli_skips_on_a_non_zero_exit(monkeypatch, capsys):
+def test_chat_skips_when_the_cli_reports_a_failure(monkeypatch):
+    """The runner logs the reason; `_chat` only has to degrade to a skip."""
     monkeypatch.setattr(config, "AI_CLI_TOKEN", "tok")
-
-    class R:
-        returncode = 1
-        stdout = ""
-        stderr = "Access denied by policy settings"
-
-    monkeypatch.setattr(ai.subprocess, "run", lambda *a, **k: R())
+    monkeypatch.setattr(ai.copilot, "run", lambda *a, **k: None)
     assert ai._chat(_payload(), token="unused", what="Doc-answer judge") is None
-    assert "Access denied by policy settings" in capsys.readouterr().out
 
 
-def test_chat_via_cli_skips_when_the_reply_is_not_json(monkeypatch, capsys):
+def test_chat_skips_when_the_reply_is_not_json(monkeypatch, capsys):
     """Losing schema enforcement means prose is possible; it must not raise."""
     monkeypatch.setattr(config, "AI_CLI_TOKEN", "tok")
-
-    class R:
-        returncode = 0
-        stdout = "I think the issue is probably a network problem."
-        stderr = ""
-
-    monkeypatch.setattr(ai.subprocess, "run", lambda *a, **k: R())
+    monkeypatch.setattr(
+        ai.copilot, "run",
+        lambda *a, **k: "I think the issue is probably a network problem.",
+    )
     assert ai._chat(_payload(), token="unused", what="AI assessment") is None
     assert "was not JSON" in capsys.readouterr().out
 

--- a/.github/scripts/tests/test_copilot.py
+++ b/.github/scripts/tests/test_copilot.py
@@ -1,0 +1,68 @@
+"""Tests for the one place that launches the Copilot CLI.
+
+Each of these pins a security rule rather than a convenience, so they assert the
+launch contract — argv, stdin, environment — not just the return value.
+"""
+
+from ma_triage import config, copilot
+
+
+def test_run_sends_the_prompt_on_stdin_not_argv(monkeypatch):
+    """Issue text is written by anyone, and argv is readable from the process
+    table by every other step in the job."""
+    monkeypatch.setattr(config, "AI_CLI_TOKEN", "tok")
+    seen = {}
+
+    def fake_run(args, **kwargs):
+        seen["args"] = args
+        seen["input"] = kwargs.get("input")
+        seen["env"] = kwargs.get("env")
+
+        class R:
+            returncode = 0
+            stdout = "hello"
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(copilot.subprocess, "run", fake_run)
+
+    assert copilot.run("ISSUE BODY: something", what="X") == "hello"
+    assert seen["args"] == ["copilot", "-s", "--no-ask-user"]
+    assert not any("ISSUE BODY" in arg for arg in seen["args"])
+    assert "ISSUE BODY" in seen["input"]
+    # Passed explicitly: the CLI finds its own credentials otherwise, and
+    # authenticating as something else silently is worse than failing.
+    assert seen["env"]["COPILOT_GITHUB_TOKEN"] == "tok"
+
+
+def test_run_returns_none_and_names_the_caller_on_a_non_zero_exit(
+    monkeypatch, capsys
+):
+    class R:
+        returncode = 1
+        stdout = ""
+        stderr = "Access denied by policy settings"
+
+    monkeypatch.setattr(copilot.subprocess, "run", lambda *a, **k: R())
+
+    assert copilot.run("prompt", what="Doc-answer judge") is None
+    out = capsys.readouterr().out
+    assert "Access denied by policy settings" in out
+    assert "Doc-answer judge" in out
+
+
+def test_run_returns_none_and_names_the_caller_when_the_cli_is_missing(
+    monkeypatch, capsys
+):
+    """An absent binary must skip the step, never break triage."""
+
+    def boom(*args, **kwargs):
+        raise OSError("No such file or directory: 'copilot'")
+
+    monkeypatch.setattr(copilot.subprocess, "run", boom)
+
+    assert copilot.run("prompt", what="AI assessment") is None
+    out = capsys.readouterr().out
+    assert "AI assessment" in out
+    assert "No such file or directory" in out


### PR DESCRIPTION
Prerequisite for a security fix, not just tidying — please read it as the first
of two.

Every rule about how the Copilot CLI subprocess is launched is a security rule:
the prompt on stdin rather than argv because argv is readable from the process
table, the token passed explicitly because the CLI otherwise finds its own
credentials, and a logged reason on every failure. Those rules lived inside
`ai._chat_via_cli`, where a second caller would have had to restate them and
could have restated them differently. A second caller is coming.

Behaviour is unchanged. The subprocess invocation is identical argument for
argument — I diffed the moved body against the original to confirm it, rather
than assuming.

The tests split along the same seam: `test_copilot.py` pins the launch contract
(argv, stdin, environment), and the `_chat` tests stub the runner and cover what
they were always really about, which is decoding a reply that has no schema to
enforce it.

301 tests pass on Python 3.12.