### PR TITLE
Hand the Copilot CLI an environment instead of the job's own

### DIFF
--- a/.github/scripts/ma_triage/copilot.py
+++ b/.github/scripts/ma_triage/copilot.py
@@ -1,9 +1,8 @@
 """One place that runs the GitHub Copilot CLI.
 
-The CLI replaced GitHub Models as the chat backend when Models was retired, so
-it is reached as a subprocess rather than an endpoint. Every rule about how that
-subprocess is launched is a security rule, and they live here so a second caller
-cannot quietly disagree with the first:
+The chat backend is a command rather than an endpoint, so it is reached as a
+subprocess. Every rule about how that subprocess is launched is a security rule,
+and they live here so a second caller cannot quietly disagree with the first:
 
 * the prompt goes in on **stdin, never argv** — it carries issue text written by
   anyone, and argv is readable from the process table by every other step in the
@@ -11,17 +10,22 @@ cannot quietly disagree with the first:
 * the token is passed **explicitly**, because the CLI will otherwise find its
   own credentials, and a run that silently authenticates as something else is
   worse than one that fails;
-* every failure returns ``None`` with the reason printed, naming the caller. A
-  silent or mislabelled failure here is what once hid a dead provider behind a
-  green build for sixteen days.
+* every failure returns ``None`` with the reason printed, naming the caller, so
+  a broken backend is distinguishable from a disabled one.
 """
 
 from __future__ import annotations
 
 import os
 import subprocess
+import tempfile
 
 from . import config
+
+# The CLI is given a constructed environment. Its input is issue text written by
+# anyone, and the job around it holds an app token with `issues: write` in
+# `GITHUB_TOKEN`; only what the CLI needs to start is copied through.
+_ENV_PASSTHROUGH = ("PATH",)
 
 
 def run(prompt: str, *, what: str) -> str | None:
@@ -29,16 +33,18 @@ def run(prompt: str, *, what: str) -> str | None:
 
     ``what`` names the caller in that message, so a skipped step says which one.
     """
+    args = ["copilot", "-s", "--no-ask-user", "--disable-builtin-mcps"]
     try:
-        completed = subprocess.run(
-            ["copilot", "-s", "--no-ask-user"],
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=config.AI_CLI_TIMEOUT,
-            env={**os.environ, "COPILOT_GITHUB_TOKEN": config.AI_CLI_TOKEN},
-            check=False,
-        )
+        with tempfile.TemporaryDirectory(prefix="copilot-home-") as home:
+            completed = subprocess.run(
+                args,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=config.AI_CLI_TIMEOUT,
+                env=_environment(home),
+                check=False,
+            )
     except (OSError, subprocess.SubprocessError) as exc:
         print(f"{what} skipped: {exc}")
         return None
@@ -47,3 +53,16 @@ def run(prompt: str, *, what: str) -> str | None:
         print(f"{what} skipped: copilot exited {completed.returncode}: {detail}")
         return None
     return completed.stdout
+
+
+def _environment(home: str) -> dict[str, str]:
+    """The complete environment for a CLI run, built from nothing.
+
+    ``HOME`` points at a scratch directory. With ``HOME`` unset the CLI resolves
+    the real one from the password database and reads the credentials and
+    configuration stored there.
+    """
+    env = {name: os.environ[name] for name in _ENV_PASSTHROUGH if name in os.environ}
+    env["HOME"] = home
+    env["COPILOT_GITHUB_TOKEN"] = config.AI_CLI_TOKEN
+    return env

--- a/.github/scripts/tests/test_copilot.py
+++ b/.github/scripts/tests/test_copilot.py
@@ -4,6 +4,8 @@ Each of these pins a security rule rather than a convenience, so they assert the
 launch contract — argv, stdin, environment — not just the return value.
 """
 
+import os
+
 from ma_triage import config, copilot
 
 
@@ -28,12 +30,65 @@ def test_run_sends_the_prompt_on_stdin_not_argv(monkeypatch):
     monkeypatch.setattr(copilot.subprocess, "run", fake_run)
 
     assert copilot.run("ISSUE BODY: something", what="X") == "hello"
-    assert seen["args"] == ["copilot", "-s", "--no-ask-user"]
+    assert seen["args"] == [
+        "copilot", "-s", "--no-ask-user", "--disable-builtin-mcps",
+    ]
     assert not any("ISSUE BODY" in arg for arg in seen["args"])
     assert "ISSUE BODY" in seen["input"]
     # Passed explicitly: the CLI finds its own credentials otherwise, and
     # authenticating as something else silently is worse than failing.
     assert seen["env"]["COPILOT_GITHUB_TOKEN"] == "tok"
+
+
+def test_run_hands_the_cli_a_built_environment_not_the_job_s(monkeypatch):
+    """The job's own environment holds tokens this process must not reach."""
+    monkeypatch.setenv("GITHUB_TOKEN", "app-token-with-issues-write")
+    monkeypatch.setenv("GH_MODELS_TOKEN", "another-secret")
+    monkeypatch.setattr(config, "AI_CLI_TOKEN", "tok")
+    seen = {}
+
+    def fake_run(args, **kwargs):
+        seen["env"] = kwargs.get("env")
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(copilot.subprocess, "run", fake_run)
+    copilot.run("prompt", what="X")
+
+    assert "GITHUB_TOKEN" not in seen["env"]
+    assert "GH_MODELS_TOKEN" not in seen["env"]
+    assert set(seen["env"]) <= {"PATH", "HOME", "COPILOT_GITHUB_TOKEN"}
+
+
+def test_run_points_home_at_a_scratch_directory(monkeypatch):
+    """Set, never merely omitted: with no HOME the CLI resolves the real one
+    from the password database and reads the credentials stored there."""
+    monkeypatch.setattr(config, "AI_CLI_TOKEN", "tok")
+    seen = {}
+
+    def fake_run(args, **kwargs):
+        seen["home"] = kwargs["env"]["HOME"]
+        seen["exists"] = os.path.isdir(seen["home"])
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(copilot.subprocess, "run", fake_run)
+    copilot.run("prompt", what="X")
+
+    assert seen["exists"]
+    assert seen["home"] != os.path.expanduser("~")
+    # Cleaned up once the run is over.
+    assert not os.path.isdir(seen["home"])
 
 
 def test_run_returns_none_and_names_the_caller_on_a_non_zero_exit(


### PR DESCRIPTION
Stacked on #6142.

The CLI runs in the analyze job, which holds an app token with `issues: write`
in `GITHUB_TOKEN`, and its own credential is a long-lived personal PAT. The
subprocess inherited all of it, and its input is issue text written by anyone.

Build the environment from nothing instead: `PATH`, a scratch `HOME`, and the
Copilot token.

`HOME` is **set** rather than omitted, and that distinction is the whole fix.
With no `HOME` at all the CLI still resolves the real one from the password
database and reads the credentials stored there — I checked, and it
authenticated successfully with `HOME` absent from the environment. Only
pointing it at a scratch directory actually isolates it.

`--disable-builtin-mcps` costs nothing and makes the invariant explicit; the
chat call uses no tools today.

Verified against the real binary rather than only a stub: the built environment
is enough for the CLI to start, it does not reach the credentials in the real
home directory, and an unusable token degrades to a skip with the reason logged.

**Not verified, and it cannot be from a unit test:** a *valid* token through
this environment. That needs a dry-run dispatch. If it were wrong the failure
mode is visible rather than silent — every AI call would log a skip — but it is
worth a dispatch before this is relied on.

303 tests pass on Python 3.12.