### PR TITLE
List a provider's directory instead of guessing its filenames

### DIFF
--- a/.github/scripts/ma_triage/code_context.py
+++ b/.github/scripts/ma_triage/code_context.py
@@ -49,15 +49,7 @@ _STOP_WORDS = frozenset(
         "version",
     }
 )
-_PROVIDER_FILES = (
-    "manifest.json",
-    "helpers.py",
-    "__init__.py",
-    "provider.py",
-    "client.py",
-    "ARCHITECTURE.md",
-    "strings.json",
-)
+_MAX_PROVIDER_FILES = 10
 _PACKAGING_HINTS = (
     "binary",
     "dependency",
@@ -129,6 +121,39 @@ def _origin_paths(
                 elif describes_report:
                     paths.add(path)
     return paths
+
+
+def _provider_paths(
+    gh: GitHubClient, domains: list[str], refs: list[str]
+) -> set[str]:
+    """The files in each reported provider's directory, shallowest first.
+
+    Providers carry parsers, models, auth helpers and subpackages under names of
+    their own choosing, so the directory is the only authority on what is there.
+    Depth orders the candidates because a provider's own modules sit beside its
+    ``__init__.py`` while subpackages hold the details.
+    """
+    if not domains:
+        return set()
+    roots = tuple(f"music_assistant/providers/{domain}/" for domain in domains)
+    for ref in refs:
+        tree = gh.get_tree(config.SERVER_REPO, ref)
+        if not tree:
+            continue
+        paths: set[str] = set()
+        for root in roots:
+            in_root = sorted(
+                (
+                    str(entry.get("path", ""))
+                    for entry in tree
+                    if entry.get("type") == "blob"
+                    and str(entry.get("path", "")).startswith(root)
+                ),
+                key=lambda path: (path.count("/"), path),
+            )
+            paths.update(in_root[:_MAX_PROVIDER_FILES])
+        return paths
+    return set()
 
 
 def _refs(version: str | None) -> list[str]:
@@ -211,16 +236,14 @@ def build(
         for label in sorted(provider_labels, key=str.lower)[:2]
     ]
     prefixes = tuple(f"music_assistant/providers/{domain}/" for domain in domains)
+    refs = _refs(version)
     paths = _origin_paths(diagnostics, issue_terms, provider_prefixes=prefixes)
-    for domain in domains:
-        root = f"music_assistant/providers/{domain}"
-        paths.update(f"{root}/{name}" for name in _PROVIDER_FILES)
+    paths.update(_provider_paths(gh, domains, refs))
 
     combined = f"{title}\n{body}".lower()
     if any(hint in combined for hint in _PACKAGING_HINTS):
         paths.update({"Dockerfile", "Dockerfile.base"})
 
-    refs = _refs(version)
     snippets: list[_Snippet] = []
     for path in sorted(paths):
         fetched = _fetch(gh, path, refs)

--- a/.github/scripts/ma_triage/gh.py
+++ b/.github/scripts/ma_triage/gh.py
@@ -238,6 +238,10 @@ class GitHubClient:
         if isinstance(data, dict):
             tree = data.get("tree")
             if isinstance(tree, list):
+                if data.get("truncated"):
+                    # Callers filter this list by prefix, so a truncated tree
+                    # reads as a directory with fewer files in it.
+                    log(f"Tree {repo}@{ref} was truncated by the API")
                 return tree
         return []
 

--- a/.github/scripts/tests/test_code_context.py
+++ b/.github/scripts/tests/test_code_context.py
@@ -25,8 +25,17 @@ def _diagnostics(*, origin=None, message="go-librespot binary not found on PATH"
     )
 
 
+def _tree(*paths):
+    """A git tree listing, which is how provider files are discovered."""
+    return [{"path": path, "type": "blob"} for path in paths]
+
+
 def test_build_retrieves_provider_and_packaging_evidence():
     gh = FakeGH(
+        tree=_tree(
+            "music_assistant/providers/spotify_connect/__init__.py",
+            "music_assistant/providers/spotify_connect/helpers.py",
+        ),
         raw_files={
             "music_assistant/providers/spotify_connect/helpers.py": (
                 "def get_go_librespot_binary():\n"
@@ -172,3 +181,80 @@ def test_build_keeps_reported_provider_paths_without_shared_vocabulary():
 
     assert _SONOS in evidence
     assert _HASS not in evidence
+
+
+def test_build_finds_provider_modules_by_listing_the_directory():
+    """Providers name their own modules; the directory is the only authority."""
+    parsers = "music_assistant/providers/opensubsonic/parsers.py"
+    gh = FakeGH(
+        tree=_tree(
+            "music_assistant/providers/opensubsonic/__init__.py",
+            parsers,
+        ),
+        raw_files={
+            parsers: (
+                "def parse_track(item):\n"
+                "    # Cover art id is optional in the Subsonic response.\n"
+                "    return Track(image=item.get('coverArt'))\n"
+            )
+        },
+    )
+
+    evidence = code_context.build(
+        gh,
+        title="Track cover art missing in playlist view",
+        body="The coverArt image never loads for tracks in a playlist.",
+        diagnostics=_diagnostics(message="cover art missing"),
+        provider_labels={"subsonic"},
+        version="2.9.7",
+    )
+
+    assert parsers in evidence
+
+
+def test_build_bounds_how_many_provider_files_it_will_fetch():
+    """A directory listing is unbounded; the fetch budget is not."""
+    many = [
+        f"music_assistant/providers/opensubsonic/mod{index:02d}.py"
+        for index in range(30)
+    ]
+    gh = FakeGH(tree=_tree(*many))
+
+    code_context.build(
+        gh,
+        title="Subsonic playback fails",
+        body="Playback stops immediately on every track.",
+        diagnostics=_diagnostics(message="playback failure"),
+        provider_labels={"subsonic"},
+        version="2.9.7",
+    )
+
+    fetched = [path for path in gh.raw_reads if path.startswith("music_assistant/")]
+    assert len(set(fetched)) <= code_context._MAX_PROVIDER_FILES
+
+
+def test_the_fetch_budget_is_per_provider_for_each_reported_provider():
+    """Two reported providers means two directories, and two budgets."""
+    tree = _tree(
+        *(
+            f"music_assistant/providers/{domain}/mod{index:02d}.py"
+            for domain in ("opensubsonic", "spotify")
+            for index in range(30)
+        )
+    )
+    gh = FakeGH(tree=tree)
+
+    code_context.build(
+        gh,
+        title="Subsonic and Spotify playback both fail",
+        body="Playback stops immediately on every track from either source.",
+        diagnostics=_diagnostics(message="playback failure"),
+        provider_labels={"subsonic", "spotify"},
+        version="2.9.7",
+    )
+
+    fetched = {path for path in gh.raw_reads if path.startswith("music_assistant/")}
+    assert len(fetched) <= code_context._MAX_PROVIDER_FILES * 2
+    for domain in ("opensubsonic", "spotify"):
+        in_domain = [p for p in fetched if f"/{domain}/" in p]
+        assert 0 < len(in_domain) <= code_context._MAX_PROVIDER_FILES


### PR DESCRIPTION
Stacked on #6143.

Provider code context was assembled from seven hardcoded filenames —
`manifest.json`, `helpers.py`, `__init__.py`, `provider.py`, `client.py`,
`ARCHITECTURE.md`, `strings.json` — tried against each reported provider.
Providers do not agree to that: they carry parsers, models, auth helpers and
subpackages under names of their own choosing.

### Measured

I mined an eval set for this: closed support issues carry cross-referenced
timeline events pointing at the server PR that fixed them, and that PR's changed
files are the answer key. 322 issues with a known fix.

- **58 of the 141 issues whose fix lay inside the reported provider's directory
  — 41% — were in a file none of those seven names would ever request.**
- Listing the directory moves recall@5 from 25% to 34%, recall@10 from 26% to 42%.

The git tree is the authority on what a directory holds, and `get_tree` already
fetches it for the docs corpus. One listing also replaces up to fourteen
speculative fetches, most of which 404: the median provider directory holds six
files against seven guessed names.

### The cap, and one result that went against my instinct

Candidates are capped because a listing has no natural bound and one directory
runs to 48 files. Ten is where the measurement stops improving — identical
recall to no cap at all.

I assumed the conventional filenames should be ordered first so the cap dropped
the long tail. **Measured, that is worse: recall@5 27% against 34%.** Those seven
names are the files every provider *has*, not the ones that explain a bug. So
ordering is by path depth, which hardcodes nothing.

`get_tree` also now logs a truncated response, which callers would otherwise
read as a directory holding fewer files.

306 tests pass on Python 3.12.