### PR TITLE
Run the code trace in its own job

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -157,6 +157,7 @@ Maintainer override labels: `triage/hold` (pause automation), `triage/skip`
 | `TRIAGE_AI_ENABLED` | `false` | `true` | Evidence-grounded GitHub Models assessment. |
 | `TRIAGE_RAG_ENABLED` | `true` | `true` (default) | Docs answers, pinned notices and related reports. |
 | `TRIAGE_DISCUSSIONS_ENABLED` | `false` | `true` | Docs-grounded triage on new/edited Discussions. |
+| `TRIAGE_CODE_TRACE_ENABLED` | `false` | `false` | Let the assessment model search a server checkout for the code behind a report. |
 | `TRIAGE_SCAN_LOGS` | `true` | `true` (default) | Redact and scan a raw log when diagnostics are absent. |
 | `TRIAGE_AI_MODEL` | `openai/gpt-4o-mini` | default | Evidence assessment model. |
 | `TRIAGE_ANSWER_MODEL` | `openai/gpt-4o` | default | Docs judge/answer model. |
@@ -211,6 +212,7 @@ tokens.
 
 | Workflow job | App-token permissions | Traced use |
 |---|---|---|
+| `triage.yml` / `trace` | none — built-in `GITHUB_TOKEN` only | Searches a checkout of the server repository under the direction of untrusted issue text. Holds `contents: read` and `copilot-requests: write`, no App token, and cannot comment. |
 | `triage.yml` / `analyze` | `contents: read`, `discussions: read`, `issues: write`, `metadata: read` | Read releases, manifests and RAG indexes; read pinned Discussions; search issues; read/update issues, labels, assignees and sticky comments. |
 | `triage.yml` / `respond` | `issues: write` | Read the issue and update response-state labels. |
 | `triage_scheduled.yml` / `sweep` | `issues: write` | List issues/comments, post reminders, update labels and close stale issues. |

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -8,6 +8,7 @@ shell interpolation of untrusted issue content):
     python -m ma_triage respond     # react to a new issue comment
     python -m ma_triage sweep       # scheduled reminder / auto-close pass
     python -m ma_triage discussion  # answer a new/edited discussion (RAG)
+    python -m ma_triage trace       # find the code behind an issue (no token)
 
 Required env: ``GITHUB_TOKEN``. Issue subcommands also read ``ISSUE_NUMBER``
 (and, for triage, ``ISSUE_TITLE`` / ``ISSUE_BODY``). Feature flags come from the
@@ -16,15 +17,18 @@ Required env: ``GITHUB_TOKEN``. Issue subcommands also read ``ISSUE_NUMBER``
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from . import (
     ai,
     analyze,
     code_context,
+    code_trace,
     comment,
     config,
     embeddings,
@@ -368,6 +372,39 @@ def _diag_status(result: TriageResult) -> str:
     return "missing"
 
 
+def cmd_trace() -> int:
+    """Find the code behind the reported problem, for the triage job to use.
+
+    Runs in a job of its own, holding no credential that can write to the
+    repository, because it searches a tree under the direction of issue text
+    written by the public. Its whole output is a list of paths on disk.
+
+    Always exits 0: tracing is an optimisation, and a trace that fails must
+    leave triage to run on its deterministic selection rather than block it.
+    """
+    destination = config.CODE_TRACE_PATHS_FILE
+    if not destination:
+        log("TRIAGE_TRACED_PATHS is required to record traced paths")
+        return 0
+    if not code_trace.enabled():
+        log("Code tracing is disabled")
+        Path(destination).write_text("[]")
+        return 0
+
+    body = os.environ.get("ISSUE_BODY", "")
+    if not find_diagnostics_url(body):
+        # Without diagnostics the report never reaches the assessment, so
+        # anything found here would have no consumer.
+        log("No diagnostics attached — nothing would read a traced path")
+        Path(destination).write_text("[]")
+        return 0
+
+    paths = code_trace.trace(title=os.environ.get("ISSUE_TITLE", ""), body=body)
+    Path(destination).write_text(json.dumps(paths, indent=1))
+    log(f"Traced {len(paths)} candidate path(s)")
+    return 0
+
+
 def cmd_respond(gh: GitHubClient) -> int:
     number = int(_env("ISSUE_NUMBER"))
     actor = _env("COMMENT_AUTHOR_LOGIN")
@@ -708,10 +745,17 @@ def main(argv: list[str] | None = None) -> int:
     if not argv:
         log(
             "usage: python -m ma_triage "
-            "{triage|respond|sweep|index|index-append|discussion|discussion-append}"
+            "{triage|trace|respond|sweep|index|index-append|"
+            "discussion|discussion-append}"
         )
         return 2
     command = argv[0]
+
+    # Tracing reads a local checkout and writes a local file. Dispatched before
+    # the client is built because it needs no API access, and a job that needs
+    # no token should not be handed one.
+    if command == "trace":
+        return cmd_trace()
 
     token = os.environ.get("GITHUB_TOKEN", "")
     if not token:

--- a/.github/scripts/tests/test_code_trace.py
+++ b/.github/scripts/tests/test_code_trace.py
@@ -187,3 +187,73 @@ def test_load_survives_a_corrupt_artifact(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(config, "CODE_TRACE_PATHS_FILE", str(recorded))
     assert code_trace.load() == []
     assert "Traced paths ignored" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# The `trace` subcommand, which is the whole of the separate job.
+# --------------------------------------------------------------------------- #
+def _run_command(monkeypatch, tmp_path, *, body, enabled=True, traced=None):
+    from ma_triage import __main__ as main
+
+    destination = tmp_path / "traced-paths.json"
+    monkeypatch.setattr(config, "CODE_TRACE_PATHS_FILE", str(destination))
+    monkeypatch.setattr(config, "CODE_TRACE_ENABLED", enabled)
+    monkeypatch.setattr(config, "CODE_TRACE_CHECKOUT", str(tmp_path))
+    monkeypatch.setenv("ISSUE_TITLE", "Players drop out")
+    monkeypatch.setenv("ISSUE_BODY", body)
+    monkeypatch.setattr(
+        main.code_trace, "trace", lambda **kwargs: list(traced or [])
+    )
+    code = main.cmd_trace()
+    written = json.loads(destination.read_text()) if destination.exists() else None
+    return code, written
+
+
+def test_the_trace_command_needs_no_github_token(monkeypatch, tmp_path):
+    """It reads a local checkout and writes a local file, nothing more — so the
+    job that runs it is never handed a credential."""
+    from ma_triage import __main__ as main
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(config, "CODE_TRACE_PATHS_FILE", str(tmp_path / "out.json"))
+    monkeypatch.setattr(config, "CODE_TRACE_ENABLED", False)
+    assert main.main(["trace"]) == 0
+
+
+def test_the_trace_command_records_what_it_found(monkeypatch, tmp_path):
+    code, written = _run_command(
+        monkeypatch,
+        tmp_path,
+        body="Logs attached https://github.com/user-attachments/files/1/diag.json",
+        traced=["music_assistant/helpers/util.py"],
+    )
+    assert code == 0
+    assert written == ["music_assistant/helpers/util.py"]
+
+
+def test_the_trace_command_writes_an_empty_result_when_disabled(
+    monkeypatch, tmp_path
+):
+    """`analyze` downloads this artifact; absent and empty must mean the same."""
+    code, written = _run_command(
+        monkeypatch,
+        tmp_path,
+        body="Logs attached https://github.com/user-attachments/files/1/diag.json",
+        enabled=False,
+        traced=["never/used.py"],
+    )
+    assert code == 0
+    assert written == []
+
+
+def test_the_trace_command_skips_a_report_with_no_diagnostics(monkeypatch, tmp_path):
+    """Without diagnostics the report never reaches the assessment, so a traced
+    path would have no consumer and the model call would be spent for nothing."""
+    code, written = _run_command(
+        monkeypatch,
+        tmp_path,
+        body="It just stopped working, no file attached.",
+        traced=["music_assistant/helpers/util.py"],
+    )
+    assert code == 0
+    assert written == []

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -32,11 +32,83 @@ permissions:
   contents: read
 
 jobs:
+  # Searches a checkout of the server repository for the code behind the report,
+  # and writes the paths it finds for `analyze` to pick up.
+  #
+  # Separate from `analyze` on purpose, and for the same reason `index-append` is
+  # separate: this job runs a model with search tools over text a member of the
+  # public wrote, so it must not be the job that can comment. It holds no app
+  # token, and neither checkout keeps its credentials on disk — a process that
+  # can read files is a process that can read `.git/config`.
+  trace:
+    # Gated at the job, not only in the script: with tracing off there is no
+    # consumer for a traced path, and an ungated job would still pay for two
+    # checkouts and a CLI install on every issue while `analyze` waited on it.
+    if: >-
+      ${{ vars.TRIAGE_CODE_TRACE_ENABLED == 'true'
+      && vars.TRIAGE_AI_ENABLED == 'true'
+      && ((github.event_name == 'issues' && !github.event.issue.pull_request)
+      || github.event_name == 'workflow_dispatch') }}
+    runs-on: ubuntu-latest
+    # `analyze` waits on this job, so a hung trace delays the comment a
+    # reporter is waiting for. The tracer stops itself after four minutes; this
+    # bounds everything around it.
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      copilot-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: music-assistant/server
+          ref: ${{ vars.TRIAGE_SERVER_REF || 'dev' }}
+          path: server
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        working-directory: .github/scripts
+        run: pip install -r requirements.txt
+      - uses: ./.github/actions/setup-copilot
+      - name: Trace the code behind the report
+        working-directory: .github/scripts
+        env:
+          # Untrusted content — safe because it is an env var, not shell input.
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          TRIAGE_CODE_TRACE_ENABLED: ${{ vars.TRIAGE_CODE_TRACE_ENABLED }}
+          TRIAGE_SERVER_CHECKOUT: ${{ github.workspace }}/server
+          TRIAGE_TRACED_PATHS: ${{ runner.temp }}/traced-paths.json
+          # The built-in token, never the personal PAT that `analyze` may fall
+          # back to. `cat` is one of the tools this job grants, and a process
+          # that can read files can read its own `/proc/self/environ`, so this
+          # job must hold only a credential scoped to this run. That ties
+          # tracing to org Copilot seats, which is why it ships disabled.
+          COPILOT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python -m ma_triage trace
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: traced-paths
+          path: ${{ runner.temp }}/traced-paths.json
+          if-no-files-found: ignore
+          retention-days: 1
+
   analyze:
     # Opened/edited/reopened issues (never PRs), or a manual dispatch.
+    #
+    # `needs: trace` only orders the two; `!cancelled()` keeps this job running
+    # when the trace failed, timed out or was skipped. Code tracing is an
+    # optimisation and deterministic triage must not depend on it, while a
+    # cancelled run still stops.
+    needs: [trace]
     if: >-
-      ${{ (github.event_name == 'issues' && !github.event.issue.pull_request)
-      || github.event_name == 'workflow_dispatch' }}
+      ${{ !cancelled()
+      && ((github.event_name == 'issues' && !github.event.issue.pull_request)
+      || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,6 +134,12 @@ jobs:
         run: pip install -r requirements.txt
       - uses: ./.github/actions/start-embeddings
       - uses: ./.github/actions/setup-copilot
+      - name: Collect the traced paths
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: traced-paths
+          path: ${{ runner.temp }}
       - name: Triage issue
         working-directory: .github/scripts
         env:
@@ -83,6 +161,9 @@ jobs:
           TRIAGE_ANSWER_LO: ${{ vars.TRIAGE_ANSWER_LO }}
           TRIAGE_DOCS_REPO: ${{ vars.TRIAGE_DOCS_REPO }}
           TRIAGE_SERVER_REF: ${{ vars.TRIAGE_SERVER_REF }}
+          # Written by the `trace` job. Absent whenever tracing is off or the
+          # trace did not finish, which reads as "no traced paths".
+          TRIAGE_TRACED_PATHS: ${{ runner.temp }}/traced-paths.json
           TRIAGE_INDEX_BRANCH: ${{ vars.TRIAGE_INDEX_BRANCH }}
           TRIAGE_DOCS_MAX_PER_PAGE: ${{ vars.TRIAGE_DOCS_MAX_PER_PAGE }}
           TRIAGE_RELATED_POSTS: ${{ vars.TRIAGE_RELATED_POSTS }}


### PR DESCRIPTION
Stacked on #6145. This is the diff that wants security attention.

Tracing searches a source tree under the direction of issue text a member of the
public wrote. The job that does that should not also be the job holding an app
token with `issues: write`, so it gets one of its own — the same split, and the
same reasoning, as the `index-append` job that can write repo contents but
deliberately cannot comment.

### What closes the boundary

- **No app token.** The trace job holds `contents: read` and
  `copilot-requests: write`, nothing else.
- **Built-in token only, never the personal PAT.** `cat` is one of the tools this
  job grants, and a process that can read files can read its own
  `/proc/self/environ` — no chaining needed. Whatever this job holds is readable
  by the model it is steering, so it holds only a credential scoped to the run.
  **This ties tracing to org Copilot seats**, which is one reason it ships
  disabled.
- **No token at all for the script.** `python -m ma_triage trace` is dispatched
  before the API client is built, because it needs none.
- **Neither checkout keeps credentials.** Depends on #6141 for the rest of them.
- **Narrow output channel.** A list of paths, each re-validated for shape on the
  far side of the artifact boundary, where they become fetch URLs.

### Failure behaviour

`analyze` orders itself after the trace with `!cancelled()` rather than
`always()`: a failed, skipped or timed-out trace leaves triage running on its
deterministic selection, while a cancelled run still stops. The download is
`continue-on-error`, and a missing artifact reads as "no traced paths" — which is
also what the trace job writes when tracing is off, so absent and empty mean the
same thing.

### Cost

Gated at the job on `TRIAGE_CODE_TRACE_ENABLED` and `TRIAGE_AI_ENABLED`, so with
either off it costs nothing rather than paying for two checkouts and a CLI
install while `analyze` waits. Bounded at fifteen minutes for the same reason.

A report with no diagnostics attachment is skipped before the model is called:
it can never reach the assessment, so anything found would have no consumer.

When enabled it adds roughly a minute to a triage run — measured median 81s per
trace — and a second CLI invocation per issue.

### Still unverified

`persist-credentials: false` behaving as expected on the runner, and a valid
Copilot token through the scrubbed environment. Both need a dry-run dispatch;
neither is something CI can show.

325 tests pass on Python 3.12.