### PR TITLE
Let the trace job see the reported problem

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -212,7 +212,7 @@ tokens.
 
 | Workflow job | App-token permissions | Traced use |
 |---|---|---|
-| `triage.yml` / `trace` | none — built-in `GITHUB_TOKEN` only | Searches a checkout of the server repository under the direction of untrusted issue text. Holds `contents: read` and `copilot-requests: write`, no App token, and cannot comment. |
+| `triage.yml` / `trace` | none — built-in `GITHUB_TOKEN` only | Searches a checkout of the server repository under the direction of untrusted issue text. Holds `contents: read`, `issues: read` and `copilot-requests: write`, no App token, and cannot comment. The read token is scoped to the step that fetches the issue, so it is absent from the environment that launches the model. |
 | `triage.yml` / `analyze` | `contents: read`, `discussions: read`, `issues: write`, `metadata: read` | Read releases, manifests and RAG indexes; read pinned Discussions; search issues; read/update issues, labels, assignees and sticky comments. |
 | `triage.yml` / `respond` | `issues: write` | Read the issue and update response-state labels. |
 | `triage_scheduled.yml` / `sweep` | `issues: write` | List issues/comments, post reminders, update labels and close stale issues. |

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -372,6 +372,34 @@ def _diag_status(result: TriageResult) -> str:
     return "missing"
 
 
+def _reported_problem() -> tuple[str, str]:
+    """The issue's title and body for the trace job.
+
+    The event payload is used when present. A manual dispatch carries none, so
+    the workflow fetches the issue to a file and this reads that instead.
+
+    Returns empty strings only when neither source has anything, and says which
+    one was missing: this command cannot fail, so its log is the only place a
+    broken wiring can show itself.
+    """
+    title = _env("ISSUE_TITLE")
+    body = _env("ISSUE_BODY")
+    if title or body:
+        return title, body
+    if not config.CODE_TRACE_ISSUE_FILE:
+        log("No issue payload, and TRIAGE_ISSUE_FILE names no fetched copy")
+        return "", ""
+    try:
+        issue = json.loads(Path(config.CODE_TRACE_ISSUE_FILE).read_text())
+    except (OSError, ValueError) as exc:
+        log(f"Could not read the fetched issue: {exc}")
+        return "", ""
+    if not isinstance(issue, dict):
+        log(f"Fetched issue was {type(issue).__name__}, expected an object")
+        return "", ""
+    return str(issue.get("title") or ""), str(issue.get("body") or "")
+
+
 def cmd_trace() -> int:
     """Find the code behind the reported problem, for the triage job to use.
 
@@ -391,7 +419,13 @@ def cmd_trace() -> int:
         Path(destination).write_text("[]")
         return 0
 
-    body = os.environ.get("ISSUE_BODY", "")
+    title, body = _reported_problem()
+    if not (title or body):
+        # Distinct from the skip below: nothing arrived to look at, which is a
+        # wiring fault rather than a property of the report.
+        log("Code tracing skipped: the reported problem never reached this job")
+        Path(destination).write_text("[]")
+        return 0
     if not find_diagnostics_url(body):
         # Without diagnostics the report never reaches the assessment, so
         # anything found here would have no consumer.
@@ -399,7 +433,7 @@ def cmd_trace() -> int:
         Path(destination).write_text("[]")
         return 0
 
-    paths = code_trace.trace(title=os.environ.get("ISSUE_TITLE", ""), body=body)
+    paths = code_trace.trace(title=title, body=body)
     Path(destination).write_text(json.dumps(paths, indent=1))
     log(f"Traced {len(paths)} candidate path(s)")
     return 0

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -309,6 +309,10 @@ CODE_TRACE_CHECKOUT = _env_str("TRIAGE_SERVER_CHECKOUT", "")
 # searches a tree under the direction of public issue text holds no token that
 # can write to the repository.
 CODE_TRACE_PATHS_FILE = _env_str("TRIAGE_TRACED_PATHS", "")
+# The reported problem, fetched to a file for the trace job. A manual dispatch
+# carries no issue payload, so the file is the only source of the issue text
+# there, and reading one keeps that job free of an API client and its token.
+CODE_TRACE_ISSUE_FILE = _env_str("TRIAGE_ISSUE_FILE", "")
 # The report as handed to the tracer. Smaller than MAX_AI_INPUT_CHARS because
 # the tracer gets only the report, never the diagnostics or retrieved evidence.
 MAX_TRACE_INPUT_CHARS = 6000

--- a/.github/scripts/tests/test_code_trace.py
+++ b/.github/scripts/tests/test_code_trace.py
@@ -257,3 +257,120 @@ def test_the_trace_command_skips_a_report_with_no_diagnostics(monkeypatch, tmp_p
     )
     assert code == 0
     assert written == []
+
+
+def _run_with_capture(monkeypatch, tmp_path, *, title=""):
+    """Run `cmd_trace` and report the title and body the tracer was handed."""
+    from ma_triage import __main__ as main
+
+    monkeypatch.setattr(config, "CODE_TRACE_PATHS_FILE", str(tmp_path / "out.json"))
+    monkeypatch.setattr(config, "CODE_TRACE_ENABLED", True)
+    monkeypatch.setattr(config, "CODE_TRACE_CHECKOUT", str(tmp_path))
+    if title:
+        monkeypatch.setenv("ISSUE_TITLE", title)
+    seen = {}
+
+    def fake_trace(*, title, body):
+        seen["title"] = title
+        seen["body"] = body
+        return []
+
+    monkeypatch.setattr(main.code_trace, "trace", fake_trace)
+    main.cmd_trace()
+    return seen
+
+
+def test_the_trace_command_reads_the_issue_the_workflow_fetched(
+    monkeypatch, tmp_path
+):
+    """A manual dispatch carries no issue payload, so the environment is empty
+    on exactly the path a maintainer uses to test."""
+    from ma_triage import __main__ as main
+
+    fetched = tmp_path / "issue.json"
+    fetched.write_text(
+        json.dumps(
+            {
+                "title": "Playback stops after ten minutes",
+                "body": "Logs: https://github.com/user-attachments/files/1/diag.json",
+            }
+        )
+    )
+    destination = tmp_path / "traced-paths.json"
+    monkeypatch.setattr(config, "CODE_TRACE_PATHS_FILE", str(destination))
+    monkeypatch.setattr(config, "CODE_TRACE_ISSUE_FILE", str(fetched))
+    monkeypatch.setattr(config, "CODE_TRACE_ENABLED", True)
+    monkeypatch.setattr(config, "CODE_TRACE_CHECKOUT", str(tmp_path))
+    monkeypatch.delenv("ISSUE_TITLE", raising=False)
+    monkeypatch.delenv("ISSUE_BODY", raising=False)
+    seen = {}
+
+    def fake_trace(*, title, body):
+        seen["title"] = title
+        seen["body"] = body
+        return ["music_assistant/helpers/util.py"]
+
+    monkeypatch.setattr(main.code_trace, "trace", fake_trace)
+
+    assert main.cmd_trace() == 0
+    assert seen["title"] == "Playback stops after ten minutes"
+    assert json.loads(destination.read_text()) == ["music_assistant/helpers/util.py"]
+
+
+def test_the_event_payload_wins_over_the_fetched_copy(monkeypatch, tmp_path):
+    """An issue event already carries the text; the fetch is for dispatch only."""
+    from ma_triage import __main__ as main
+
+    fetched = tmp_path / "issue.json"
+    fetched.write_text(json.dumps({"title": "stale", "body": "stale"}))
+    monkeypatch.setattr(config, "CODE_TRACE_ISSUE_FILE", str(fetched))
+    monkeypatch.setenv("ISSUE_BODY", "https://github.com/user-attachments/files/1/d.json")
+    seen = _run_with_capture(monkeypatch, tmp_path, title="from the event")
+
+    assert seen["title"] == "from the event"
+    assert "stale" not in seen["body"]
+
+
+def test_an_unreadable_fetched_issue_reports_the_wiring_not_the_report(
+    monkeypatch, tmp_path, capsys
+):
+    """This command cannot fail, so its log is the only place a broken wiring
+    can show itself — and it must not read as a property of the report."""
+    from ma_triage import __main__ as main
+
+    broken = tmp_path / "issue.json"
+    broken.write_text("{not json")
+    destination = tmp_path / "traced-paths.json"
+    monkeypatch.setattr(config, "CODE_TRACE_ISSUE_FILE", str(broken))
+    monkeypatch.setattr(config, "CODE_TRACE_PATHS_FILE", str(destination))
+    monkeypatch.setattr(config, "CODE_TRACE_ENABLED", True)
+    monkeypatch.setattr(config, "CODE_TRACE_CHECKOUT", str(tmp_path))
+    monkeypatch.delenv("ISSUE_TITLE", raising=False)
+    monkeypatch.delenv("ISSUE_BODY", raising=False)
+
+    assert main.cmd_trace() == 0
+    err = capsys.readouterr().err
+    assert "Could not read the fetched issue" in err
+    assert "never reached this job" in err
+    assert "No diagnostics attached" not in err
+    assert json.loads(destination.read_text()) == []
+
+
+def test_no_payload_and_no_fetched_copy_names_the_missing_wiring(
+    monkeypatch, tmp_path, capsys
+):
+    """The configuration as shipped before the fetch step existed."""
+    from ma_triage import __main__ as main
+
+    destination = tmp_path / "traced-paths.json"
+    monkeypatch.setattr(config, "CODE_TRACE_ISSUE_FILE", "")
+    monkeypatch.setattr(config, "CODE_TRACE_PATHS_FILE", str(destination))
+    monkeypatch.setattr(config, "CODE_TRACE_ENABLED", True)
+    monkeypatch.setattr(config, "CODE_TRACE_CHECKOUT", str(tmp_path))
+    monkeypatch.delenv("ISSUE_TITLE", raising=False)
+    monkeypatch.delenv("ISSUE_BODY", raising=False)
+
+    assert main.cmd_trace() == 0
+    err = capsys.readouterr().err
+    assert "TRIAGE_ISSUE_FILE" in err
+    assert "No diagnostics attached" not in err

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -56,6 +56,10 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      # Reading the issue on a manual dispatch. A public repo can be read
+      # unauthenticated, but that shares a 60/hour limit across every runner on
+      # the same address, so it fails intermittently rather than never.
+      issues: read
       copilot-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -74,12 +78,30 @@ jobs:
         working-directory: .github/scripts
         run: pip install -r requirements.txt
       - uses: ./.github/actions/setup-copilot
+      - name: Fetch the reported problem
+        # A manual dispatch carries no issue payload. The token lives in this
+        # step alone: the step after it launches a model holding file-reading
+        # tools, and must not have a credential anywhere in its environment.
+        # `gh api` authenticated from GH_TOKEN leaves nothing on disk either —
+        # only `gh auth login` writes a credential file — so the fetched copy is
+        # the public issue text and nothing more.
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+        run: |
+          gh api "/repos/${REPOSITORY}/issues/${ISSUE_NUMBER}" \
+            --jq '{title, body}' > "${RUNNER_TEMP}/issue.json"
       - name: Trace the code behind the report
         working-directory: .github/scripts
         env:
           # Untrusted content — safe because it is an env var, not shell input.
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          # Only read when the payload above is empty, which is the dispatch
+          # case; an issue event always carries a title.
+          TRIAGE_ISSUE_FILE: ${{ runner.temp }}/issue.json
           TRIAGE_CODE_TRACE_ENABLED: ${{ vars.TRIAGE_CODE_TRACE_ENABLED }}
           TRIAGE_SERVER_CHECKOUT: ${{ github.workspace }}/server
           TRIAGE_TRACED_PATHS: ${{ runner.temp }}/traced-paths.json


### PR DESCRIPTION
Found by the dry run, not by CI.

`ISSUE_TITLE` and `ISSUE_BODY` come from `github.event.issue`, which a manual
dispatch does not have. `cmd_triage` already falls back to the API for that;
`cmd_trace` had no fallback, because it is dispatched before the API client is
built so its job needs no token. It therefore saw an empty body, found no
diagnostics link, and skipped — on **every manual dispatch**, which is how a
maintainer tests this.

Dispatched against #6132, which carries a diagnostics file, the trace job logged
`No diagnostics attached — nothing would read a traced path`. Every unit test
passed and CI was green throughout.

### The fix

The workflow fetches the issue to a file when there is no payload, and the
command falls back to that.

A file rather than the environment, because there is no safe route into a
*later* step's environment: that means `$GITHUB_ENV`, where a body carrying a
crafted delimiter can set arbitrary variables. Passing the text to the step as
an env var stays safe and is what an issue event already does.

`GH_TOKEN` lives in the fetch step alone — the step after it launches a model
holding file-reading tools. `gh api` authenticated from the environment writes
nothing to disk (only `gh auth login` does), so the fetched copy is the public
issue text and nothing more. `issues: read` is declared rather than relying on
unauthenticated public reads, which share a 60/hour limit across every runner on
an address and so fail intermittently rather than never.

### The message was wrong beyond this instance

The skip reported a property of the report when what had happened was that no
report arrived. Missing input is now its own branch with its own message, and
each way the wiring can fail says which one it was. `cmd_trace` always exits
zero, so its log is the only place a fault can surface — the same reasoning that
put a reason on every `copilot.run` failure.

### Tests

329 pass. Three of the four new tests fail against pre-fix `main`, and fail
behaviourally rather than on a missing symbol, because they all drive
`cmd_trace` rather than the private helper. The fourth passes both before and
after by design: it pins that an issue event's payload still wins, which this
does not change.

### Not fixed by this

Tracing still cannot run end to end: org Copilot seats are 0/`unconfigured`, and
the trace job deliberately takes the built-in token, so its CLI call is refused
regardless. This makes the feature testable by dispatch; it does not make it
work.