### PR TITLE
Run the code trace on the Copilot PAT

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -212,7 +212,7 @@ tokens.
 
 | Workflow job | App-token permissions | Traced use |
 |---|---|---|
-| `triage.yml` / `trace` | none — built-in `GITHUB_TOKEN` only | Searches a checkout of the server repository under the direction of untrusted issue text. Holds `contents: read`, `issues: read` and `copilot-requests: write`, no App token, and cannot comment. The read token is scoped to the step that fetches the issue, so it is absent from the environment that launches the model. |
+| `triage.yml` / `trace` | none — built-in `GITHUB_TOKEN` only | Searches a checkout of the server repository under the direction of untrusted issue text. Holds `contents: read`, `issues: read` and `copilot-requests: write`, no App token, and cannot comment. The read token is scoped to the step that fetches the issue, so it is absent from the environment that launches the model. The Copilot credential is not: while it is a personal PAT rather than the org-billed built-in token, it sits in the environment of the process the model runs in, and that model has file-reading tools. |
 | `triage.yml` / `analyze` | `contents: read`, `discussions: read`, `issues: write`, `metadata: read` | Read releases, manifests and RAG indexes; read pinned Discussions; search issues; read/update issues, labels, assignees and sticky comments. |
 | `triage.yml` / `respond` | `issues: write` | Read the issue and update response-state labels. |
 | `triage_scheduled.yml` / `sweep` | `issues: write` | List issues/comments, post reminders, update labels and close stale issues. |

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -105,12 +105,19 @@ jobs:
           TRIAGE_CODE_TRACE_ENABLED: ${{ vars.TRIAGE_CODE_TRACE_ENABLED }}
           TRIAGE_SERVER_CHECKOUT: ${{ github.workspace }}/server
           TRIAGE_TRACED_PATHS: ${{ runner.temp }}/traced-paths.json
-          # The built-in token, never the personal PAT that `analyze` may fall
-          # back to. `cat` is one of the tools this job grants, and a process
-          # that can read files can read its own `/proc/self/environ`, so this
-          # job must hold only a credential scoped to this run. That ties
-          # tracing to org Copilot seats, which is why it ships disabled.
-          COPILOT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Falls through to the workflow token once org Copilot seats exist,
+          # so moving off the personal PAT is a secret deletion. Matches the
+          # `analyze` job, which already runs on the same credential.
+          #
+          # KNOWN EXPOSURE while the PAT is the credential in use: this job
+          # grants the model file-reading tools, and `/proc/self/environ` is a
+          # file, so the token in this environment is readable by the model
+          # that issue text is steering. It cannot be sent anywhere from here —
+          # no granted binary opens a network connection, and the only output
+          # channel is a path list filtered against the checkout — but it can
+          # be read into a prompt. The built-in token closes that off, and is
+          # refused until the org configures Copilot seats.
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT || secrets.GITHUB_TOKEN }}
         run: python -m ma_triage trace
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
The trace job asked for a Copilot request with the built-in token, which the org
refuses. Checked rather than assumed:

```
org music-assistant   plan: enterprise
policies              cli: enabled · platform_chat: enabled · ide_chat: enabled
seat_breakdown        total: 0
seat_management_setting: "unconfigured"
```

The policies that would *permit* org-billed Copilot are on; the seats that would
*pay* for it were never configured. That is why the error reads `Access denied
by policy settings` when the real cause is "no entitlement to bill". Every other
Copilot call in this repo already runs on a maintainer's PAT for the same
reason, including the assessment in `analyze`.

So the trace job now uses the same expression `analyze` does. When seats are
configured, deleting the `COPILOT_PAT` secret moves both jobs to org billing
with no code change.

### The cost, stated where the token is set

This is not the same trade as `analyze`'s, and the comment says so rather than
letting a reader assume the two jobs are equivalent. The trace job grants the
model file-reading tools, and `/proc/self/environ` is a file, so the credential
in that environment is readable by the model that issue text is steering.

Bounded, but not zero:

- it cannot be sent anywhere from the job — no granted binary opens a network
  connection, and the tool allowlist is `grep`/`cat`/`ls`/`head`/`wc`, none of
  which can invoke a second command (verified: `;`, `&&` and `| sh` are all
  refused by the permission layer)
- the only output channel is a path list, filtered to files that exist in the
  checkout, so a token cannot ride out as a result
- what it can do is read the token into a prompt

The built-in token closes that off entirely, and is what this returns to once
the org can bill for it.

### Also worth knowing before enabling

With this in place, each issue costs two Copilot requests instead of one,
charged to the PAT owner, on a trigger the reporter controls via `issues:
edited`. `TRIAGE_CODE_TRACE_ENABLED` still defaults to `false`.

329 tests pass on Python 3.12.