### PR TITLE
Apply the frontend label the repository actually has

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_frontend_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_frontend_bug_report.yml
@@ -1,6 +1,6 @@
 name: 🖥️ Frontend/UI bug report
 description: Report a visual or user-interface bug in the Music Assistant web app.
-labels: ["triage", "frontend"]
+labels: ["triage", "Frontend"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
One word. `2_frontend_bug_report.yml` asks GitHub for `frontend`; the label in
this repository is `Frontend`. GitHub silently drops a declared label that does
not match an existing one, so the form has only ever applied `triage`.

### What that costs

`form_kind` classifies from labels, so every frontend report is treated as a
main server bug report. Measured over a 2000-issue sample, by looking for the
frontend form's own heading in the body rather than by label:

- **10 issues were filed on the frontend form**
- **0 carried the label**
- **10 of 10 were asked by the bot for a diagnostics `.json` or for how they run
  Music Assistant** — neither of which that form collects

Most recent is #6138, where the reporter was told their screenshot was not a log
file. A screenshot is the attachment that form asks for.

Confirmation that it has never worked: every issue currently carrying `Frontend`
had it applied by a human — OzGav or MarvinSchenkel — never once at creation.

### Why `Frontend` and not renaming the label

Capitalised matches the other multi-word labels here (`HA Player`, `Spotify
Connect`, `Chromecast`, `WiiM`), and renaming would break saved filters and
existing links. Nothing in the bot needs to change: `form_kind` already
lowercases both sides, and `config.LABEL_FRONTEND` can stay lowercase.

### Not fixed by this

Reports already filed keep their labels, so the ten above stay misclassified
until relabelled or until the bot learns to read the form from the body. That is
a separate change; this one stops new reports being misdirected and needs no
Python.

There is also a mirror of this bug reachable today — a main-form report that a
maintainer labels `Frontend` gets asked for a section its form does not contain
— which the same follow-up addresses. #5475 is a live example.