### PR TITLE
Show the model more of the file it was given

### DIFF
--- a/.github/scripts/ma_triage/code_context.py
+++ b/.github/scripts/ma_triage/code_context.py
@@ -52,6 +52,13 @@ _STOP_WORDS = frozenset(
     }
 )
 _MAX_PROVIDER_FILES = 10
+# One file's share of the evidence block, so the per-file and total budgets
+# cannot contradict each other.
+_EXCERPT_CHARS = config.MAX_CODE_CONTEXT_CHARS // config.MAX_CODE_CONTEXT_FILES
+# The best-scoring window keeps its surroundings; later ones are tightened, so
+# the budget reaches more of the file than it reaches around one line of it.
+_EXCERPT_RADIUS = 3
+_EXCERPT_RADIUS_TAIL = 1
 _PACKAGING_HINTS = (
     "binary",
     "dependency",
@@ -177,37 +184,46 @@ def _line_score(line: str, terms: set[str]) -> int:
     return sum(min(len(term), 24) for term in terms if term in lowered)
 
 
-def _excerpt(text: str, terms: set[str], max_chars: int = 1400) -> tuple[int, str]:
+def _excerpt(
+    text: str, terms: set[str], max_chars: int = _EXCERPT_CHARS
+) -> tuple[int, str]:
+    """Score a file against ``terms``, and quote the lines that earned it.
+
+    Returns ``(0, "")`` when no line matches. ``max_chars`` bounds the quoted
+    text and is the only limit on how many windows it holds.
+    """
     lines = text.splitlines()
+    scored = [(_line_score(line, terms), index) for index, line in enumerate(lines)]
+    # Highest score first; among equals the earliest line, which is where a
+    # module's public surface sits.
     ranked = sorted(
-        (
-            (_line_score(line, terms), index)
-            for index, line in enumerate(lines)
-        ),
-        reverse=True,
+        ((score, index) for score, index in scored if score > 0),
+        key=lambda item: (-item[0], item[1]),
     )
-    ranked = [(score, index) for score, index in ranked if score > 0]
     if not ranked:
         return 0, ""
 
     selected: set[int] = set()
-    blocks: list[str] = []
+    blocks: list[tuple[int, str]] = []
     selected_scores: list[int] = []
     used = 0
-    for score, index in ranked[:8]:
-        if index in selected:
+    for score, index in ranked:
+        radius = _EXCERPT_RADIUS if not blocks else _EXCERPT_RADIUS_TAIL
+        window = range(max(0, index - radius), min(len(lines), index + radius + 1))
+        if selected.intersection(window):
+            # Overlapping windows would quote the same line in two blocks, and
+            # split one contiguous region into what reads as several places.
             continue
-        window = range(max(0, index - 3), min(len(lines), index + 4))
         rendered = "\n".join(f"L{line + 1}: {lines[line]}" for line in window)
         if used + len(rendered) + 2 > max_chars:
             continue
-        blocks.append(rendered)
+        blocks.append((index, rendered))
         selected_scores.append(score)
         selected.update(window)
         used += len(rendered) + 2
     if not blocks:
         return 0, ""
-    excerpt = "\n\n".join(blocks)
+    excerpt = "\n\n".join(text for _, text in sorted(blocks))
     distinct_matches = sum(1 for term in terms if term in excerpt.lower())
     return max(selected_scores) + distinct_matches * 5, excerpt
 

--- a/.github/scripts/tests/test_code_context.py
+++ b/.github/scripts/tests/test_code_context.py
@@ -1,5 +1,7 @@
 """Tests for bounded official server-code evidence retrieval."""
 
+import re
+
 from conftest import FakeGH
 from ma_triage import code_context, config
 from ma_triage.models import Diagnostics, ExceptionEntry, SystemInfo
@@ -258,3 +260,73 @@ def test_the_fetch_budget_is_per_provider_for_each_reported_provider():
     for domain in ("opensubsonic", "spotify"):
         in_domain = [p for p in fetched if f"/{domain}/" in p]
         assert 0 < len(in_domain) <= code_context._MAX_PROVIDER_FILES
+
+
+def test_excerpt_breaks_a_score_tie_toward_the_top_of_the_file():
+    """Among lines that score equally, the earliest is the one quoted."""
+    lines = ["filler"] * 400
+    lines[10] = "def set_shuffle(queue_id, shuffle_enabled):"
+    for index in range(300, 340):
+        lines[index] = "queue.shuffle_enabled = shuffle_enabled"
+    terms = {"shuffle", "enabled"}
+
+    _, excerpt = code_context._excerpt("\n".join(lines), terms)
+
+    shown = {int(n) for n in re.findall(r"^L(\d+): ", excerpt, re.M)}
+    assert 11 in shown, f"the definition was never quoted: {sorted(shown)[:6]}"
+
+
+def test_excerpt_spends_its_budget_on_more_places_not_more_context():
+    """A file's relevant code is rarely all in one spot, so only the best
+    window keeps its full surroundings and the rest are tightened.
+    """
+    lines = ["a fairly long line of filler that eats into the budget"] * 900
+    relevant = tuple(range(20, 900, 60))
+    for index in relevant:
+        lines[index] = "shuffle_enabled matters on this particular line here"
+    terms = {"shuffle", "enabled", "matters"}
+
+    _, excerpt = code_context._excerpt("\n".join(lines), terms, max_chars=1000)
+
+    shown = {int(n) for n in re.findall(r"^L(\d+): ", excerpt, re.M)}
+    reached = sum(1 for index in relevant if index + 1 in shown)
+    assert len(excerpt) <= 1000
+    assert reached >= 4, f"only reached {reached} of {len(relevant)} locations"
+
+
+def test_excerpt_never_quotes_the_same_line_twice():
+    """Windows that overlap would repeat lines and split one contiguous region
+    into what reads as several separate places in the file."""
+    lines = ["filler"] * 400
+    for index in range(100, 140):
+        lines[index] = "queue.shuffle_enabled = shuffle_enabled"
+
+    _, excerpt = code_context._excerpt("\n".join(lines), {"shuffle", "enabled"})
+
+    quoted = [int(n) for n in re.findall(r"^L(\d+): ", excerpt, re.M)]
+    assert len(quoted) == len(set(quoted)), f"repeated lines: {sorted(quoted)}"
+
+
+def test_build_reaches_several_files_when_each_one_fills_its_share():
+    """The per-file budget is a share of the total, so a long first file cannot
+    swallow the whole block and starve the ones behind it."""
+    paths = [f"music_assistant/providers/opensubsonic/mod{n}.py" for n in range(6)]
+    body = "\n".join(
+        f"def handler_{n}(): return 'playback stalled on subsonic'" for n in range(60)
+    )
+    gh = FakeGH(
+        tree=_tree(*paths),
+        raw_files={path: body for path in paths},
+    )
+
+    evidence = code_context.build(
+        gh,
+        title="Subsonic playback stalled",
+        body="Playback stalled on every track.",
+        diagnostics=_diagnostics(message="playback stalled"),
+        provider_labels={"subsonic"},
+        version="2.9.7",
+    )
+
+    assert evidence.count("SOURCE: ") >= 4
+    assert len(evidence) <= config.MAX_CODE_CONTEXT_CHARS


### PR DESCRIPTION
Retrieval now finds the right file far more often than the excerpt shows the
right part of it.

On #6152 the tracer returned every file in `controllers/player_queues/`, and the
model was quoted `controller.py:1774-1780` when `set_shuffle` is at line **248**.
It said it could not confirm the mechanism and dropped confidence to 40% — the
correct response to the evidence it had. The failure was ours, not the model's.

### Three causes, all in `_excerpt`

**Ties resolved toward the end of the file.** `sorted((score, index),
reverse=True)` orders equal scores by descending index, and equal scores are the
common case — on #6152 thirteen lines tied at the top score, the handler among
them, and every quoted window came from the last 39% of the file.

**The budget bought context rather than coverage.** Seven lines around every
match leaves no room for the file's other relevant locations.

**Windows could overlap**, because the already-quoted check tested a window's
centre while the whole window was marked. Narrower windows make that systematic:
a dense run of matches quoted eight lines twice and split one contiguous region
into blocks that read as separate places. Caught in review, not by me.

**The per-file budget is now a share of the total.** 1400 chars against five
files never fit the 5000-char block, so `MAX_CODE_CONTEXT_FILES` was unreachable
and a long first file starved the rest.

### Measured

New harness. Ground truth is each fixing PR's own patch hunk headers, which name
the range in the **pre-fix** file, so files are fetched at the PR's `base.sha` —
the tree triage actually sees. 110 issues, 162 gold files. The question: does the
excerpt contain a line the fix changed?

| | shipped | this change |
|---|---|---|
| shows a line the fix changed | 33% | **37%** |
| duplicated lines across 162 files | 0 | 0 |
| mean excerpt | 1006 chars | 910 chars |
| files fitting the 5000-char block | 4 | **5** |

**My first diagnosis was wrong at the aggregate level.** I predicted the
tie-break was the main problem; measured, it is worth about 2 points and window
width about 8. #6152 is a real instance of the tie-break, but not a
representative one.

An intermediate version scored 43% by keeping the 1400-char per-file budget —
but that spends a whole file to buy per-file coverage, taking the block from
four files to three. Deriving the budget from the total is better on both axes
than what ships today rather than trading one for the other.

### Where the rest of it is

The ceiling for this measure is **77%** — for the remaining 23%, no line the fix
touched matches any word in the report. That is a vocabulary problem, not a
layout one. Hit rate also falls with file size (68% under 200 lines, 46% at
200-600, 37% at 600-1500, 33% over 1500), which points at ranking: `_line_score`
weights a term by its length and has no notion of rarity, so in a file about
queues the word `queue` counts as much as the word that actually matters.
That is the next change, not this one.

333 tests pass on Python 3.12. Three of the four new tests fail against `main`
behaviourally rather than on a missing symbol; the fourth is a guard against
file starvation and passes both before and after by design.