### PR TITLE
Give the search the time a runner actually needs

### DIFF
--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -309,12 +309,16 @@ CODE_TRACE_CHECKOUT = _env_str("TRIAGE_SERVER_CHECKOUT", "")
 # searches a tree under the direction of public issue text holds no token that
 # can write to the repository.
 CODE_TRACE_PATHS_FILE = _env_str("TRIAGE_TRACED_PATHS", "")
-# How long the model may search. What is left of the time a reporter waits once
-# the job around it and the assessment after it are paid for; how much a search
-# needs depends on the size of the tree TRIAGE_SERVER_REF names, so it is
-# tunable without a release. Raising it past six minutes has no effect: the job
-# is cancelled at seven, and a cancelled job uploads nothing at all.
-CODE_TRACE_TIMEOUT = _env_int("TRIAGE_CODE_TRACE_TIMEOUT", 360)
+# How long the model may search. A runner searches a great deal more slowly than
+# a laptop does — measured on seven runs against the same tree, a search that
+# takes 139s locally takes 250-280s here, and the ones that need longest are the
+# reports where a trace is worth most. Cutting them off returns nothing, while
+# letting them run costs only the reports that were slow anyway: most finish in
+# a few minutes and are unaffected by where this sits.
+#
+# Raising it past fourteen minutes has no effect: the job is cancelled at
+# fifteen, and a cancelled job uploads nothing at all.
+CODE_TRACE_TIMEOUT = _env_int("TRIAGE_CODE_TRACE_TIMEOUT", 840)
 # The reported problem, fetched to a file for the trace job. A manual dispatch
 # carries no issue payload, so the file is the only source of the issue text
 # there, and reading one keeps that job free of an API client and its token.

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -51,14 +51,15 @@ jobs:
       || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     # `analyze` waits on this job, so a slow trace delays the comment a reporter
-    # is waiting for. Seven minutes here and three on `analyze` hold the pair to
-    # the ten a reporter may wait, whatever either of them does.
+    # is waiting for. Most searches finish in a few minutes and are unaffected
+    # by this; it exists for the tail, where cutting the search off returns
+    # nothing at all rather than returning late.
     #
     # The search stops itself first, via TRIAGE_CODE_TRACE_TIMEOUT. It has to,
     # because a job cancelled at this limit uploads no artifact and the trace is
     # wasted entirely. Keep the search below this minus the steps before it,
     # which measured 15s and 13s on two production runs.
-    timeout-minutes: 7
+    timeout-minutes: 15
     permissions:
       contents: read
       # Reading the issue on a manual dispatch. A public repo can be read


### PR DESCRIPTION
Found by dry-running the merged tracing feature before enabling it.

The search limit was calibrated from local timings. Measured on seven production
runs against the same tree, a runner is about twice as slow:

```
 66s -> 2 paths      264s -> 6 paths      276s -> 3 paths      287s -> 4 paths
268s -> 0 paths (a genuine empty answer)
376s -> cut off      386s -> cut off
```

Two of seven returned nothing because the six-minute limit stopped them, not
because there was nothing to find. Locally the same searches median at 139s.

The earlier tail measurement is the reason this matters: of thirteen searches
that returned nothing inside a shorter limit, **twelve finished when simply
allowed to run**, and six of those thirteen finished inside the original limit
when run a second time — so the limit was cutting a noisy distribution rather
than excluding hard reports.

Fourteen minutes for the search, fifteen for the job. **Most searches finish in a
few minutes and are unaffected by where this sits** — four of the seven above
finished between 66 and 287 seconds. This only changes what happens to the tail,
where the choice is between a late answer and no answer.

A search that still runs out returns nothing rather than late, and triage
continues on its deterministic selection, which is what the two cut-off runs
above did: both logged the timeout plainly and still produced a comment.

Also verified in those runs: tracing degrades exactly as designed. One run
logged `Code tracing skipped: ... timed out after 360 seconds` and `analyze`
carried on and produced its assessment.