### PR TITLE
Degrade when the embeddings server does not start

### DIFF
--- a/.github/actions/start-embeddings/action.yml
+++ b/.github/actions/start-embeddings/action.yml
@@ -90,8 +90,10 @@ runs:
           echo "TRIAGE_EMBED_BATCH=4"
           # Empty when the server never came up. The bot then keeps its
           # configured model string and finds no endpoint to call, which is the
-          # same degraded state as an unreachable provider.
-          [ -n "$model" ] && echo "TRIAGE_EMBED_MODEL=$model"
+          # same degraded state as an unreachable provider. Written with `if`
+          # rather than `&&` because a false test is this step's last command,
+          # and under `-e` that fails the job the degradation exists to avoid.
+          if [ -n "$model" ]; then echo "TRIAGE_EMBED_MODEL=$model"; fi
         } >> "$GITHUB_ENV"
 
 # NOTE: callers must not set TRIAGE_EMBED_DIM, _MODEL, _ENDPOINT or _BATCH in a


### PR DESCRIPTION
Pre-existing, and unrelated to anything in flight — found by dry-running
something else.

`start-embeddings` ends its last step with:

```bash
[ -n "$model" ] && echo "TRIAGE_EMBED_MODEL=$model"
```

`$model` is empty when the embeddings server did not come up. The test is then
false, it is the final command of a step run under `bash -e`, and the step exits
1 — failing the whole `analyze` job.

The comment immediately above that line describes the opposite intent:

> Empty when the server never came up. The bot then keeps its configured model
> string and finds no endpoint to call, which is the same degraded state as an
> unreachable provider.

Reproduced exactly, running the step body the way the action does:

```
empty model   -> exit 1
model present -> exit 0
```

An `if` instead of `&&` so a false test is not the step's exit status.

### How often

Once in the last hundred triage runs, so the embeddings server is reliable. But
on that run the reporter got **no comment at all**, where a degraded one was
available — and triage is built to survive an unreachable provider. Losing the
whole comment to its own setup is the one failure mode the design does not
account for.