### PR TITLE
Don't append to a posts index this configuration did not build

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -614,6 +614,19 @@ def cmd_index_append(gh: GitHubClient, token: str) -> int:
         "updated_at": issue.get("updated_at"),
     }
     index, embedded = embeddings.append_post(gh, post, token=token)
+    if index is None:
+        # The stored index was built by a different schema, model or width.
+        # Appending rewrites the header, which would relabel those records as
+        # current, so it is left for the scheduled build to rebuild instead.
+        # Quieter than the vectorless case below even though it writes nothing
+        # at all: `_collect_posts` re-reads from the API rather than the index,
+        # so the rebuild picks this post up regardless.
+        summary(
+            f"issue #{number}: the posts index is awaiting a rebuild, so it "
+            "was not appended to. This becomes visible to dense duplicate "
+            "detection after the next scheduled build."
+        )
+        return 0
     if not embedded:
         # Annotate but exit 0 on purpose: this runs inside per-issue triage, and
         # failing here would mark every incoming issue's workflow red for a
@@ -753,6 +766,15 @@ def cmd_discussion_append(gh: GitHubClient, token: str) -> int:
         "updated_at": _now_iso(),
     }
     index, embedded = embeddings.append_post(gh, post, token=token)
+    if index is None:
+        # See `cmd_index_append`: a header this configuration did not build is
+        # left for the scheduled rebuild rather than relabelled.
+        summary(
+            f"discussion #{number}: the posts index is awaiting a rebuild, so "
+            "it was not appended to. This becomes visible to dense duplicate "
+            "detection after the next scheduled build."
+        )
+        return 0
     if not embedded:
         # Annotate but exit 0 on purpose: this runs inside per-issue triage, and
         # failing here would mark every incoming issue's workflow red for a

--- a/.github/scripts/ma_triage/embeddings.py
+++ b/.github/scripts/ma_triage/embeddings.py
@@ -157,6 +157,21 @@ def dim_matches(index: dict[str, Any]) -> bool:
     return isinstance(stored, int) and stored > 0
 
 
+def index_is_current(index: dict[str, Any] | None) -> bool:
+    """Whether a stored index was built by the current schema, model and width.
+
+    The three are one compatibility key rather than three separate checks: every
+    reader accepts an index only when all of them agree, so anything that
+    rewrites the header has to answer the same question they ask.
+    """
+    return bool(
+        index
+        and index.get("schema") == _SCHEMA
+        and index.get("model") == config.EMBED_MODEL
+        and dim_matches(index)
+    )
+
+
 def load_docs_chunks(gh: GitHubClient) -> list[DocChunk]:
     """Load ``docs.json`` into :class:`DocChunk` objects (with embeddings)."""
     index = load_index(gh, config.DOCS_INDEX_PATH)
@@ -341,6 +356,12 @@ def reusable_vector(cached: dict[str, Any] | None, sha: str) -> bool:
     The sha check is what keeps a vector paired with the text it was computed
     from; an edited post fails it and must be re-embedded before its vector can
     be trusted again.
+
+    It covers the reporter's text only, not the schema, model or width that
+    turned it into a vector — those live in the header and are checked by
+    :func:`index_is_current`. A record carried into an index whose header says
+    something else therefore passes here forever, which is why `append_post`
+    refuses to rewrite a header it did not build.
     """
     return bool(cached and cached.get("sha") == sha and cached.get("embedding"))
 
@@ -515,11 +536,12 @@ def build_posts_index(
 
 def append_post(
     gh: GitHubClient, post: dict[str, Any], *, token: str
-) -> tuple[dict[str, Any], bool]:
+) -> tuple[dict[str, Any] | None, bool]:
     """Embed a single new post and upsert it into the posts index.
 
     Returns the index and whether the upserted record carries a vector, so the
     caller can report a provider outage without having to inspect the record.
+    ``None`` when the stored index predates the current schema — see below.
 
     Between nightly builds this is the only path that admits new posts, so it
     writes the record whether or not a vector could be obtained. Unlike the
@@ -527,8 +549,27 @@ def append_post(
     for unchanged text is kept rather than overwritten with a vectorless
     record — a post edited during a provider outage would otherwise lose a good
     vector it could not get back until the next successful build.
+
+    An index the current configuration did not build is left alone rather than
+    appended to. This path rewrites the whole header, so appending would stamp
+    the current schema, model and width onto records produced by a previous one
+    — and `post_sha` covers the reporter's raw text rather than the embedder
+    that read it, so the nightly build would then accept every relabelled record
+    as current and never rebuild it. Until the append, that mismatch is
+    self-healing: the readers reject the file outright and the next scheduled
+    build re-embeds it. A post waiting for that build loses a day of dense
+    visibility; relabelling costs the index its correctness for good.
     """
-    previous = load_index(gh, config.POSTS_INDEX_PATH) or _empty_posts_index()
+    previous = load_index(gh, config.POSTS_INDEX_PATH)
+    if previous is not None and not index_is_current(previous):
+        log(
+            f"Posts index was built by schema {previous.get('schema')} / "
+            f"{previous.get('model')} / dim {previous.get('dim')}, not "
+            f"{_SCHEMA} / {config.EMBED_MODEL} / dim {config.EMBED_DIM or 'any'}; "
+            "leaving it for the scheduled rebuild rather than appending to it."
+        )
+        return None, False
+    previous = previous or _empty_posts_index()
     vector = embed_text(
         f"{post.get('title', '')}\n\n{post.get('body', '')}", token=token
     )

--- a/.github/scripts/tests/test_embeddings.py
+++ b/.github/scripts/tests/test_embeddings.py
@@ -388,3 +388,62 @@ def test_dim_matches_accepts_any_real_width_when_none_is_requested(monkeypatch):
     # 0 means no vectors were stored, so there is nothing to rank against.
     assert not embeddings.dim_matches({"dim": 0})
     assert not embeddings.dim_matches({})
+
+
+# --- append must not relabel a header it did not build ------------------------ #
+def _stale_index(**header):
+    base = {
+        "schema": embeddings._SCHEMA,
+        "model": config.EMBED_MODEL,
+        "dim": 512,
+        "posts": [{"kind": "issue", "number": 1, "title": "old", "excerpt": "e",
+                   "sha": "x", "embedding": "AA=="}],
+    }
+    base.update(header)
+    return base
+
+
+@pytest.mark.parametrize(
+    ("header", "why"),
+    [
+        ({"schema": embeddings._SCHEMA - 1}, "an older schema"),
+        ({"model": "some-other/embedder"}, "a different embedder"),
+        ({"dim": 1024}, "a different vector width"),
+    ],
+)
+def test_append_leaves_an_index_it_did_not_build_alone(
+    ai_on, monkeypatch, header, why
+):
+    """Appending rewrites the header, which would relabel every record under it.
+
+    `post_sha` covers the reporter's raw text, not the embedder that read it, so
+    once relabelled the nightly build accepts those records as current and never
+    rebuilds them. Until then the mismatch is self-healing — the readers reject
+    the file and the next build re-embeds it.
+    """
+    monkeypatch.setattr(config, "EMBED_DIM", 512)
+    monkeypatch.setattr(
+        embeddings, "embed_texts", lambda texts, *, token: [[0.1] for _ in texts]
+    )
+    gh = FakeGH(
+        index_files={config.POSTS_INDEX_PATH: json.dumps(_stale_index(**header))}
+    )
+    index, embedded = embeddings.append_post(
+        gh, {"kind": "issue", "number": 2, "title": "new", "body": "b",
+             "url": "u", "state": "open"}, token="t",
+    )
+    assert index is None and embedded is False, why
+
+
+def test_append_still_creates_the_first_index(ai_on, monkeypatch):
+    """No index yet is not the same state as an index that does not match."""
+    monkeypatch.setattr(config, "EMBED_DIM", 0)
+    monkeypatch.setattr(
+        embeddings, "embed_texts", lambda texts, *, token: [[0.1] for _ in texts]
+    )
+    index, embedded = embeddings.append_post(
+        FakeGH(), {"kind": "issue", "number": 2, "title": "new", "body": "b",
+                   "url": "u", "state": "open"}, token="t",
+    )
+    assert index is not None and embedded is True
+    assert [p["number"] for p in index["posts"]] == [2]


### PR DESCRIPTION
`append_post` reads whatever index is stored and rewrites the whole header, stamping the current schema, model and vector width onto records produced by a previous one. Nothing downstream can tell afterwards: `post_sha` covers the reporter's raw title and body, not the embedder that read them, so the nightly build accepts every relabelled record as current and never rebuilds it, and `cosine` scores the mismatched widths 0.0 — the posts stay in the file and disappear from duplicate detection without an error anywhere.

Until the append, that state is self-healing. The readers check schema, model and width together and reject the file outright, the lexical fallback keeps serving from its text, and the next scheduled build re-embeds everything. The append is what converts a recoverable mismatch into a permanent one.

The three fields are one compatibility key, so `index_is_current` now expresses it once and the writer asks exactly what the readers ask. An index that fails it is left alone: the incoming post waits for the scheduled build, which costs it a day of dense visibility and no more, since posts are collected from the API rather than from the index.