### PR TITLE
Stop ranking reports on the form they share

### DIFF
--- a/.github/scripts/ma_triage/embeddings.py
+++ b/.github/scripts/ma_triage/embeddings.py
@@ -30,7 +30,7 @@ from typing import Any
 
 import requests
 
-from . import config, docs
+from . import config, docs, template
 from .gh import GitHubClient, log
 from .models import DocChunk
 from .retrieval import decode_vec, encode_vec
@@ -122,6 +122,26 @@ def _chunk_embed_input(chunk: DocChunk) -> str:
 # --------------------------------------------------------------------------- #
 # Index (de)serialisation
 # --------------------------------------------------------------------------- #
+def post_excerpt(body: str | None) -> str:
+    """
+    The stored excerpt: BM25F's body field, and the assessment's evidence.
+
+    Stripped of the issue form's consent block, which is identical in nearly
+    every report and so tells a ranker nothing about which two reports match.
+    Every excerpt reaching a comment or the assessment is built here, whether it
+    came from the index, the search fallback or a pinned notice.
+    The embedded text is *not* stripped: the embedder pools the last token of a
+    capped input, so removing text from the top pulls new text past the cap and
+    changes the vector wholesale — measured as a recall loss on exactly the
+    long reports it applies to.
+
+    Both writers below must produce this identically, or an excerpt that differs
+    from the stored one reads as a metadata change and rewrites the index on
+    every run.
+    """
+    return template.strip_boilerplate(str(body or ""))[: config.RELATED_EXCERPT_CHARS]
+
+
 def _dumps(index: dict[str, Any]) -> str:
     return json.dumps(index, separators=(",", ":"), sort_keys=True)
 
@@ -371,7 +391,7 @@ def _post_record(
             },
             key=str.lower,
         ),
-        "excerpt": str(post.get("body", ""))[: config.RELATED_EXCERPT_CHARS],
+        "excerpt": post_excerpt(post.get("body")),
         "sha": post_sha(str(post.get("title", "")), str(post.get("body", ""))),
     }
     if embedding:
@@ -465,7 +485,7 @@ def build_posts_index(
                 },
                 key=str.lower,
             )
-            excerpt = str(post.get("body", ""))[: config.RELATED_EXCERPT_CHARS]
+            excerpt = post_excerpt(post.get("body"))
             if record.get("providers") != providers:
                 record["providers"] = providers
                 metadata_changed = True

--- a/.github/scripts/ma_triage/rag.py
+++ b/.github/scripts/ma_triage/rag.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import hashlib
 from urllib.parse import urlparse
 
-from . import ai, config, embeddings, similar
+from . import ai, config, embeddings, similar, template
 from .gh import GitHubClient, log
 from .models import DocAnswer, DocChunk, DocHit, ProviderDoc, RagResult
 from .retrieval import cosine, retrieve_docs
@@ -134,6 +134,11 @@ def answer(
     try:
         query_text = f"{title}\n\n{body}".strip()
         query_vec = embeddings.embed_text(query_text, token=token)
+        # The lexical leg of `retrieve_docs` ranks tokens, and the consent block
+        # names the troubleshooting guide and the supported installations — the
+        # two pages it then pulls every query towards. The dense leg keeps the
+        # unstripped text, which is what its vectors were built from.
+        lexical_query = f"{title}\n\n{template.strip_boilerplate(body)}".strip()
 
         # A docs answer needs the query vector. Without one `retrieve_docs`
         # ranks on its BM25 leg alone, and the judge would then be paid to
@@ -144,7 +149,7 @@ def answer(
         doc_hits: list[DocHit] = []
         if query_vec is not None:
             chunks = embeddings.load_docs_chunks(gh)
-            doc_hits = retrieve_docs(query_vec, query_text, chunks)
+            doc_hits = retrieve_docs(query_vec, lexical_query, chunks)
             doc_hits = _promote_provider_docs(
                 query_vec,
                 chunks,

--- a/.github/scripts/ma_triage/similar.py
+++ b/.github/scripts/ma_triage/similar.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import re
 
-from . import config
+from . import config, embeddings, template
 from .gh import GitHubClient, log
 from .models import RelatedPost
 from .providers import detect_provider_labels_from_text
@@ -150,7 +150,10 @@ def related_from_lexical(
 
     titles = [tokenize(post.get("title")) for post in candidates]
     bodies = [tokenize(post.get("excerpt")) for post in candidates]
-    query = tokenize(f"{query_title}\n\n{query_body}")
+    # Stripped to match the excerpts being ranked. While both carried the form's
+    # consent block those terms cancelled out; against stripped excerpts they are
+    # terms almost no document has, and idf rewards whichever still holds them.
+    query = tokenize(f"{query_title}\n\n{template.strip_boilerplate(query_body)}")
     scores = bm25f_scores(
         query,
         {"title": titles, "body": bodies},
@@ -219,7 +222,7 @@ def related_from_search(
                 url=str(item.get("html_url", "")),
                 score=0.0,
                 state=item.get("state"),
-                excerpt=str(item.get("body", ""))[: config.RELATED_EXCERPT_CHARS],
+                excerpt=embeddings.post_excerpt(item.get("body")),
                 source="search",
             )
         )
@@ -320,9 +323,7 @@ def find_pinned(
                 score=1.0,
                 state="closed" if discussion.get("closed") else "open",
                 source="pinned",
-                excerpt=str(discussion.get("body", ""))[
-                    : config.RELATED_EXCERPT_CHARS
-                ],
+                excerpt=embeddings.post_excerpt(discussion.get("body")),
             )
         )
     return matches

--- a/.github/scripts/ma_triage/template.py
+++ b/.github/scripts/ma_triage/template.py
@@ -56,7 +56,22 @@ PROVIDER_SCAN_SECTIONS = (
     SECTION_ANYTHING_ELSE,
 )
 
+# Consent sections, matched by lowercase heading *prefix* rather than in full.
+# Each has carried a markdown link whose URL changed at least once, and the
+# index reaches back to 2022, so four generations of the wording sit in it at
+# the same time. The prefix is the part that stayed put.
+CONSENT_SECTION_PREFIXES = (
+    "before you begin",
+    "carefully read the troubleshooting faq",
+    "mandatory: carefully read",
+    "as applicable: carefully read",
+    "have you tried everything",
+    "have you included all",
+    "have you reviewed the",
+)
+
 _RE_SECTION = re.compile(r"^###\s+(.*?)\s*$")
+_RE_CHECKBOX = re.compile(r"^\s*[-*]\s*\[[ xX]\].*$", re.MULTILINE)
 # A line that looks like a log line: has a level keyword or an ISO-ish timestamp.
 _RE_LOG_LINE = re.compile(
     r"(?:\b(?:CRITICAL|ERROR|WARNING|WARN|INFO|DEBUG)\b)"
@@ -98,6 +113,40 @@ def parse_sections(body: str | None) -> dict[str, str]:
     if current is not None:
         sections[current] = "\n".join(buffer).strip()
     return sections
+
+
+def _is_consent_heading(name: str | None) -> bool:
+    """True for a heading that introduces the form's consent block."""
+    return (name or "").strip().lower().startswith(CONSENT_SECTION_PREFIXES)
+
+
+def strip_boilerplate(body: str | None) -> str:
+    """
+    Return ``body`` without the parts every report repeats word for word.
+
+    The consent block and its checkboxes are identical across nearly every
+    issue, so ranking one report against another spends most of the body field
+    comparing the form to itself. Headings and fenced blocks are deliberately
+    kept: an error string is often the only thing that makes two reports the
+    same, and dropping either measurably costs recall.
+
+    For lexical ranking only. The embedded text is deliberately left alone —
+    see :func:`embeddings.build_posts_index`.
+    """
+    if not body:
+        return ""
+    kept: list[str] = []
+    dropping = False
+    for line in body.splitlines():
+        heading = _RE_SECTION.match(line)
+        if heading:
+            dropping = _is_consent_heading(heading.group(1))
+        if dropping:
+            continue
+        kept.append(line)
+    # Older forms also asked for confirmations inline, outside a consent block.
+    text = _RE_CHECKBOX.sub("", "\n".join(kept))
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
 
 
 def _is_empty(content: str | None) -> bool:

--- a/.github/scripts/tests/test_embeddings.py
+++ b/.github/scripts/tests/test_embeddings.py
@@ -388,3 +388,45 @@ def test_dim_matches_accepts_any_real_width_when_none_is_requested(monkeypatch):
     # 0 means no vectors were stored, so there is nothing to rank against.
     assert not embeddings.dim_matches({"dim": 0})
     assert not embeddings.dim_matches({})
+
+
+# --- the excerpt is what BM25F ranks on --------------------------------------- #
+_CONSENT_BODY = (
+    "### Before you begin\n\n"
+    "- [x] I have read the [troubleshooting guide](https://www.music-assistant.io"
+    "/faq/troubleshooting/) and it did not solve my problem.\n\n"
+    "### What happened?\n\nAirPlay drops out mid-track"
+)
+
+
+def test_stored_excerpt_drops_the_consent_block(ai_on, monkeypatch):
+    monkeypatch.setattr(
+        embeddings, "embed_texts", lambda texts, *, token: [[0.1] for _ in texts]
+    )
+    post = {"kind": "issue", "number": 8, "title": "t", "body": _CONSENT_BODY,
+            "url": "u", "state": "open"}
+    index, _ = embeddings.build_posts_index(FakeGH(), [post], token="t")
+    excerpt = index["posts"][0]["excerpt"]
+    assert "troubleshooting guide" not in excerpt
+    assert "AirPlay drops out mid-track" in excerpt
+
+
+def test_embedded_text_is_left_unstripped(ai_on, monkeypatch):
+    """The embedder pools the last token of a capped input.
+
+    Stripping from the top pulls new text past the cap and changes the vector
+    wholesale, which measured as a recall loss on the long reports it applies
+    to. The excerpt is cleaned; what gets embedded is not.
+    """
+    seen: list[str] = []
+    monkeypatch.setattr(
+        embeddings, "embed_texts",
+        lambda texts, *, token: (seen.extend(texts), [[0.1] for _ in texts])[1],
+    )
+    embeddings.build_posts_index(
+        FakeGH(),
+        [{"kind": "issue", "number": 9, "title": "t", "body": _CONSENT_BODY,
+          "url": "u", "state": "open"}],
+        token="t",
+    )
+    assert "troubleshooting guide" in seen[0]

--- a/.github/scripts/tests/test_template.py
+++ b/.github/scripts/tests/test_template.py
@@ -97,3 +97,63 @@ def test_detect_log_wall_fenced():
 
 def test_no_log_wall_for_short_body():
     assert template.detect_log_wall("just a short description") is False
+
+
+# --- boilerplate stripping ---------------------------------------------------- #
+def test_strip_boilerplate_drops_the_consent_block():
+    body = (
+        "### Before you begin\n\n"
+        "- [x] I have searched the [open and closed issues](https://x).\n"
+        "- [X] I have read the [troubleshooting guide](https://y).\n\n"
+        "### What happened?\n\nAirPlay goes silent when the group is joined"
+    )
+    stripped = template.strip_boilerplate(body)
+    assert "Before you begin" not in stripped
+    assert "troubleshooting guide" not in stripped
+    assert "### What happened?" in stripped
+    assert "AirPlay goes silent when the group is joined" in stripped
+
+
+def test_strip_boilerplate_covers_every_form_generation():
+    """The index reaches back to 2022, so all four wordings are live at once."""
+    for heading in (
+        "Before you begin",
+        "Carefully read the Troubleshooting FAQ and confirm that",
+        "Mandatory: Carefully read the Troubleshooting FAQ and confirm that",
+        "As Applicable: Carefully read the Troubleshooting FAQ and confirm that",
+        "Have you tried everything in the Troubleshooting FAQ and reviewed the "
+        "Open and Closed Issues and Discussions to resolve this yourself?",
+        "Have you included ALL of the information specified in the "
+        "Troubleshooting FAQ or explained why you cannot",
+        "Have you reviewed the [Open](https://a) and [Closed](https://b) Issues "
+        "to resolve this yourself?",
+    ):
+        stripped = template.strip_boilerplate(
+            f"### {heading}\n\n- [x] Yes\n\n### The problem\n\nNo sound"
+        )
+        assert heading.split("[")[0].strip() not in stripped, heading
+        assert "No sound" in stripped
+
+
+def test_strip_boilerplate_keeps_logs_and_headings():
+    """Error text is what makes two reports the same; it has to survive."""
+    body = (
+        "### What happened?\n\nPlayback fails\n\n"
+        "```\n2026-08-14 ERROR [ffmpeg.1065] Invalid data found\n```\n\n"
+        "### Anything else?\n\nNothing"
+    )
+    stripped = template.strip_boilerplate(body)
+    assert "ERROR [ffmpeg.1065] Invalid data found" in stripped
+    assert "### What happened?" in stripped and "### Anything else?" in stripped
+
+
+def test_strip_boilerplate_removes_inline_checkboxes():
+    stripped = template.strip_boilerplate(
+        "### The problem\n\n- [ ] not yet done\nReal text here"
+    )
+    assert "not yet done" not in stripped and "Real text here" in stripped
+
+
+def test_strip_boilerplate_handles_empty_input():
+    assert template.strip_boilerplate(None) == ""
+    assert template.strip_boilerplate("") == ""


### PR DESCRIPTION
## What

Every report carries the same consent block — a heading, confirmation
checkboxes, and the links inside them. It is stored verbatim in each record's
`excerpt`, which is BM25F's body field and the evidence the AI assessment reads.
Around 450 of the 1200 excerpt characters said nothing about the report, so
ranking one report against another spent most of that field comparing the form
to itself.

This strips it, at every point an excerpt is produced.

## Measurement

Over the 144 mined duplicate pairs (34 strong, 110 weak), replayed through
`similar.related_from_lexical` against records built by `embeddings._post_record`
— the shipped path, with each arm scoring its own excerpts with its own query:

| pairs | n | recall@3 | recall@5 | recall@10 |
| --- | --- | --- | --- | --- |
| strong | 34 | 38% → 44% | 44% → 53% | 47% → 65% |
| weak | 110 | 27% → 35% | 32% → 39% | 37% → 43% |
| all | 144 | 30% → 38% | 35% → 42% | 40% → 48% |

## What is deliberately not changed

**The embedded text.** Stripping it was measured too, against the model CI
serves, and it makes dense retrieval *worse*: recall@5 49% → 48% over the same
144 pairs, and 50% → 44% on the strong ones. The cause is the interaction with
`MAX_POST_EMBED_CHARS` — Qwen3-Embedding pools the last token, so removing text
from the top pulls new text past the cap and changes the vector wholesale. The
loss is entirely in the 22 pairs where at least one side is long enough to
truncate (32% → 14%); where neither side truncates it is mildly positive.
`test_embedded_text_is_left_unstripped` pins this so it is not "tidied up" later.

**The schema.** An excerpt is metadata, so `build_posts_index` rewrites the
field through its `metadata_changed` branch and reuses every cached vector. A
schema bump would discard 3.9 MB of vectors and force a full re-embed for no
reason.

## Notes for review

- Four heading generations are present in the index simultaneously, and each has
  carried a markdown link whose URL has changed, so they are matched by
  lowercase prefix rather than in full.
- Headings and fenced blocks are kept. Dropping either measurably costs recall:
  an error string is often the only thing that makes two reports the same.
- `_RE_CHECKBOX` applies to the whole body, so a `- [ ]`-shaped line inside a
  fenced block goes too. Checked against all 3221 issue bodies; in practice it
  only ever matches consent blocks and inline confirmations.
- Between merge and the first successful `cmd_index`, stripped queries meet
  unstripped excerpts. That is the harmless direction — consent terms appear in
  nearly every document, so their idf is ~0 and they contributed almost nothing
  to BM25 anyway. Running `cmd_index` manually after merge closes it sooner.
- The lexical query is stripped to match, on both the related-posts path and the
  BM25 leg of docs retrieval, where the block's own words ("troubleshooting
  guide", "supported installation") were pulling every query towards those two
  pages. The dense leg keeps the unstripped query its vectors were built from.

## Test plan

`python -m pytest tests/` — 356 pass. Five new template tests cover all four
form generations, logs and headings surviving, inline checkboxes, and empty
input. Two new embeddings tests cover the stored excerpt and the invariant that
the embedded text stays unstripped.
