### PR TITLE
Index every issue, not the newest 2500

### DIFF
--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -427,10 +427,17 @@ BM25_B = 0.75
 # issues duplicate detection depends on.
 #
 # The ceiling that matters is on-disk size rather than post count: the index is
-# committed to git and rewritten whole on every new post. At ~0.7 KB per
-# quantised vector (see `retrieval.encode_vec`) these caps cost ~2 MB; under the
-# previous JSON-float encoding the same would have been ~30 MB.
-INDEX_MAX_ISSUES = _env_int("TRIAGE_INDEX_MAX_ISSUES", 2500)
+# committed to git and rewritten whole on every new post. Measured on the live
+# file: 1.4 KB per quantised 1024-wide vector (see `retrieval.encode_vec`) plus
+# up to `RELATED_EXCERPT_CHARS` of text, so ~2.3 KB a post. Under the previous
+# JSON-float encoding the vector alone would have been ~10x that.
+#
+# The issue cap covers the repository's whole history with headroom, because a
+# duplicate can point at any earlier report and one that is not indexed can
+# never be found. Discussions stay capped by recency: they are mostly feature
+# requests, which score near zero against a bug report, so the older ones buy
+# far less than they cost.
+INDEX_MAX_ISSUES = _env_int("TRIAGE_INDEX_MAX_ISSUES", 3500)
 INDEX_MAX_DISCUSSIONS = _env_int("TRIAGE_INDEX_MAX_DISCUSSIONS", 500)
 # Bounds how much is *fetched* before trimming; the per-kind caps above decide
 # what is kept.

--- a/.github/scripts/tests/test_config.py
+++ b/.github/scripts/tests/test_config.py
@@ -51,10 +51,10 @@ def test_empty_env_vars_fall_back_to_defaults(monkeypatch):
     assert config.ANSWER_HI == 0.75
     assert config.ANSWER_LO == 0.45
     assert config.RELATED_POSTS == 3
-    assert config.INDEX_MAX_ISSUES == 2500
+    assert config.INDEX_MAX_ISSUES == 3500
     assert config.INDEX_MAX_DISCUSSIONS == 500
     # The fetch bound defaults to the sum of the two per-kind caps.
-    assert config.INDEX_MAX_POSTS == 3000
+    assert config.INDEX_MAX_POSTS == 4000
     assert config.EMBED_MODEL == "openai/text-embedding-3-small"
     assert config.ANSWER_MODEL == "openai/gpt-4o"
     assert config.INDEX_BRANCH == "triage-index"


### PR DESCRIPTION
## What

`INDEX_MAX_ISSUES` was 2500 against a repository holding 3221 issues, so the
oldest 22% of them could never be returned as a related post. A duplicate can
point at any earlier report, and one that is not in the index is not merely
ranked badly — it is not a candidate at all.

This is the same failure mode that PR #6094 fixed when issues and discussions
shared a single cap, one size up.

## Sizing

The comment on these constants correctly says the ceiling that matters is
on-disk size, not post count, since the index is committed to git and rewritten
whole on every new post. Measured on the live file:

| | size |
| --- | --- |
| today, 3000 posts | 7.9 MB (vectors 3.9, excerpts 3.0, other 0.9) |
| same 3000 after #6258 | 6.8 MB |
| all 3221 issues + 500 discussions | 8.4 MB |

So net of the excerpt change this admits every issue for about half a megabyte
above where the file sits today. 3500 is measured headroom — roughly two more
years at the current rate — not a ceiling; the next bump should be re-derived
from a size budget rather than argued from scratch.

## Discussions stay at 500

Lifting them to the full 2130 costs four times what the issue change does. They
are mostly feature requests, which score near zero against a bug report, so the
older ones buy far less than they cost. Discussion-to-discussion matching is a
real capability but a separate one.

## Notes for review

- `vars.TRIAGE_INDEX_MAX_POSTS` is currently **unset**, which is what makes this
  effective: it is the only one of the three the workflows pass through, and
  `_collect_posts` fetches with it. If it is ever set, raising the per-kind caps
  here does nothing.
- The derived fetch bound goes 3000 → 4000, which also raises what
  `list_discussions` pages through against its unchanged 500 keep-cap. Not
  introduced here, but worth its own look at some point.
- Expect one red nightly while the newly admitted issues are embedded;
  `cmd_index` exits non-zero on a shortfall by design and still commits progress.

## Test plan

`python -m pytest tests/` — 349 pass, with the defaults asserted in
`test_config.py` updated.
