### PR TITLE
Show five related posts, not three

### DIFF
--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -390,15 +390,21 @@ DOCS_TOP_K = _env_int("TRIAGE_DOCS_TOP_K", 6)
 # the same page rank together, so without a cap the top-K is spent on one page.
 # The authoritative provider-doc promotion in rag.py deliberately overrides this.
 DOCS_MAX_PER_PAGE = _env_int("TRIAGE_DOCS_MAX_PER_PAGE", 1)
-RELATED_POSTS = _env_int("TRIAGE_RELATED_POSTS", 3)
+RELATED_POSTS = _env_int("TRIAGE_RELATED_POSTS", 5)
 # Two posts from the same project share a lot of vocabulary (players, providers,
 # playback, Home Assistant), so cosine between any two of them rarely drops below
-# ~0.35 — a floor set there filters nothing. Measured over live discussion
-# triage, the useful matches sit at ~0.65+ and the noise below ~0.55.
-RELATED_MIN_SCORE = _env_float("TRIAGE_RELATED_MIN_SCORE", 0.60)
+# ~0.35 — a floor set there filters nothing. Swept against the mined duplicate
+# pairs: raising it from 0.60 to 0.75 leaves recall unchanged at every k while
+# cutting the number of suggestions per issue, because confirmed duplicates
+# score 0.73 and above and the noise sits well below.
+RELATED_MIN_SCORE = _env_float("TRIAGE_RELATED_MIN_SCORE", 0.75)
 # Keep weak semantic matches available without presenting them as likely
-# duplicates. Only scores at/above this threshold render expanded.
-RELATED_EXPAND_SCORE = _env_float("TRIAGE_RELATED_EXPAND_SCORE", 0.70)
+# duplicates. Only scores at/above this threshold render expanded. It has to sit
+# above the floor or every match shown is also expanded and the weak tier is
+# unreachable. Measured over the mined pairs against 4000 random issue pairs:
+# confirmed duplicates run 0.63 to 0.86, random pairs peak around 0.64, and at
+# 0.80 a third of the confirmed pairs still clear it while no random pair does.
+RELATED_EXPAND_SCORE = _env_float("TRIAGE_RELATED_EXPAND_SCORE", 0.80)
 # Pinned Feature Polls mention providers but are not operational status notices.
 PINNED_EXCLUDE_CATEGORIES = tuple(
     c.strip().lower()

--- a/.github/scripts/tests/test_config.py
+++ b/.github/scripts/tests/test_config.py
@@ -50,7 +50,7 @@ def test_empty_env_vars_fall_back_to_defaults(monkeypatch):
     assert config.EMBED_BATCH == 64
     assert config.ANSWER_HI == 0.75
     assert config.ANSWER_LO == 0.45
-    assert config.RELATED_POSTS == 3
+    assert config.RELATED_POSTS == 5
     assert config.INDEX_MAX_ISSUES == 2500
     assert config.INDEX_MAX_DISCUSSIONS == 500
     # The fetch bound defaults to the sum of the two per-kind caps.


### PR DESCRIPTION
## What

Three constants that together make one operating point for related posts. They
are in one PR because changing any of them alone leaves a state that is worse
than either end: showing five results at a 0.60 floor fills the two new slots
with noise, and raising the floor without moving the expand threshold leaves the
weak tier unreachable.

| constant | before | after |
| --- | --- | --- |
| `RELATED_POSTS` | 3 | 5 |
| `RELATED_MIN_SCORE` | 0.60 | 0.75 |
| `RELATED_EXPAND_SCORE` | 0.70 | 0.80 |

## Why each

**Top-k.** Sweeping k against the mined duplicate pairs: 3 → 5 adds six points
of recall. Going on to 10 adds nine more but at nearly ten suggestions an issue,
which is far too many to put in a comment.

**Floor.** 0.60 is barely a filter — 39–49% of *random* issue pairs clear it,
while confirmed duplicates score 0.73 and above. Raising it to 0.75 costs no
recall at any k. This half is already live: `vars.TRIAGE_RELATED_MIN_SCORE` is
set to 0.75 on this repository, so it changes nothing in production and brings
the committed default in line with what we actually run. It is a real change for
local runs, tests and forks.

**Expand.** This is the one that changes what reporters see, and it fixes a
genuine inversion: at 0.70 the expand threshold sat *below* the floor, so every
match that got shown also rendered expanded. The `<details>` "possibly related"
block in `comment.py`, the `RELATED_POSTS_WEAK_*` copy, and the
`RELATED_EXPAND_SCORE` filter in `rag.answer`'s `duplicates_only` branch were
all unreachable. That is already true in production via `vars`.

Measured over the mined pairs against 4000 random issue-to-issue pairs, using
the vectors the production model produces:

| threshold | confirmed pairs kept | random pairs kept |
| --- | --- | --- |
| 0.70 | 71% | 1.7% |
| 0.75 | 50% | 0.3% |
| 0.80 | 29% | 0.0% |

Confirmed duplicates run 0.63–0.86 and random pairs peak around 0.64. A floor at
0.75 with expansion at 0.80 gives a two-tier split where both tiers mean
something: above 0.80 is a likely duplicate, 0.75–0.80 is worth a look.

## Test plan

`python -m pytest tests/` — 349 pass, with the defaults asserted in
`test_config.py` updated. Worth eyeballing how a real comment renders with both
tiers populated, since the collapsed tier has effectively never been shown.
