### PR TITLE
Record the whole triage decision, not the half the comment shows

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -297,14 +297,28 @@ def apply_triage(
             gh.remove_label(number, stale)
 
     if result.should_comment or (result.rag is not None and result.rag.has_output):
+        # The whole decision, not the half of it the comment happens to show.
+        # Everything here already exists on `TriageResult` at this point; what
+        # is left out cannot be graded later, because GitHub records what the
+        # issue became but nothing records what the bot claimed about it.
+        #
+        # `v` says which keys are present, and nothing gates on it: v2 is v1 plus
+        # six fields, so a reader of either keeps working. Unlike `_SCHEMA` in
+        # `embeddings`, this is not a compatibility break and needs no migration.
         state = {
-            "v": 1,
+            "v": 2,
             "last_run": _now_iso(),
             "form": result.form_kind,
             "providers": sorted(result.reported_providers),
             "has_diagnostics": result.has_diagnostics,
             "invalid": result.diagnostics_invalid,
             "ai": result.ai is not None,
+            "missing_sections": list(result.missing_sections),
+            "missing_attachment": result.missing_attachment,
+            "log_wall": result.log_wall_detected,
+            "labels": sorted(result.labels_to_add),
+            "pinged": sorted(result.maintainers_to_ping),
+            "findings": [f.title for f in result.findings],
         }
         if result.diagnostics is not None:
             state["version"] = result.diagnostics.system.version
@@ -700,7 +714,9 @@ def cmd_discussion(gh: GitHubClient, token: str) -> int:
         f" · related: {len(rag_result.related_posts)}"
     )
     state = {
-        "v": 1,
+        # Same generation as the issue sticky above: `v` describes the state
+        # format, and one number meaning two things by blob is worse than none.
+        "v": 2,
         "last_run": _now_iso(),
         "kind": "discussion",
         "rag": {

--- a/.github/scripts/tests/test_main.py
+++ b/.github/scripts/tests/test_main.py
@@ -268,3 +268,42 @@ def test_apply_triage_keeps_state_when_unchanged(fake_gh):
     result = TriageResult(form_kind="main", missing_sections=["What happened?"])
     main.apply_triage(fake_gh, 43, issue, result)
     assert not any(c[0] == "remove_label" for c in fake_gh.calls)
+
+
+def test_state_records_the_whole_decision(monkeypatch, fake_gh):
+    """Every claim the bot makes has to leave a trace that can be graded.
+
+    GitHub records what an issue became; nothing records what the bot said about
+    it. A field missing here is a capability that cannot be measured against the
+    outcome afterwards.
+    """
+    from ma_triage.models import Finding, Severity, TriageResult
+
+    result = TriageResult(
+        form_kind="main",
+        has_diagnostics=True,
+        missing_sections=["How to reproduce"],
+        missing_attachment=True,
+        log_wall_detected=True,
+        reported_providers={"sonos"},
+        labels_to_add={"sonos", "bug"},
+        maintainers_to_ping={"@someone"},
+        findings=[Finding(severity=Severity.WARNING, title="Outdated version",
+                          detail="d")],
+    )
+    captured: dict = {}
+    monkeypatch.setattr(
+        main.comment, "upsert",
+        lambda gh, number, body, state: captured.update(state),
+    )
+    monkeypatch.setattr(main.comment, "build_body", lambda r: "body")
+    monkeypatch.setattr(main, "_resolve_labels", lambda gh, r: [])
+    main.apply_triage(fake_gh, 1, {"labels": []}, result)
+
+    assert captured["v"] == 2
+    assert captured["missing_sections"] == ["How to reproduce"]
+    assert captured["missing_attachment"] is True
+    assert captured["log_wall"] is True
+    assert captured["labels"] == ["bug", "sonos"]
+    assert captured["pinged"] == ["@someone"]
+    assert captured["findings"] == ["Outdated version"]


### PR DESCRIPTION
## What

The sticky comment already carries a machine-readable record of what the bot
decided. It holds the RAG half — tiers, cited chunks, related numbers, scores,
judge confidence — and nothing about the rest: the field checks, the labels
applied, the maintainers pinged, the deterministic findings. All of those exist
on `TriageResult` at the moment the comment is written, and are then discarded.

Six keys, all already computed:

`missing_sections`, `missing_attachment`, `log_wall`, `labels`, `pinged`,
`findings` (titles only).

## Why it matters

GitHub records what an issue *became*: how it was closed, which labels survived,
who commented. Only this blob records what the bot *claimed* about it. With both
you can ask whether a nudge produced the missing field, whether a ping reached
someone who then replied, whether a label survived review. With only one you
cannot ask anything.

That is the difference between judging how triage is doing and guessing at it,
and it costs six keys that are already in memory.

## On the version bump

`v` goes 1 → 2 on **both** stickies — the issue one and the discussion one — so
the number does not mean two different things depending on which blob produced
it.

This is not a compatibility break and needs no migration. v2 is v1 plus six
fields; nothing in the codebase reads `v`, and any external reader of v1 keeps
working unchanged. It is deliberately unlike `_SCHEMA` in `embeddings`, which is
a rejection gate — the two happen to share a spelling and do opposite things.

## Test plan

`python -m pytest tests/` — 350 pass, including a new test asserting all six
keys and `v == 2` reach `comment.upsert`.
