### PR TITLE
Lead with the gist of a long report

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -83,6 +83,14 @@ users. Any retrieval/model failure degrades gracefully to the available
 evidence/deterministic result. Models calls use `GH_MODELS_TOKEN`; the assessment
 renders as a collapsed `<details>` block for maintainers.
 
+A report whose description reaches `TRIAGE_GIST_MIN_CHARS` also gets a three-line
+gist — what the reporter was doing, what happened, what they expected — at the
+top of the comment, from one extra model call. It is the one piece of model
+output shown uncollapsed, because it restates the report rather than
+hypothesising about it and the text it restates is immediately below. A beat the
+report never states is rendered as missing, which is how the most common gap in
+a bug report gets surfaced without a nudge.
+
 ### Docs-grounded answers & similar reports
 The live bot adds a **retrieval-augmented** layer on top of the analysis:
 

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -164,6 +164,13 @@ def build_result(
         findings.extend(v_findings)
         labels_to_add |= v_labels
 
+    # A report long enough that its first line is not the point gets condensed to
+    # three beats at the top of the comment. Independent of diagnostics: half of
+    # the long reports attach none, and those are the ones worth condensing.
+    description = template.section_value(body, template.SECTION_WHAT_HAPPENED) or ""
+    if config.AI_ENABLED and len(description) >= config.GIST_MIN_CHARS:
+        result.gist = ai.summarise_report(title, body, token=token)
+
     # Retrieve docs, pinned notices and provider-matched reports *before* Tier-1
     # so the root-cause assessment sees the same evidence rendered to the user.
     result.rag = rag.answer(

--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -15,6 +15,7 @@ This tier is entirely optional and defensive:
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 import requests
@@ -27,6 +28,7 @@ from .models import (
     DocHit,
     ProviderDoc,
     RagResult,
+    ReportGist,
 )
 from .sanitize import fenced, inline
 
@@ -284,6 +286,102 @@ def assess(
     except Exception as exc:  # noqa: BLE001 — never let AI break triage
         print(f"AI assessment skipped: {exc}")
         return None
+
+
+# --------------------------------------------------------------------------- #
+# Report gist — the three beats, for reports too long to skim
+# --------------------------------------------------------------------------- #
+_GIST_SCHEMA: dict[str, Any] = {
+    "name": "report_gist",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "doing": {"type": ["string", "null"]},
+            "happened": {"type": ["string", "null"]},
+            "expected": {"type": ["string", "null"]},
+        },
+        "required": ["doing", "happened", "expected"],
+    },
+}
+
+_GIST_SYSTEM_PROMPT = (
+    "You condense a Music Assistant bug report to three short lines so a "
+    "maintainer knows what it is about without reading all of it.\n\n"
+    "doing: what the reporter was doing when the problem appeared.\n"
+    "happened: what actually went wrong.\n"
+    "expected: what they say should have happened instead.\n\n"
+    "Use only what the report states. Do not diagnose, do not guess a cause, "
+    "and do not repair an incomplete report: if it never says what was "
+    "expected, return null for that field rather than inferring the obvious. "
+    "A null is useful information — it tells the maintainer what to ask for.\n\n"
+    "One sentence per field, at most 20 words, in the reporter's own terms."
+)
+
+
+def summarise_report(title: str, body: str, *, token: str) -> ReportGist | None:
+    """Condense a long report to three beats; ``None`` when unavailable.
+
+    A separate call rather than part of the assessment, because the assessment
+    needs parsed diagnostics and only half of the long reports attach any — and
+    a report with no diagnostics and 4000 words of prose is the case this exists
+    for.
+    """
+    if not config.AI_ENABLED:
+        return None
+    payload = {
+        "model": config.AI_MODEL,
+        "messages": [
+            {"role": "system", "content": _GIST_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": (
+                    f"ISSUE TITLE: {inline(title, max_len=300)}\n\n"
+                    f"ISSUE BODY (untrusted excerpt):\n"
+                    f"{fenced(body, max_len=config.MAX_AI_INPUT_CHARS)}"
+                ),
+            },
+        ],
+        "temperature": 0.0,
+        "response_format": {"type": "json_schema", "json_schema": _GIST_SCHEMA},
+    }
+    data = _chat(payload, token=token, what="report gist")
+    if data is None:
+        return None
+    try:
+        gist = ReportGist(
+            doing=_gist_line(data.get("doing")),
+            happened=_gist_line(data.get("happened")),
+            expected=_gist_line(data.get("expected")),
+        )
+        return gist if gist.has_content else None
+    except Exception as exc:  # noqa: BLE001 — never let AI break triage
+        print(f"Report gist skipped: {exc}")
+        return None
+
+
+def _gist_line(value: Any) -> str | None:
+    """A single beat, or ``None`` for anything the model left unanswered."""
+    if not isinstance(value, str):
+        return None
+    # Collapsing newlines here is load-bearing: the comment renders each beat as
+    # a single list item, and `markdown_safe` does not collapse them.
+    text = " ".join(value.split())
+    if not text or _RE_GIST_NON_ANSWER.fullmatch(text.rstrip(". ")):
+        return None
+    return text
+
+
+# Models reach for prose instead of the null the schema allows, and there are
+# more ways to write it than are worth enumerating — the first attempt at a list
+# missed the contraction used in our own copy.
+_RE_GIST_NON_ANSWER = re.compile(
+    r"(null|none|n/?a|unknown|unclear|unspecified)"
+    r"|(the (report|reporter) (does\s?n[o']t|did\s?n[o']t)\s+\w+.*)"
+    r"|(not\s+(stated|specified|mentioned|provided|described|applicable|given))",
+    re.IGNORECASE,
+)
 
 
 # --------------------------------------------------------------------------- #

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -358,9 +358,51 @@ def build_discussion_body(rag: RagResult, *, title: str = "") -> str:
     return "\n".join(parts)
 
 
+def _gist_section(result: TriageResult) -> str:
+    """The three beats, for a report too long to skim.
+
+    A beat the report never states is rendered as missing rather than dropped:
+    that is the most useful line in the block, because it names exactly what a
+    maintainer would otherwise have to ask for.
+
+    Shown uncollapsed, unlike the assessment below it, and the distinction is
+    the point: the assessment is a hypothesis about a cause the report does not
+    contain, so it belongs behind a disclosure a maintainer opens deliberately.
+    This only restates what the reporter already wrote, and the text it restates
+    is directly underneath — wrong is falsifiable at a glance, which is what
+    earns it the space above the fold.
+    """
+    gist = result.gist
+    if gist is None or not gist.has_content:
+        return ""
+    def beat(value: str | None) -> str:
+        if not value:
+            return config.GIST_MISSING
+        return markdown_safe(value, max_len=config.MAX_STRING_ECHO)
+
+    return "\n".join(
+        [
+            config.GIST_HEADING,
+            "",
+            f"- **Doing:** {beat(gist.doing)}",
+            f"- **Happened:** {beat(gist.happened)}",
+            f"- **Expected:** {beat(gist.expected)}",
+            "",
+            config.GIST_FOOTER,
+        ]
+    )
+
+
 def build_body(result: TriageResult) -> str:
     """Render the full sticky-comment body for a triage pass."""
     parts = [config.STICKY_MARKER, "", config.GREETING, ""]
+
+    # Before everything else: a long report should say what it is about in three
+    # lines. Only the main form reaches this — `build_result` returns early for
+    # the frontend form, which has no long-report problem to solve.
+    gist = _gist_section(result)
+    if gist:
+        parts.extend([gist, ""])
 
     if result.form_kind == "frontend":
         parts.extend(_frontend_body(result))

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -551,6 +551,18 @@ DOCS_ANSWER_DISCLAIMER = (
     "perfectly match your setup, and a maintainer will still take a look. If it "
     "helped, a 👍 on this comment helps me learn; a 👎 tells me I got it wrong._"
 )
+# A description this long is one a maintainer reads through before knowing what
+# the report is about, so it gets a three-line gist. Measured over the issues
+# filed since the current form: 1200 characters is the top fifth of
+# descriptions, and the share above it doubled between June and August 2026 as
+# reports written with an assistant became common.
+GIST_MIN_CHARS = _env_int("TRIAGE_GIST_MIN_CHARS", 1200)
+GIST_HEADING = "**In short**"
+GIST_MISSING = "_the report doesn't say_"
+GIST_FOOTER = (
+    "<sub>Condensed from the report above by a bot, so it may be wrong — the "
+    "reporter's own words are below.</sub>"
+)
 RELATED_POSTS_HEADING = "### 🔁 Similar past reports"
 RELATED_POSTS_INTRO = (
     "These earlier issues or discussions look related and might already have an "

--- a/.github/scripts/ma_triage/models.py
+++ b/.github/scripts/ma_triage/models.py
@@ -122,6 +122,25 @@ class AIResult:
     maintainer_next_step: str = ""
 
 
+@dataclass
+class ReportGist:
+    """What the reporter was doing, what happened, and what they expected.
+
+    Each field is ``None`` when the report does not say. That is not a failure
+    to extract — it is the answer, and it is rendered, because a missing
+    expectation is the single most common gap in a bug report here.
+    """
+
+    doing: str | None = None
+    happened: str | None = None
+    expected: str | None = None
+
+    @property
+    def has_content(self) -> bool:
+        """True when at least one beat was actually found."""
+        return any((self.doing, self.happened, self.expected))
+
+
 # --------------------------------------------------------------------------- #
 # RAG layer (Phase 2)
 # --------------------------------------------------------------------------- #
@@ -266,6 +285,7 @@ class TriageResult:
     provider_docs: list[ProviderDoc] = field(default_factory=list)
     maintainers_to_ping: set[str] = field(default_factory=set)
     ai: AIResult | None = None
+    gist: "ReportGist | None" = None
     diagnostics: Diagnostics | None = None
     # RAG layer output (Phase 2). ``None`` whenever the RAG layer is disabled or
     # failed, which keeps the rendered comment byte-identical to Phase 1.

--- a/.github/scripts/tests/test_ai.py
+++ b/.github/scripts/tests/test_ai.py
@@ -248,3 +248,39 @@ def test_chat_uses_http_when_no_cli_token_is_present(monkeypatch):
         lambda *a, **k: _Resp({"choices": [{"message": {"content": '{"ok": 1}'}}]}),
     )
     assert ai._chat(_payload(), token="t", what="X") == {"ok": 1}
+
+
+# --- report gist --------------------------------------------------------------- #
+def test_gist_line_treats_prose_non_answers_as_unanswered():
+    """The schema allows null, but models reach for prose instead."""
+    for value in ("Not stated", "n/a", "unknown", "The report does not say.", "", None):
+        assert ai._gist_line(value) is None
+    assert ai._gist_line("  Pressed   play  ") == "Pressed play"
+
+
+def test_summarise_report_is_skipped_when_ai_is_off(monkeypatch):
+    monkeypatch.setattr(config, "AI_ENABLED", False)
+    assert ai.summarise_report("t", "b" * 5000, token="x") is None
+
+
+def test_summarise_report_returns_none_when_no_beat_was_found(monkeypatch):
+    """All three null means the report said nothing useful, not a partial gist."""
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(
+        ai, "_chat",
+        lambda payload, *, token, what: {"doing": None, "happened": "n/a", "expected": None},
+    )
+    assert ai.summarise_report("t", "b" * 5000, token="x") is None
+
+
+def test_summarise_report_builds_the_gist(monkeypatch):
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(
+        ai, "_chat",
+        lambda payload, *, token, what: {
+            "doing": "Pressed play", "happened": "No audio", "expected": None,
+        },
+    )
+    gist = ai.summarise_report("t", "b" * 5000, token="x")
+    assert gist.doing == "Pressed play" and gist.happened == "No audio"
+    assert gist.expected is None and gist.has_content

--- a/.github/scripts/tests/test_comment.py
+++ b/.github/scripts/tests/test_comment.py
@@ -213,3 +213,56 @@ def test_ai_output_is_sanitized(sample_raw, fake_gh):
     # a forged marker in AI text must not be parseable as real state
     full = f"{body}\n\n{comment._render_state({'ok': True})}"
     assert comment.parse_state(full) == {"ok": True}
+
+
+# --- the gist of a long report ------------------------------------------------ #
+def _gist_result(**beats):
+    from ma_triage.models import ReportGist, TriageResult
+
+    return TriageResult(form_kind="main", gist=ReportGist(**beats))
+
+
+def test_gist_renders_all_three_beats():
+    body = comment._gist_section(
+        _gist_result(doing="Pressed play", happened="No audio", expected="Audio")
+    )
+    assert "**Doing:** Pressed play" in body
+    assert "**Happened:** No audio" in body
+    assert "**Expected:** Audio" in body
+
+
+def test_gist_names_the_beat_the_report_omits():
+    """The missing line is the useful one — it is what a maintainer would ask for."""
+    body = comment._gist_section(_gist_result(doing="Pressed play", happened="No audio"))
+    assert f"**Expected:** {config.GIST_MISSING}" in body
+
+
+def test_gist_is_absent_when_there_is_nothing_to_say():
+    from ma_triage.models import TriageResult
+
+    assert comment._gist_section(TriageResult(form_kind="main")) == ""
+    assert comment._gist_section(_gist_result()) == ""
+
+
+def test_gist_leads_the_comment():
+    """A long report should say what it is about before anything else.
+
+    This is the contested part of the design — every other piece of model output
+    in the comment is collapsed — so it is pinned against content further down
+    rather than against the gist block's own lines.
+    """
+    result = _gist_result(doing="Pressed play", happened="No audio")
+    result.missing_sections = ["How to reproduce"]
+    body = comment.build_body(result)
+    heading = body.index(config.GIST_HEADING)
+    assert heading < body.index("How to reproduce")
+    assert heading < body.index(config.GREETING) + len(config.GREETING) + 200
+
+
+def test_gist_cannot_smuggle_markdown_or_mentions():
+    """It is model output derived from untrusted text, so it is sanitised."""
+    body = comment._gist_section(
+        _gist_result(doing="ping @maintainer see [x](https://evil.example)")
+    )
+    assert "@maintainer" not in body
+    assert "](https://evil.example)" not in body

--- a/.github/scripts/tests/test_main.py
+++ b/.github/scripts/tests/test_main.py
@@ -307,3 +307,38 @@ def test_state_records_the_whole_decision(monkeypatch, fake_gh):
     assert captured["labels"] == ["bug", "sonos"]
     assert captured["pinged"] == ["@someone"]
     assert captured["findings"] == ["Outdated version"]
+
+
+# --- the gist fires only for reports long enough to need it -------------------- #
+def _body_with_description(chars):
+    return (
+        f"### What happened?\n\n{'x' * chars}\n\n"
+        "### How to reproduce\n\nDo the thing\n\n"
+        "### Music Assistant version\n\n2.10.0\n\n"
+        "### How do you run Music Assistant?\n\nHome Assistant add-on"
+    )
+
+
+def _gist_calls(monkeypatch, fake_gh, chars, *, ai_enabled=True):
+    """How many gist calls `build_result` makes for a description of `chars`."""
+    calls = []
+    monkeypatch.setattr(config, "AI_ENABLED", ai_enabled)
+    monkeypatch.setattr(config, "RAG_ENABLED", False)
+    monkeypatch.setattr(
+        main.ai, "summarise_report",
+        lambda title, body, *, token: calls.append(title) or None,
+    )
+    main.build_result(fake_gh, "t", _body_with_description(chars), token="x")
+    return len(calls)
+
+
+def test_gist_is_skipped_for_a_report_short_enough_to_read(monkeypatch, fake_gh):
+    assert _gist_calls(monkeypatch, fake_gh, config.GIST_MIN_CHARS - 1) == 0
+
+
+def test_gist_fires_once_the_description_is_long(monkeypatch, fake_gh):
+    assert _gist_calls(monkeypatch, fake_gh, config.GIST_MIN_CHARS) == 1
+
+
+def test_gist_costs_nothing_when_ai_is_off(monkeypatch, fake_gh):
+    assert _gist_calls(monkeypatch, fake_gh, 5000, ai_enabled=False) == 0


### PR DESCRIPTION
Reports have got much longer. Descriptions over 1500 characters were 0% of issues in January 2026 and 22% in July; ones carrying their own markdown headings inside the form field went 3% to 9% over the same period. August was the busiest month on record, so that is roughly nine long reports a month becoming thirty.

The information in them is usually present, just buried — maintainers asked for clarification on only 7 of 384 recent issues, and three of those had an empty description the existing check already catches. So this does not nag anyone. A length-and-structure rule was tried first and rejected: it flags the best reports in the tracker, including one that traced a race condition to the exact guard in the source. Penalising the reporters who put in the most effort is the wrong trade.

Instead, a description of at least `GIST_MIN_CHARS` gets three lines at the top of the comment: what they were doing, what happened, what they expected. A beat the report never states renders as missing rather than being dropped, and that is the most useful line in the block — 74% of reports state no expectation anywhere, so it names what a maintainer would otherwise have to ask for, without a nudge that lands on everyone.

It is a separate model call rather than three more fields on the assessment, because the assessment needs parsed diagnostics and only half of the long reports attach any. Those are the ones most worth condensing.

It is also the one piece of model output the comment shows uncollapsed. The assessment is a hypothesis about a cause the report does not contain, so it stays behind a disclosure. This only restates what the reporter wrote, directly above their own words, where being wrong is falsifiable at a glance.