### PR TITLE
Gist the reports that need it most

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -167,8 +167,15 @@ def build_result(
     # A report long enough that its first line is not the point gets condensed to
     # three beats at the top of the comment. Independent of diagnostics: half of
     # the long reports attach none, and those are the ones worth condensing.
-    description = template.section_value(body, template.SECTION_WHAT_HAPPENED) or ""
-    if config.AI_ENABLED and len(description) >= config.GIST_MIN_CHARS:
+    #
+    # Measured against the reporter's prose wherever they put it. Keying on the
+    # "What happened?" section alone silently excluded every report that replaced
+    # the form with its own headings — 25 of the 384 filed since June, the
+    # longest and least skimmable of them, and the set that needs this most.
+    description = template.section_value(body, template.SECTION_WHAT_HAPPENED)
+    if description is None and not template.parse_sections(body):
+        description = body or ""
+    if config.AI_ENABLED and len(description or "") >= config.GIST_MIN_CHARS:
         result.gist = ai.summarise_report(title, body, token=token)
 
     # Retrieve docs, pinned notices and provider-matched reports *before* Tier-1

--- a/.github/scripts/tests/test_main.py
+++ b/.github/scripts/tests/test_main.py
@@ -342,3 +342,21 @@ def test_gist_fires_once_the_description_is_long(monkeypatch, fake_gh):
 
 def test_gist_costs_nothing_when_ai_is_off(monkeypatch, fake_gh):
     assert _gist_calls(monkeypatch, fake_gh, 5000, ai_enabled=False) == 0
+
+
+def test_gist_reaches_a_report_that_replaced_the_form(monkeypatch, fake_gh):
+    """These have no "What happened?" section, so the old gate excluded them.
+
+    They are the longest reports in the tracker and the ones a maintainer most
+    needs condensed; keying on a section they do not have got that backwards.
+    """
+    calls = []
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", False)
+    monkeypatch.setattr(
+        main.ai, "summarise_report",
+        lambda title, body, *, token: calls.append(title) or None,
+    )
+    own_headings = "# My bug\n\n## Environment\n\nMA 2.9.2, Docker\n\n## Detail\n\n" + "x" * 2000
+    main.build_result(fake_gh, "t", own_headings, token="x")
+    assert calls, "a report that replaced the form should still be condensed"


### PR DESCRIPTION
## What

The gist gated on the length of the **"What happened?" section**. A report that
replaced the issue form with its own headings has no such section, so its
description length was zero and it never got a gist.

Those are the longest reports in the tracker — around 3,000 characters at the
median — and the set a maintainer most needs condensed before reading. Keying on
a section they don't have got that exactly backwards.

## The change

The gate now measures the reporter's prose wherever they put it: the section
when the form was used, the whole body when no form section is present at all.

A report that used the form and left its description short is untouched, so this
only admits reports that were previously excluded by *structure* rather than by
*length*.

## Effect

Measured over the 384 issues filed since 2026-06-01:

| | before | after |
| --- | --- | --- |
| issues gisted | 55 (14%) | 69 (18%) |
| formless reports gisted | 0 of 17 | 14 of 17 |

## Test plan

`python -m pytest tests/` — 374 pass, including a new test that a report built
from its own headings still reaches `summarise_report`.
