### PR TITLE
Recover the form's answers when a report replaced it

### DIFF
--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -113,21 +113,16 @@ def build_result(
     # --- main server bug form ------------------------------------------------
     result.install_method = template.extract_install_method(body)
 
-    # Condense a report that is too long to skim, and — when the form is gone —
-    # read back out of the prose what the form would have been asked for. The
-    # gate has to be the reporter's own words wherever they put them: keying on
-    # the "What happened?" section alone missed every replaced form, which is
-    # exactly the set that most needs both.
+    # Condense a report too long to skim, and — when the form is gone — read the
+    # answers it would have asked for back out of the prose. The gate is the
+    # reporter's own words wherever they put them.
     description = template.section_value(body, template.SECTION_WHAT_HAPPENED) or ""
     if config.AI_ENABLED and (
         len(description) >= config.GIST_MIN_CHARS or result.form_replaced
     ):
         result.gist = ai.summarise_report(title, body, token=token)
-    if result.gist is not None and result.form_replaced:
-        # Only ever fills a blank. A form answer always wins over a reading of it.
-        result.reported_version = result.reported_version or result.gist.version
-        result.install_method = result.install_method or result.gist.install_method
     _load_diagnostics_or_log(gh, body, result)
+    _apply_recovered_fields(result)
 
     findings = list(result.findings)
     labels_to_add: set[str] = set(result.labels_to_add)
@@ -166,7 +161,8 @@ def build_result(
                 result.reported_version, gh
             )
             findings.extend(v_findings)
-            labels_to_add |= v_labels
+            if not result.has_recovered_fields:
+                labels_to_add |= v_labels
 
         # Ping conservatively: one clearly reported provider on an actionable
         # report. Never ping maintainers for incidental census/error providers.
@@ -178,7 +174,14 @@ def build_result(
         # No attachment we could parse — still nudge on an outdated version.
         v_findings, v_labels = analyze.version_findings(result.reported_version, gh)
         findings.extend(v_findings)
-        labels_to_add |= v_labels
+        # A version read out of prose may state the one a bug appeared in rather
+        # than the one being run. That is worth a sentence the reporter can
+        # correct, and not worth a label, which nothing reads the comment before
+        # trusting. Elsewhere the model may only narrow the deterministic label
+        # set (`ai.assess` filters against `candidate_labels`); it never adds to
+        # it, and this is not the place to make it the exception.
+        if not result.has_recovered_fields:
+            labels_to_add |= v_labels
 
     # Retrieve docs, pinned notices and provider-matched reports *before* Tier-1
     # so the root-cause assessment sees the same evidence rendered to the user.
@@ -228,6 +231,39 @@ def build_result(
     result.labels_to_add = labels_to_add
     result.maintainers_to_ping = maintainers
     return result
+
+
+def _apply_recovered_fields(result: TriageResult) -> None:
+    """Let a replaced form's prose stand in for the answers it never gave.
+
+    Runs after diagnostics so it can never contradict them: an attached report
+    states the version outright, and a reading of the prose must not argue with
+    it in the same comment.
+
+    A recovered answer also clears its question from ``missing_sections``. That
+    list is what decides whether the comment asks for anything *and* whether
+    ``waiting-for-user`` is applied, so leaving it whole would mean asking for
+    nothing and then closing the issue when nobody replied.
+    """
+    if not result.has_recovered_fields:
+        return
+    gist = result.gist
+    diagnosed = result.diagnostics.system.version if result.diagnostics else None
+    if diagnosed:
+        gist.version = None  # the file already answered it, and answers louder
+    else:
+        result.reported_version = result.reported_version or gist.version
+    result.install_method = result.install_method or gist.install_method
+
+    answered = {
+        template.SECTION_WHAT_HAPPENED: gist.happened,
+        template.SECTION_HOW_TO_REPRODUCE: gist.doing,
+        template.SECTION_VERSION: result.reported_version,
+        template.SECTION_INSTALL_METHOD: result.install_method,
+    }
+    result.missing_sections = [
+        name for name in result.missing_sections if not answered.get(name)
+    ]
 
 
 def _load_diagnostics_or_log(
@@ -331,7 +367,7 @@ def apply_triage(
             "ai": result.ai is not None,
             "missing_sections": list(result.missing_sections),
             "form_replaced": result.form_replaced,
-            "recovered": bool(result.gist and result.gist.has_recovered_fields),
+            "recovered": result.has_recovered_fields,
             "missing_attachment": result.missing_attachment,
             "log_wall": result.log_wall_detected,
             "labels": sorted(result.labels_to_add),

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -101,6 +101,7 @@ def build_result(
     result = TriageResult(form_kind=kind)
     result.missing_sections = template.missing_sections(body, kind)
     result.log_wall_detected = template.detect_log_wall(body)
+    result.form_replaced = template.form_replaced(body, kind)
     result.reported_version = template.extract_version(body)
     result.has_media_attachment = has_media_attachment(body)
 
@@ -321,6 +322,7 @@ def apply_triage(
             "invalid": result.diagnostics_invalid,
             "ai": result.ai is not None,
             "missing_sections": list(result.missing_sections),
+            "form_replaced": result.form_replaced,
             "missing_attachment": result.missing_attachment,
             "log_wall": result.log_wall_detected,
             "labels": sorted(result.labels_to_add),

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -112,6 +112,21 @@ def build_result(
 
     # --- main server bug form ------------------------------------------------
     result.install_method = template.extract_install_method(body)
+
+    # Condense a report that is too long to skim, and — when the form is gone —
+    # read back out of the prose what the form would have been asked for. The
+    # gate has to be the reporter's own words wherever they put them: keying on
+    # the "What happened?" section alone missed every replaced form, which is
+    # exactly the set that most needs both.
+    description = template.section_value(body, template.SECTION_WHAT_HAPPENED) or ""
+    if config.AI_ENABLED and (
+        len(description) >= config.GIST_MIN_CHARS or result.form_replaced
+    ):
+        result.gist = ai.summarise_report(title, body, token=token)
+    if result.gist is not None and result.form_replaced:
+        # Only ever fills a blank. A form answer always wins over a reading of it.
+        result.reported_version = result.reported_version or result.gist.version
+        result.install_method = result.install_method or result.gist.install_method
     _load_diagnostics_or_log(gh, body, result)
 
     findings = list(result.findings)
@@ -164,13 +179,6 @@ def build_result(
         v_findings, v_labels = analyze.version_findings(result.reported_version, gh)
         findings.extend(v_findings)
         labels_to_add |= v_labels
-
-    # A report long enough that its first line is not the point gets condensed to
-    # three beats at the top of the comment. Independent of diagnostics: half of
-    # the long reports attach none, and those are the ones worth condensing.
-    description = template.section_value(body, template.SECTION_WHAT_HAPPENED) or ""
-    if config.AI_ENABLED and len(description) >= config.GIST_MIN_CHARS:
-        result.gist = ai.summarise_report(title, body, token=token)
 
     # Retrieve docs, pinned notices and provider-matched reports *before* Tier-1
     # so the root-cause assessment sees the same evidence rendered to the user.
@@ -323,6 +331,7 @@ def apply_triage(
             "ai": result.ai is not None,
             "missing_sections": list(result.missing_sections),
             "form_replaced": result.form_replaced,
+            "recovered": bool(result.gist and result.gist.has_recovered_fields),
             "missing_attachment": result.missing_attachment,
             "log_wall": result.log_wall_detected,
             "labels": sorted(result.labels_to_add),

--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -301,8 +301,10 @@ _GIST_SCHEMA: dict[str, Any] = {
             "doing": {"type": ["string", "null"]},
             "happened": {"type": ["string", "null"]},
             "expected": {"type": ["string", "null"]},
+            "version": {"type": ["string", "null"]},
+            "install_method": {"type": ["string", "null"]},
         },
-        "required": ["doing", "happened", "expected"],
+        "required": ["doing", "happened", "expected", "version", "install_method"],
     },
 }
 
@@ -316,7 +318,13 @@ _GIST_SYSTEM_PROMPT = (
     "and do not repair an incomplete report: if it never says what was "
     "expected, return null for that field rather than inferring the obvious. "
     "A null is useful information — it tells the maintainer what to ask for.\n\n"
-    "One sentence per field, at most 20 words, in the reporter's own terms."
+    "One sentence per field, at most 20 words, in the reporter's own terms.\n\n"
+    "version: the Music Assistant version the reporter is RUNNING. Reports name "
+    "other versions too — one a bug appeared in, one something worked in, one a "
+    "fix landed in. Those are not it. Null unless the report says which they are "
+    "on, and never take a version from a changelog reference or a code path.\n"
+    "install_method: how they run it, in their words (Home Assistant add-on, "
+    "Docker container, standalone). Null if not stated."
 )
 
 
@@ -354,8 +362,10 @@ def summarise_report(title: str, body: str, *, token: str) -> ReportGist | None:
             doing=_gist_line(data.get("doing")),
             happened=_gist_line(data.get("happened")),
             expected=_gist_line(data.get("expected")),
+            version=_gist_line(data.get("version")),
+            install_method=_gist_line(data.get("install_method")),
         )
-        return gist if gist.has_content else None
+        return gist if (gist.has_content or gist.has_recovered_fields) else None
     except Exception as exc:  # noqa: BLE001 — never let AI break triage
         print(f"Report gist skipped: {exc}")
         return None

--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -322,7 +322,9 @@ _GIST_SYSTEM_PROMPT = (
     "version: the Music Assistant version the reporter is RUNNING. Reports name "
     "other versions too — one a bug appeared in, one something worked in, one a "
     "fix landed in. Those are not it. Null unless the report says which they are "
-    "on, and never take a version from a changelog reference or a code path.\n"
+    "on, and never take a version from a changelog reference or a code path. If "
+    "the report gives more than one answer and does not say which is current, "
+    "return null rather than choosing.\n"
     "install_method: how they run it, in their words (Home Assistant add-on, "
     "Docker container, standalone). Null if not stated."
 )

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -199,8 +199,17 @@ def _frontend_body(result: TriageResult) -> list[str]:
 
 
 def _missing_sections_line(result: TriageResult) -> str:
-    """A gentle request for empty required sections (main form)."""
-    if result.form_kind != "main" or not result.missing_sections:
+    """A gentle request for empty required sections (main form).
+
+    Yields to :data:`config.FORM_REPLACED_NOTE` when the form is gone entirely:
+    naming four sections to fill in reads as nonsense to someone whose report
+    has none of them.
+    """
+    if result.form_kind != "main":
+        return ""
+    if result.form_replaced:
+        return config.FORM_REPLACED_NOTE
+    if not result.missing_sections:
         return ""
     pretty = ", ".join(f"**{s}**" for s in result.missing_sections)
     return (
@@ -430,7 +439,9 @@ def build_body(result: TriageResult) -> str:
         )
     else:
         # Main form, no usable attachment.
-        if result.missing_sections:
+        if result.form_replaced:
+            parts.append(config.FORM_REPLACED_NOTE + "\n")
+        elif result.missing_sections:
             pretty = ", ".join(f"**{s}**" for s in result.missing_sections)
             parts.append(
                 f"To help us look into this, could you fill in the following "
@@ -440,8 +451,9 @@ def build_body(result: TriageResult) -> str:
             # Reporter pasted a screenshot/image instead of the actual file.
             parts.append(config.SCREENSHOT_ATTACHMENT_NOTE + " " + _DIAGNOSTICS_HOWTO)
         else:
+            # Both leads end as questions; they share the trailing question mark.
             lead = (
-                "It would also really help if you could attach"
+                "Could you also attach"
                 if result.missing_sections
                 else "Could you attach"
             )

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -208,6 +208,10 @@ def _missing_sections_line(result: TriageResult) -> str:
     if result.form_kind != "main":
         return ""
     if result.form_replaced:
+        # Recovering the answers is the better outcome than asking for them, so
+        # the ask is reserved for the report nothing could be read out of.
+        if result.gist is not None and result.gist.has_recovered_fields:
+            return ""
         return config.FORM_REPLACED_NOTE
     if not result.missing_sections:
         return ""
@@ -402,6 +406,24 @@ def _gist_section(result: TriageResult) -> str:
     )
 
 
+def _recovered_fields_line(result: TriageResult) -> str:
+    """What the form would have told us, read back out of the reporter's prose.
+
+    Shown so the reporter can correct it: these values drive the version check
+    and the install-method advice, and a version taken from the wrong sentence
+    would produce confident, wrong guidance about upgrading.
+    """
+    gist = result.gist
+    if not result.form_replaced or gist is None or not gist.has_recovered_fields:
+        return ""
+    bits = []
+    if gist.version:
+        bits.append(f"**Version:** {inline(gist.version, max_len=40)}")
+    if gist.install_method:
+        bits.append(f"**Install:** {inline(gist.install_method, max_len=60)}")
+    return f"{config.RECOVERED_FIELDS_NOTE}\n\n" + " · ".join(bits)
+
+
 def build_body(result: TriageResult) -> str:
     """Render the full sticky-comment body for a triage pass."""
     parts = [config.STICKY_MARKER, "", config.GREETING, ""]
@@ -412,6 +434,9 @@ def build_body(result: TriageResult) -> str:
     gist = _gist_section(result)
     if gist:
         parts.extend([gist, ""])
+    recovered = _recovered_fields_line(result)
+    if recovered:
+        parts.extend([recovered, ""])
 
     if result.form_kind == "frontend":
         parts.extend(_frontend_body(result))
@@ -439,8 +464,12 @@ def build_body(result: TriageResult) -> str:
         )
     else:
         # Main form, no usable attachment.
-        if result.form_replaced:
+        if result.form_replaced and not (
+            result.gist is not None and result.gist.has_recovered_fields
+        ):
             parts.append(config.FORM_REPLACED_NOTE + "\n")
+        elif result.form_replaced:
+            pass  # the recovered-fields line above already covers it
         elif result.missing_sections:
             pretty = ", ".join(f"**{s}**" for s in result.missing_sections)
             parts.append(

--- a/.github/scripts/ma_triage/comment.py
+++ b/.github/scripts/ma_triage/comment.py
@@ -205,16 +205,12 @@ def _missing_sections_line(result: TriageResult) -> str:
     naming four sections to fill in reads as nonsense to someone whose report
     has none of them.
     """
-    if result.form_kind != "main":
+    if result.form_kind != "main" or not result.missing_sections:
         return ""
     if result.form_replaced:
-        # Recovering the answers is the better outcome than asking for them, so
-        # the ask is reserved for the report nothing could be read out of.
-        if result.gist is not None and result.gist.has_recovered_fields:
-            return ""
+        # Whatever was recovered is already gone from `missing_sections`, so
+        # reaching here means questions genuinely remain unanswered.
         return config.FORM_REPLACED_NOTE
-    if not result.missing_sections:
-        return ""
     pretty = ", ".join(f"**{s}**" for s in result.missing_sections)
     return (
         f"One thing to help us dig in: the following required section(s) look "
@@ -413,14 +409,16 @@ def _recovered_fields_line(result: TriageResult) -> str:
     and the install-method advice, and a version taken from the wrong sentence
     would produce confident, wrong guidance about upgrading.
     """
-    gist = result.gist
-    if not result.form_replaced or gist is None or not gist.has_recovered_fields:
+    if not result.has_recovered_fields:
         return ""
+    gist = result.gist
     bits = []
+    # `markdown_safe`, not `inline`: only it escapes link syntax and breaks URL
+    # schemes, and this is model output derived from a stranger's prose.
     if gist.version:
-        bits.append(f"**Version:** {inline(gist.version, max_len=40)}")
+        bits.append(f"**Version:** {markdown_safe(gist.version, max_len=40)}")
     if gist.install_method:
-        bits.append(f"**Install:** {inline(gist.install_method, max_len=60)}")
+        bits.append(f"**Install:** {markdown_safe(gist.install_method, max_len=60)}")
     return f"{config.RECOVERED_FIELDS_NOTE}\n\n" + " · ".join(bits)
 
 
@@ -464,12 +462,9 @@ def build_body(result: TriageResult) -> str:
         )
     else:
         # Main form, no usable attachment.
-        if result.form_replaced and not (
-            result.gist is not None and result.gist.has_recovered_fields
-        ):
-            parts.append(config.FORM_REPLACED_NOTE + "\n")
-        elif result.form_replaced:
-            pass  # the recovered-fields line above already covers it
+        if result.form_replaced:
+            if result.missing_sections:
+                parts.append(config.FORM_REPLACED_NOTE + "\n")
         elif result.missing_sections:
             pretty = ", ".join(f"**{s}**" for s in result.missing_sections)
             parts.append(

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -568,6 +568,10 @@ FORM_REPLACED_MIN_CHARS = _env_int("TRIAGE_FORM_REPLACED_MIN_CHARS", 1500)
 # field is `required: true` in the form, so a body missing all of them did not
 # come through it, whoever wrote it. Kept to one ask: this fires on reports that
 # are already long, and answering a wall of text with one helps nobody.
+RECOVERED_FIELDS_NOTE = (
+    "The form's answers weren't where we look for them, so these are read back "
+    "out of your report — correct me if I've got them wrong."
+)
 FORM_REPLACED_NOTE = (
     "This looks like it was written out rather than filled in through the issue "
     "form, so the answers we triage on aren't where we look for them. Could you "

--- a/.github/scripts/ma_triage/config.py
+++ b/.github/scripts/ma_triage/config.py
@@ -557,6 +557,23 @@ DOCS_ANSWER_DISCLAIMER = (
 # descriptions, and the share above it doubled between June and August 2026 as
 # reports written with an assistant became common.
 GIST_MIN_CHARS = _env_int("TRIAGE_GIST_MIN_CHARS", 1200)
+# A substantial report that answers none of the form's questions has replaced the
+# template rather than skipped a field. Measured over issues since 2026-06: this
+# fires on 7% of them and covers 10 of the 14 a maintainer pushed back on for
+# being pasted, generated text. The length floor keeps it off the one-line
+# reports that are merely terse.
+FORM_REPLACED_MIN_CHARS = _env_int("TRIAGE_FORM_REPLACED_MIN_CHARS", 1500)
+# Says only what the check established: the form was not used. It cannot tell a
+# generated report from a hand-written one and does not try — every required
+# field is `required: true` in the form, so a body missing all of them did not
+# come through it, whoever wrote it. Kept to one ask: this fires on reports that
+# are already long, and answering a wall of text with one helps nobody.
+FORM_REPLACED_NOTE = (
+    "This looks like it was written out rather than filled in through the issue "
+    "form, so the answers we triage on aren't where we look for them. Could you "
+    "add them here, or re-file through "
+    "[the form](https://github.com/music-assistant/support/issues/new/choose)?"
+)
 GIST_HEADING = "**In short**"
 GIST_MISSING = "_the report doesn't say_"
 GIST_FOOTER = (

--- a/.github/scripts/ma_triage/models.py
+++ b/.github/scripts/ma_triage/models.py
@@ -307,6 +307,17 @@ class TriageResult:
         return self.has_diagnostics and not self.diagnostics_invalid
 
     @property
+    def has_recovered_fields(self) -> bool:
+        """True when the form was replaced and its answers were read from prose.
+
+        The renderer, the ask and the state record all have to agree on this, so
+        it is asked once here rather than reassembled at each of them.
+        """
+        return bool(
+            self.form_replaced and self.gist and self.gist.has_recovered_fields
+        )
+
+    @property
     def needs_user_action(self) -> bool:
         """True when the reporter still has to provide something."""
         if self.skip:

--- a/.github/scripts/ma_triage/models.py
+++ b/.github/scripts/ma_triage/models.py
@@ -134,11 +134,19 @@ class ReportGist:
     doing: str | None = None
     happened: str | None = None
     expected: str | None = None
+    # Recovered only when the form was replaced: what it would have asked for.
+    version: str | None = None
+    install_method: str | None = None
 
     @property
     def has_content(self) -> bool:
         """True when at least one beat was actually found."""
         return any((self.doing, self.happened, self.expected))
+
+    @property
+    def has_recovered_fields(self) -> bool:
+        """True when a form field was read back out of the reporter's prose."""
+        return any((self.version, self.install_method))
 
 
 # --------------------------------------------------------------------------- #

--- a/.github/scripts/ma_triage/models.py
+++ b/.github/scripts/ma_triage/models.py
@@ -273,6 +273,8 @@ class TriageResult:
     # screenshot of a log into the main form's diagnostics field).
     has_media_attachment: bool = False
     missing_sections: list[str] = field(default_factory=list)
+    # The form was not merely skipped in places — it is not there at all.
+    form_replaced: bool = False
     log_wall_detected: bool = False
 
     # Facts read straight from the form fields (available even without a file).

--- a/.github/scripts/ma_triage/template.py
+++ b/.github/scripts/ma_triage/template.py
@@ -179,6 +179,23 @@ def missing_sections(body: str | None, kind: str = "main") -> list[str]:
     return missing
 
 
+def form_replaced(body: str | None, kind: str = "main") -> bool:
+    """True when a substantial report answers none of the form's questions.
+
+    Distinct from a missing field: there is no section to fill in, because the
+    template was replaced with the reporter's own prose. The advice differs too —
+    a field can be added, a replaced form has to be answered from scratch.
+
+    Deliberately says nothing about *why* the form is gone. It cannot separate a
+    generated report from a hand-written one, and does not need to: the ask is
+    the same for both.
+    """
+    if kind != "main" or len(body or "") < config.FORM_REPLACED_MIN_CHARS:
+        return False
+    required = required_sections_for(kind)
+    return len(missing_sections(body, kind)) == len(required)
+
+
 def extract_version(body: str | None) -> str | None:
     """Reporter-entered value of the "Music Assistant version" field."""
     return section_value(body, SECTION_VERSION)

--- a/.github/scripts/tests/test_comment.py
+++ b/.github/scripts/tests/test_comment.py
@@ -324,14 +324,20 @@ def test_replaced_form_note_holds_when_diagnostics_were_attached(sample_raw):
     assert "AI_POLICY" not in body
 
 
-def _replaced(**gist_kwargs):
+def _replaced(*, still_missing=(), **gist_kwargs):
+    """A replaced form after `_apply_recovered_fields` has run.
+
+    `still_missing` is what recovery could not answer; the renderer reads only
+    that, so the two cannot drift apart the way they did when the ask and the
+    `waiting-for-user` label each decided for themselves.
+    """
     from ma_triage.models import ReportGist, TriageResult
 
     return TriageResult(
         form_kind="main",
         form_replaced=True,
         missing_attachment=True,
-        missing_sections=list(template.REQUIRED_SECTIONS_MAIN),
+        missing_sections=list(still_missing),
         gist=ReportGist(**gist_kwargs) if gist_kwargs else None,
     )
 
@@ -348,6 +354,30 @@ def test_recovering_the_answers_replaces_asking_for_them():
     assert config.FORM_REPLACED_NOTE not in body
 
 
+def test_the_ask_survives_a_partial_recovery():
+    """Recovering the install method must not silence the version question."""
+    body = comment.build_body(
+        _replaced(still_missing=[template.SECTION_VERSION],
+                  doing="d", install_method="Docker")
+    )
+    assert config.FORM_REPLACED_NOTE in body
+    assert "**Install:** Docker" in body
+
+
 def test_the_ask_remains_when_nothing_could_be_recovered():
-    assert config.FORM_REPLACED_NOTE in comment.build_body(_replaced(doing="d"))
-    assert config.FORM_REPLACED_NOTE in comment.build_body(_replaced())
+    missing = list(template.REQUIRED_SECTIONS_MAIN)
+    assert config.FORM_REPLACED_NOTE in comment.build_body(
+        _replaced(still_missing=missing, doing="d")
+    )
+    assert config.FORM_REPLACED_NOTE in comment.build_body(
+        _replaced(still_missing=missing)
+    )
+
+
+def test_recovered_fields_cannot_publish_a_link():
+    """Model output derived from a stranger's prose, rendered as markdown."""
+    body = comment.build_body(
+        _replaced(install_method="Docker, see [here](https://evil.example)")
+    )
+    assert "](https://evil.example)" not in body
+    assert "https://evil.example" not in body

--- a/.github/scripts/tests/test_comment.py
+++ b/.github/scripts/tests/test_comment.py
@@ -322,3 +322,32 @@ def test_replaced_form_note_holds_when_diagnostics_were_attached(sample_raw):
     assert config.FORM_REPLACED_NOTE in body
     assert "aren't answered anywhere" not in body
     assert "AI_POLICY" not in body
+
+
+def _replaced(**gist_kwargs):
+    from ma_triage.models import ReportGist, TriageResult
+
+    return TriageResult(
+        form_kind="main",
+        form_replaced=True,
+        missing_attachment=True,
+        missing_sections=list(template.REQUIRED_SECTIONS_MAIN),
+        gist=ReportGist(**gist_kwargs) if gist_kwargs else None,
+    )
+
+
+def test_recovered_fields_are_shown_for_correction():
+    body = comment.build_body(_replaced(doing="d", version="2.9.2", install_method="Docker"))
+    assert config.RECOVERED_FIELDS_NOTE in body
+    assert "**Version:** 2.9.2" in body and "**Install:** Docker" in body
+
+
+def test_recovering_the_answers_replaces_asking_for_them():
+    """Reading the answers out is a better outcome than requesting them again."""
+    body = comment.build_body(_replaced(doing="d", version="2.9.2"))
+    assert config.FORM_REPLACED_NOTE not in body
+
+
+def test_the_ask_remains_when_nothing_could_be_recovered():
+    assert config.FORM_REPLACED_NOTE in comment.build_body(_replaced(doing="d"))
+    assert config.FORM_REPLACED_NOTE in comment.build_body(_replaced())

--- a/.github/scripts/tests/test_comment.py
+++ b/.github/scripts/tests/test_comment.py
@@ -1,4 +1,4 @@
-from ma_triage import comment, config
+from ma_triage import comment, config, template
 from ma_triage.analyze import analyze
 from ma_triage.diagnostics import parse_diagnostics
 from ma_triage.models import AIResult, TriageResult
@@ -266,3 +266,59 @@ def test_gist_cannot_smuggle_markdown_or_mentions():
     )
     assert "@maintainer" not in body
     assert "](https://evil.example)" not in body
+
+
+def test_replaced_form_gets_its_own_ask_not_a_list_of_sections():
+    """Naming four sections to fill in is nonsense when the form is gone."""
+    from ma_triage.models import TriageResult
+
+    result = TriageResult(
+        form_kind="main",
+        missing_sections=list(template.REQUIRED_SECTIONS_MAIN),
+        form_replaced=True,
+        missing_attachment=True,
+    )
+    body = comment.build_body(result)
+    assert config.FORM_REPLACED_NOTE.split("\n")[0] in body
+    assert "could you fill in the following section(s)" not in body
+    assert "What happened?**, **How to reproduce" not in body
+
+
+def test_a_merely_incomplete_form_still_lists_its_sections():
+    from ma_triage.models import TriageResult
+
+    result = TriageResult(
+        form_kind="main", missing_sections=["How to reproduce"], missing_attachment=True
+    )
+    body = comment.build_body(result)
+    assert "**How to reproduce**" in body
+    assert config.FORM_REPLACED_NOTE.split("\n")[0] not in body
+
+
+def test_the_diagnostics_ask_is_a_question_either_way():
+    from ma_triage.models import TriageResult
+
+    for missing in ([], ["How to reproduce"]):
+        body = comment.build_body(
+            TriageResult(form_kind="main", missing_sections=missing, missing_attachment=True)
+        )
+        assert "Could you" in body
+        assert "really help if you could attach a **diagnostics" not in body
+
+
+def test_replaced_form_note_holds_when_diagnostics_were_attached(sample_raw):
+    """The actionable branch prints the version, so the note must not deny it."""
+    from ma_triage.diagnostics import parse_diagnostics
+    from ma_triage.models import TriageResult
+
+    result = TriageResult(
+        form_kind="main",
+        has_diagnostics=True,
+        diagnostics=parse_diagnostics(sample_raw),
+        missing_sections=list(template.REQUIRED_SECTIONS_MAIN),
+        form_replaced=True,
+    )
+    body = comment.build_body(result)
+    assert config.FORM_REPLACED_NOTE in body
+    assert "aren't answered anywhere" not in body
+    assert "AI_POLICY" not in body

--- a/.github/scripts/tests/test_main.py
+++ b/.github/scripts/tests/test_main.py
@@ -396,3 +396,56 @@ def test_recovery_is_not_applied_when_the_form_was_used(monkeypatch, fake_gh):
     res = main.build_result(fake_gh, "t", body, token="x")
     assert res.form_replaced is False
     assert res.reported_version == "2.10.0"
+
+
+def test_the_comment_asks_for_something_exactly_when_it_waits_for_the_user(
+    monkeypatch, fake_gh
+):
+    """The ask and the `waiting-for-user` label must not decide separately.
+
+    They did: recovery silenced the ask while `missing_sections` still held all
+    four, so the bot requested nothing and the sweep then closed the issue for
+    going unanswered.
+    """
+    from ma_triage import comment as comment_mod
+    from ma_triage.models import ReportGist
+
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", False)
+    monkeypatch.setattr(
+        main.ai, "summarise_report",
+        lambda title, body, *, token: ReportGist(
+            doing="pressed play", happened="no sound",
+            version="2.9.2", install_method="Docker",
+        ),
+    )
+    replaced = "# Bug\n\n## Detail\n\n" + "x" * 2000
+    result = main.build_result(fake_gh, "t", replaced, token="x")
+
+    assert result.form_replaced and result.has_recovered_fields
+    assert result.missing_sections == [], "recovered answers must clear their questions"
+
+    body = comment_mod.build_body(result)
+    # Recovery answered the form, so that ask is gone; the diagnostics file was
+    # never in the report and is still wanted, so that one remains.
+    assert config.FORM_REPLACED_NOTE not in body
+    asks_for_something = "Could you attach" in body or config.FORM_REPLACED_NOTE in body
+    assert asks_for_something is result.needs_user_action, (
+        "the comment and the waiting-for-user label must agree: asking for "
+        "nothing while waiting is what let the sweep close unanswered issues"
+    )
+
+
+def test_a_recovered_version_does_not_originate_a_label(monkeypatch, fake_gh):
+    """The model may narrow the deterministic label set, never add to it."""
+    from ma_triage.models import ReportGist
+
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", False)
+    monkeypatch.setattr(
+        main.ai, "summarise_report",
+        lambda title, body, *, token: ReportGist(doing="d", happened="h", version="2.0.0"),
+    )
+    result = main.build_result(fake_gh, "t", "# Bug\n\n## Detail\n\n" + "x" * 2000, token="x")
+    assert result.reported_version == "2.0.0"
+    assert not any("outdated" in label for label in result.labels_to_add)

--- a/.github/scripts/tests/test_main.py
+++ b/.github/scripts/tests/test_main.py
@@ -342,3 +342,57 @@ def test_gist_fires_once_the_description_is_long(monkeypatch, fake_gh):
 
 def test_gist_costs_nothing_when_ai_is_off(monkeypatch, fake_gh):
     assert _gist_calls(monkeypatch, fake_gh, 5000, ai_enabled=False) == 0
+
+
+# --- recovering the form's answers from a report that replaced it -------------- #
+_REPLACED = "# My bug\n\n## Environment\n\nMA 2.9.2, Docker\n\n## Detail\n\n" + "x" * 2000
+
+
+def test_gist_fires_for_a_replaced_form_with_no_description_section(monkeypatch, fake_gh):
+    """The gate keyed on a section these reports do not have, so they got none.
+
+    They are the longest, least skimmable reports in the tracker; keying on the
+    reporter's prose wherever they put it is the whole point.
+    """
+    calls = []
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", False)
+    monkeypatch.setattr(
+        main.ai, "summarise_report",
+        lambda title, body, *, token: calls.append(title) or None,
+    )
+    main.build_result(fake_gh, "t", _REPLACED, token="x")
+    assert calls, "a replaced form should still be condensed"
+
+
+def test_recovered_fields_only_ever_fill_a_blank(monkeypatch, fake_gh):
+    """A form answer always beats a reading of one."""
+    from ma_triage.models import ReportGist
+
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", False)
+    monkeypatch.setattr(
+        main.ai, "summarise_report",
+        lambda title, body, *, token: ReportGist(
+            doing="d", version="9.9.9", install_method="guessed"
+        ),
+    )
+    # A replaced form has nothing to beat it, so the reading is used.
+    res = main.build_result(fake_gh, "t", _REPLACED, token="x")
+    assert res.reported_version == "9.9.9"
+    assert res.install_method == "guessed"
+
+
+def test_recovery_is_not_applied_when_the_form_was_used(monkeypatch, fake_gh):
+    from ma_triage.models import ReportGist
+
+    monkeypatch.setattr(config, "AI_ENABLED", True)
+    monkeypatch.setattr(config, "RAG_ENABLED", False)
+    monkeypatch.setattr(
+        main.ai, "summarise_report",
+        lambda title, body, *, token: ReportGist(doing="d", version="9.9.9"),
+    )
+    body = _body_with_description(config.GIST_MIN_CHARS)
+    res = main.build_result(fake_gh, "t", body, token="x")
+    assert res.form_replaced is False
+    assert res.reported_version == "2.10.0"

--- a/.github/scripts/tests/test_template.py
+++ b/.github/scripts/tests/test_template.py
@@ -1,3 +1,6 @@
+import re
+from pathlib import Path
+
 from ma_triage import config, template
 
 
@@ -157,3 +160,50 @@ def test_strip_boilerplate_removes_inline_checkboxes():
 def test_strip_boilerplate_handles_empty_input():
     assert template.strip_boilerplate(None) == ""
     assert template.strip_boilerplate("") == ""
+
+
+# --- a replaced form is not a missing field ------------------------------------ #
+_NO_FORM = (
+    "# Sonos sync_group reports state 'idle'\n\n"
+    "## Environment\n\nMA 2.10.1, HA add-on\n\n"
+    "## Analysis\n\nThe provider returns the wrong state because "
+) + "x" * 1600
+
+
+def test_form_replaced_when_a_long_report_answers_none_of_the_form():
+    assert template.form_replaced(_NO_FORM, "main") is True
+
+
+def test_form_replaced_ignores_a_short_report_with_no_form():
+    """Terse is not the same problem, and the advice would be wrong."""
+    assert template.form_replaced("It broke. Please fix.", "main") is False
+
+
+def test_form_replaced_ignores_a_report_that_used_the_form():
+    body = _main_body()
+    assert template.form_replaced(body + "x" * 3000, "main") is False
+
+
+def test_form_replaced_only_applies_to_the_main_form():
+    assert template.form_replaced(_NO_FORM, "frontend") is False
+    assert template.form_replaced(_NO_FORM, "translation") is False
+
+
+def test_required_sections_match_the_form_that_ships():
+    """The constants claim to be kept in sync with the issue form by hand.
+
+    Nothing enforced that, and the risk changed with `form_replaced`: a stale
+    heading used to mean a redundant "please fill this in", and now means every
+    correctly-filed report is told it bypassed the form. A one-word label edit
+    should fail here rather than in production.
+    """
+    form = Path(__file__).resolve().parents[2] / "ISSUE_TEMPLATE" / "1_bug_report.yml"
+    labels = set(re.findall(r"^\s*label:\s*(.+?)\s*$", form.read_text(), re.M))
+    missing = [s for s in template.REQUIRED_SECTIONS_MAIN if s not in labels]
+    assert not missing, f"not in {form.name}: {missing}"
+
+
+def test_form_replaced_threshold_is_tunable(monkeypatch):
+    """The floor is the knob to reach for during rollout, so it has to work."""
+    monkeypatch.setattr(config, "FORM_REPLACED_MIN_CHARS", 10_000)
+    assert template.form_replaced(_NO_FORM, "main") is False


### PR DESCRIPTION
> Touches the same gate as #6284 and should merge after it. The two do not
> conflict today; if #6284 lands first I'll rebase this onto it.

## What

Every field this checks is `required: true` in the bug form, so a body missing
all of them did not come through the form at all. **25 of the 384 issues filed
since 2026-06-01** are like that, and until now the whole deterministic tier sat
idle on them: no version, no install method, nothing for `versioncheck` to
compare — and a comment asking them to "fill in the following section(s)" that
don't exist in their report.

The answers are usually there, just written out as prose. So they get read back
out of it, and only the report nothing could be recovered from gets asked.

| over those 25 | before | after |
| --- | --- | --- |
| three-line gist | 0 | 25 |
| version recovered | 0 | 19, of which 17 parse |
| install method | 0 | 15 |

Ten of the 25 are among the fourteen a maintainer pushed back on since June for
being pasted, generated text. The pattern behind those is not length or
structure — those flag the most careful reports in the tracker — but that the
template is gone. The other fifteen also bypassed the form and are also being
helped, or asked, correctly.

## Why a model reads the version and not a regex

A regex takes the first version it sees, and these reports name several: one a
bug appeared in, one something worked in, one a fix landed in.

- #6218 — first match is "This worked in **2.9.7** by accident"; the reporter is
  on 2.10.0.
- #6134 — first match is the version they say they *upgraded away from*.

Both feed `versioncheck`, so getting it wrong means confidently telling someone
to install what they already have.

Where a report answers a field twice without saying which is current, the model
returns nothing rather than choosing — #6192 gives 2.9.9 in one section and
2.9.13 in another.

## What recovery is not allowed to do

- **Originate a label.** A recovered version renders its finding but does not
  apply `triage/outdated-version`. Everywhere else the model may only narrow the
  deterministic label set (`ai.assess` filters against `candidate_labels`); a
  version read out of prose is not the place to make that the exception. A
  sentence can be corrected in a reply — a label is machine-read and nothing
  checks the comment before trusting it.
- **Overrule the form or the diagnostics.** It only ever fills a blank, and it
  runs after diagnostics load, so a report that states its version outright is
  never argued with by a reading of its prose a few lines above.
- **Publish a link.** Rendered with `markdown_safe`, which escapes link syntax
  and breaks URL schemes — this is model output derived from a stranger's prose.

Recovered values are shown for correction rather than asserted:

> The form's answers weren't where we look for them, so these are read back out
> of your report — correct me if I've got them wrong.
>
> **Version:** 2.10.0 · **Install:** docker

## The ask and the label read one fact

A recovered answer clears its own question from `missing_sections`, which is what
decides both whether the comment asks for anything and whether
`waiting-for-user` is applied. Leaving that list whole meant asking for nothing
and then having the sweep close the issue for going unanswered. A test now
asserts the comment asks for something exactly when the label says we're waiting.

## Also here

- `REQUIRED_SECTIONS_MAIN` is checked against the shipped form in CI. It was only
  kept in sync by hand, and the stakes changed: a stale heading used to mean a
  redundant request to fill in a field, and would now mean treating every
  correctly-filed report as if it had bypassed the form. Verified it fails on a
  renamed label.
- A question mark in the neighbouring diagnostics request, which this path routes
  through: "It would also really help if you could attach …?" was a statement
  carrying a question's punctuation.

## Test plan

`python -m pytest tests/` — 393 pass. New coverage for the recovery gate, the
partial-recovery case, the ask/label invariant, label origination, link
smuggling, and the form-sync guard.
