### PR TITLE
Give analyze room for a cold model cache

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -140,9 +140,14 @@ jobs:
     # optimisation and deterministic triage must not depend on it, while a
     # cancelled run still stops.
     needs: [trace]
-    # Bounds the half of the wait this job owns. It measures well under two
-    # minutes; this is a backstop, not a target.
-    timeout-minutes: 3
+    # Bounds the half of the wait this job owns. The triage itself measures well
+    # under two minutes, but `start-embeddings` runs first and is not bounded by
+    # the work: it serves the model from the runner, so a warm weights cache
+    # costs ~40s and a cold one spends minutes downloading 600MB. At three
+    # minutes that difference decided the job — three of fifteen issue runs were
+    # cancelled mid-download, having applied no labels and left no comment.
+    # This is a backstop against a hung job, not a target.
+    timeout-minutes: 10
     if: >-
       ${{ !cancelled()
       && ((github.event_name == 'issues' && !github.event.issue.pull_request)


### PR DESCRIPTION
## What

`analyze` had `timeout-minutes: 3`. Three of the fifteen most recent
issue-triggered runs were cancelled at that limit, having applied no labels and
left no comment — #6320, "Spotify Soloist setup fails", and "References to
Digitally Incorporated". The reporter on #6320 noticed before we did.

## Why three minutes stopped being enough

The limit was sized for the triage, which still measures well under two minutes.
It was not sized for `start-embeddings`, which runs first and is bounded by
neither the work nor the issue. The model is served from the runner, so the
weights cache decides the cost:

| | `start-embeddings` |
| --- | --- |
| warm cache (run 33874957750) | 42s, job finished in 87s |
| cold cache (run 33838608331) | killed at 3m00s, `Triage issue` never ran |

Median `analyze` is 70s and the slowest success is 130s, so this is not a
gradual slowdown — it is bimodal, and the job budget could not tell the two
apart.

## The change

Ten minutes. It remains a backstop against a hung job rather than a limit the
normal path can reach, and a warm run is unchanged, so nothing gets slower.

The alternative — keeping three minutes for the triage and letting a cold cache
degrade to lexical retrieval instead of killing the job — is the tidier fix and
matches what `start-embeddings` already says about an unreachable endpoint. It
is also a bigger change, and worth doing separately if the cold-cache rate stays
high; this stops issues being dropped today.

Worth noting the compound wait: `analyze` needs `trace`, which is itself capped
at 15 minutes, so the worst case a reporter can see goes from 18 to 25 minutes.
Both are backstops that the normal path does not approach.

## Test plan

None — workflow configuration only. Watch the next few issue-triggered runs for
`analyze` conclusions; three cancellations in fifteen should go to zero.
