### PR TITLE
Give AI analysis a field of its own

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -95,3 +95,16 @@ body:
     attributes:
       label: Anything else?
       description: Screenshots, an unusual network setup, whether playback is triggered from the UI or a Home Assistant action, or anything else that might help.
+
+  - type: textarea
+    id: ai_analysis
+    validations:
+      required: false
+    attributes:
+      label: AI analysis
+      description: |
+        Used an AI assistant to investigate? Put its output **here**, not in the fields above — we do read it.
+
+        The questions above still need your own words, even briefly. A short human description of what you saw is what we triage on; a generated analysis in its place usually means we have to come back and ask what actually happened, which is slower for both of us. Our [AI policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) covers this, and applies to code contributions too.
+      placeholder: |
+        Paste any AI-generated analysis, log interpretation or suggested cause here.

--- a/.github/ISSUE_TEMPLATE/2_frontend_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_frontend_bug_report.yml
@@ -68,3 +68,16 @@ body:
     attributes:
       label: Anything else?
       description: Anything else that might help — browser console errors, whether it happens on other devices, etc.
+
+  - type: textarea
+    id: ai_analysis
+    validations:
+      required: false
+    attributes:
+      label: AI analysis
+      description: |
+        Used an AI assistant to investigate? Put its output **here**, not in the fields above — we do read it.
+
+        The questions above still need your own words, even briefly. A short human description of what you saw is what we triage on; a generated analysis in its place usually means we have to come back and ask what actually happened, which is slower for both of us. Our [AI policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) covers this, and applies to code contributions too.
+      placeholder: |
+        Paste any AI-generated analysis, log interpretation or suggested cause here.

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -8,8 +8,10 @@ _Settings → System → Diagnostics → Download diagnostics_ in Music Assistan
 falls back to scanning an attached **raw log file** (for older versions without
 the diagnostics feature), posts a single sticky summary comment, applies
 setup/provider labels, involves community provider maintainers, surfaces
-docs-grounded answers and similar past reports, and manages the issue's response
-state. New/edited Discussions receive the same docs-grounded help without
+docs-grounded answers and similar past reports, manages the issue's response
+state, and folds a filled-in **AI analysis** field behind a `<details>` on the
+report itself — the one case where the bot edits an issue body, and only ever
+the markup around that section. New/edited Discussions receive the same docs-grounded help without
 issue-specific diagnostics or label handling.
 
 > **Live configuration in this repository:** deterministic triage, AI assessment,
@@ -299,6 +301,11 @@ python -m ma_triage triage
 - Set `TRIAGE_DRY_RUN=true` for an immediate non-mutating kill switch. Set
   `TRIAGE_AI_ENABLED=false` to retain deterministic triage without Models.
 - `triage/hold` pauses automation on an issue; `triage/skip` excludes it.
+- The bot edits an issue body in exactly one case: folding a filled-in AI
+  analysis behind a `<details>`. Markup only, and the change is visible in the
+  issue's edit history. It re-reads the body first so a reporter's concurrent
+  edit is not overwritten, and `trace`/`analyze` skip the `edited` event a bot
+  raises so the fold does not re-run the pipeline.
 - The bot does **not** dispatch coding agents or create fix PRs automatically.
 
 > Note: the per-form required-section lists in `ma_triage/template.py` and the

--- a/.github/scripts/ma_triage/__main__.py
+++ b/.github/scripts/ma_triage/__main__.py
@@ -403,6 +403,34 @@ def apply_triage(
             "applied labels only."
         )
 
+    _fold_ai_analysis(gh, number)
+
+
+def _fold_ai_analysis(gh: GitHubClient, number: int) -> None:
+    """Collapse a filled-in AI analysis behind a disclosure on the issue itself.
+
+    The forms cannot do it: a pre-filled `<details>` is submitted even when the
+    field is left alone, so every report would carry an empty one.
+
+    Only the markup around the section moves — nothing is inserted, removed or
+    reworded, and the edit is visible in the issue's edit history. The body is
+    re-read first because triage takes minutes and the copy this run started
+    with may already be stale; writing that one back would silently revert an
+    edit the reporter made in the meantime.
+
+    Runs last on purpose. It is cosmetic, and a failed PATCH must not cost the
+    labels and the comment that are the bot's actual output.
+    """
+    fresh = gh.get_issue(number)
+    folded = template.wrap_ai_analysis(fresh.get("body"))
+    if folded is None:
+        return
+    gh.set_issue_body(number, folded)
+    summary(
+        f"#{number}: folded the AI analysis section behind a disclosure "
+        "(formatting only; the reporter's text is unchanged)."
+    )
+
 
 # --------------------------------------------------------------------------- #
 # Subcommands

--- a/.github/scripts/ma_triage/ai.py
+++ b/.github/scripts/ma_triage/ai.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import requests
 
-from . import config, copilot
+from . import config, copilot, template
 from .models import (
     AIResult,
     Diagnostics,
@@ -330,6 +330,18 @@ _GIST_SYSTEM_PROMPT = (
 )
 
 
+def _gist_input(body: str) -> str:
+    """The report as the summariser should read it.
+
+    Without the AI analysis section. The gist fires on long reports, which is
+    what that section makes them, and a confident "the root cause is a race in
+    the bridge manager" outranks "sound cuts out after 30 seconds" every time —
+    then goes out publicly as the three lines a maintainer reads first. It also
+    keeps a version named in a changelog reference out of the recovered fields.
+    """
+    return template.strip_boilerplate(body)
+
+
 def summarise_report(title: str, body: str, *, token: str) -> ReportGist | None:
     """Condense a long report to three beats; ``None`` when unavailable.
 
@@ -349,7 +361,7 @@ def summarise_report(title: str, body: str, *, token: str) -> ReportGist | None:
                 "content": (
                     f"ISSUE TITLE: {inline(title, max_len=300)}\n\n"
                     f"ISSUE BODY (untrusted excerpt):\n"
-                    f"{fenced(body, max_len=config.MAX_AI_INPUT_CHARS)}"
+                    f"{fenced(_gist_input(body), max_len=config.MAX_AI_INPUT_CHARS)}"
                 ),
             },
         ],

--- a/.github/scripts/ma_triage/gh.py
+++ b/.github/scripts/ma_triage/gh.py
@@ -479,11 +479,12 @@ class GitHubClient:
             ),
         )
 
-    def update_issue(self, number: int, **fields: Any) -> Any:
+    def set_issue_body(self, number: int, body: str) -> Any:
+        """Replace an issue's body. The only field the bot ever rewrites."""
         return self._mutate(
-            f"update issue #{number} fields {list(fields)}",
+            f"rewrite the body of issue #{number}",
             lambda: self._rest(
-                "PATCH", f"/repos/{self.repo}/issues/{number}", json=fields
+                "PATCH", f"/repos/{self.repo}/issues/{number}", json={"body": body}
             ),
         )
 

--- a/.github/scripts/ma_triage/template.py
+++ b/.github/scripts/ma_triage/template.py
@@ -31,6 +31,8 @@ SECTION_ANYTHING_ELSE = "Anything else?"
 SECTION_BROWSER_OS = "Browser and operating system"
 SECTION_SCREENSHOT = "Screenshot or recording"
 SECTION_AI_ANALYSIS = "AI analysis"
+# Shown on the collapsed disclosure the bot folds that section into.
+AI_ANALYSIS_SUMMARY = "AI analysis (click to expand)"
 
 # Required *text* sections per form (the attachment fields are validated
 # separately via attachments.py, since their content is a URL/upload).
@@ -79,6 +81,23 @@ UNRANKED_SECTION_PREFIXES = (
     "have you reviewed the",
 )
 
+# Every heading the current forms emit. The AI analysis section ends at one of
+# these and not at any heading, because generated prose brings headings of its
+# own — "### Root cause" is the reporter's answer continuing, not a new field.
+FORM_SECTIONS = frozenset(
+    {
+        SECTION_WHAT_HAPPENED,
+        SECTION_HOW_TO_REPRODUCE,
+        SECTION_VERSION,
+        SECTION_INSTALL_METHOD,
+        SECTION_DIAGNOSTICS,
+        SECTION_ANYTHING_ELSE,
+        SECTION_BROWSER_OS,
+        SECTION_SCREENSHOT,
+        SECTION_AI_ANALYSIS,
+    }
+)
+
 _RE_SECTION = re.compile(r"^###\s+(.*?)\s*$")
 _RE_CHECKBOX = re.compile(r"^\s*[-*]\s*\[[ xX]\].*$", re.MULTILINE)
 # A line that looks like a log line: has a level keyword or an ISO-ish timestamp.
@@ -124,6 +143,32 @@ def parse_sections(body: str | None) -> dict[str, str]:
     return sections
 
 
+def _ai_analysis_span(lines: list[str]) -> tuple[int, int] | None:
+    """``(start, end)`` line range of the AI analysis section, heading included.
+
+    The end is the next heading that names a *form* section. Stopping at any
+    heading would cut the section short, because generated analyses carry their
+    own — "### Root cause" is the same answer continuing, not the next field.
+    Getting that wrong leaves half the analysis outside the fold and, worse,
+    inside the text a report is ranked on.
+
+    Shared by the fold and the strip so the two cannot disagree about where the
+    section ends.
+    """
+    start = None
+    for i, line in enumerate(lines):
+        heading = _RE_SECTION.match(line)
+        if heading is None:
+            continue
+        name = heading.group(1).strip()
+        if start is None:
+            if name == SECTION_AI_ANALYSIS:
+                start = i
+        elif name in FORM_SECTIONS:
+            return start, i
+    return (start, len(lines)) if start is not None else None
+
+
 def _is_unranked_heading(name: str | None) -> bool:
     """True for a section kept out of the text a report is ranked on."""
     return (name or "").strip().lower().startswith(UNRANKED_SECTION_PREFIXES)
@@ -146,9 +191,15 @@ def strip_boilerplate(body: str | None) -> str:
     """
     if not body:
         return ""
+    lines = body.splitlines()
+    # Removed first and whole: its own sub-headings would otherwise end the drop
+    # early and let the rest of the analysis through.
+    span = _ai_analysis_span(lines)
+    if span is not None:
+        lines = lines[: span[0]] + lines[span[1] :]
     kept: list[str] = []
     dropping = False
-    for line in body.splitlines():
+    for line in lines:
         heading = _RE_SECTION.match(line)
         if heading:
             dropping = _is_unranked_heading(heading.group(1))
@@ -205,6 +256,45 @@ def form_replaced(body: str | None, kind: str = "main") -> bool:
         return False
     required = required_sections_for(kind)
     return len(missing_sections(body, kind)) == len(required)
+
+
+def wrap_ai_analysis(body: str | None) -> str | None:
+    """Collapse the AI analysis section behind a disclosure, in place.
+
+    Returns the rewritten body, or ``None`` when there is nothing to do — no
+    such section, nothing in it, or it is wrapped already. That last case is
+    what keeps this from running twice: rewriting the body re-triggers triage,
+    and the second pass has to be a no-op rather than nesting another layer.
+
+    Only the markup around the section changes. The reporter's words are moved,
+    not edited.
+    """
+    if not body:
+        return None
+    lines = body.splitlines()
+    span = _ai_analysis_span(lines)
+    if span is None:
+        return None
+    start, end = span
+    inner = "\n".join(lines[start + 1 : end]).strip("\n")
+    # A body already folded, or hand-edited into broken markup the bot would
+    # otherwise keep trying to re-fold around.
+    if not inner or inner == config.NO_RESPONSE_SENTINEL:
+        return None
+    if "<details" in inner or "</details>" in inner:
+        return None
+    wrapped = [
+        lines[start],
+        "",
+        "<details>",
+        f"<summary>{AI_ANALYSIS_SUMMARY}</summary>",
+        "",
+        inner,
+        "",
+        "</details>",
+        "",
+    ]
+    return "\n".join(lines[:start] + wrapped + lines[end:])
 
 
 def extract_version(body: str | None) -> str | None:

--- a/.github/scripts/ma_triage/template.py
+++ b/.github/scripts/ma_triage/template.py
@@ -30,6 +30,7 @@ SECTION_DIAGNOSTICS = "Diagnostics report or log file"
 SECTION_ANYTHING_ELSE = "Anything else?"
 SECTION_BROWSER_OS = "Browser and operating system"
 SECTION_SCREENSHOT = "Screenshot or recording"
+SECTION_AI_ANALYSIS = "AI analysis"
 
 # Required *text* sections per form (the attachment fields are validated
 # separately via attachments.py, since their content is a URL/upload).
@@ -56,11 +57,19 @@ PROVIDER_SCAN_SECTIONS = (
     SECTION_ANYTHING_ELSE,
 )
 
-# Consent sections, matched by lowercase heading *prefix* rather than in full.
-# Each has carried a markdown link whose URL changed at least once, and the
-# index reaches back to 2022, so four generations of the wording sit in it at
-# the same time. The prefix is the part that stayed put.
-CONSENT_SECTION_PREFIXES = (
+# Sections dropped before a report is ranked or embedded, matched by lowercase
+# heading *prefix* rather than in full: each consent heading has carried a
+# markdown link whose URL changed at least once, and the index reaches back to
+# 2022, so four generations of the wording sit in it at the same time. The
+# prefix is the part that stayed put.
+#
+# The AI analysis field is here for a different reason. It is the reporter's
+# own investigation and a maintainer should read it, but it is speculative
+# prose about causes, and two unrelated reports that both theorise about a race
+# in a provider's event handling look far more alike to a retriever than their
+# symptoms do. Ranking on it would undo what dropping the consent block bought.
+UNRANKED_SECTION_PREFIXES = (
+    SECTION_AI_ANALYSIS.lower(),
     "before you begin",
     "carefully read the troubleshooting faq",
     "mandatory: carefully read",
@@ -115,9 +124,9 @@ def parse_sections(body: str | None) -> dict[str, str]:
     return sections
 
 
-def _is_consent_heading(name: str | None) -> bool:
-    """True for a heading that introduces the form's consent block."""
-    return (name or "").strip().lower().startswith(CONSENT_SECTION_PREFIXES)
+def _is_unranked_heading(name: str | None) -> bool:
+    """True for a section kept out of the text a report is ranked on."""
+    return (name or "").strip().lower().startswith(UNRANKED_SECTION_PREFIXES)
 
 
 def strip_boilerplate(body: str | None) -> str:
@@ -126,9 +135,11 @@ def strip_boilerplate(body: str | None) -> str:
 
     The consent block and its checkboxes are identical across nearly every
     issue, so ranking one report against another spends most of the body field
-    comparing the form to itself. Headings and fenced blocks are deliberately
-    kept: an error string is often the only thing that makes two reports the
-    same, and dropping either measurably costs recall.
+    comparing the form to itself. The AI analysis field is dropped for the
+    opposite reason: it is unique to each report but speculative about causes,
+    which makes unrelated reports resemble each other. Headings and fenced
+    blocks are deliberately kept: an error string is often the only thing that
+    makes two reports the same, and dropping either measurably costs recall.
 
     For lexical ranking only. The embedded text is deliberately left alone —
     see :func:`embeddings.build_posts_index`.
@@ -140,7 +151,7 @@ def strip_boilerplate(body: str | None) -> str:
     for line in body.splitlines():
         heading = _RE_SECTION.match(line)
         if heading:
-            dropping = _is_consent_heading(heading.group(1))
+            dropping = _is_unranked_heading(heading.group(1))
         if dropping:
             continue
         kept.append(line)
@@ -224,9 +235,14 @@ def detect_log_wall(body: str | None) -> bool:
 
     Triggers on either a long fenced code block or many consecutive log-looking
     lines. Used to gently ask the reporter to attach the file instead.
+
+    Reads the body without its unranked sections: the AI analysis field asks for
+    log interpretation in as many words, so quoting log lines there is the form
+    being followed, not a wall to nudge about.
     """
     if not body:
         return False
+    body = strip_boilerplate(body)
 
     # Count log-looking lines overall.
     log_lines = sum(1 for line in body.splitlines() if _RE_LOG_LINE.search(line))

--- a/.github/scripts/tests/test_main.py
+++ b/.github/scripts/tests/test_main.py
@@ -449,3 +449,55 @@ def test_gist_reaches_a_report_that_replaced_the_form(monkeypatch, fake_gh):
     own_headings = "# My bug\n\n## Environment\n\nMA 2.9.2, Docker\n\n## Detail\n\n" + "x" * 2000
     main.build_result(fake_gh, "t", own_headings, token="x")
     assert calls, "a report that replaced the form should still be condensed"
+
+
+def test_a_filled_ai_analysis_is_folded_on_the_issue(monkeypatch, fake_gh):
+    """The forms cannot collapse a field, so the disclosure is applied here."""
+    from ma_triage import template as tmpl
+
+    body = "### What happened?\n\nNo sound\n\n### AI analysis\n\nA cause."
+    edits = []
+    monkeypatch.setattr(type(fake_gh), "get_issue",
+                        lambda self, n: {"body": body}, raising=False)
+    monkeypatch.setattr(type(fake_gh), "set_issue_body",
+                        lambda self, n, b: edits.append(b), raising=False)
+    monkeypatch.setattr(main, "_resolve_labels", lambda gh, r: [])
+    main.apply_triage(fake_gh, 1, {"labels": [], "body": body},
+                      main.TriageResult(form_kind="main"))
+
+    assert len(edits) == 1
+    assert "<details>" in edits[0] and tmpl.AI_ANALYSIS_SUMMARY in edits[0]
+    assert "A cause." in edits[0]
+
+
+def test_the_fold_reads_the_body_back_before_rewriting_it(monkeypatch, fake_gh):
+    """Triage takes minutes; the copy it started with may already be stale.
+
+    Writing that one back would silently revert an edit the reporter made while
+    the run was in flight.
+    """
+    stale = "### What happened?\n\nTypo\n\n### AI analysis\n\nA cause."
+    fresh = "### What happened?\n\nFixed typo\n\n### AI analysis\n\nA cause."
+    edits = []
+    monkeypatch.setattr(type(fake_gh), "get_issue",
+                        lambda self, n: {"body": fresh}, raising=False)
+    monkeypatch.setattr(type(fake_gh), "set_issue_body",
+                        lambda self, n, b: edits.append(b), raising=False)
+    monkeypatch.setattr(main, "_resolve_labels", lambda gh, r: [])
+    main.apply_triage(fake_gh, 1, {"labels": [], "body": stale},
+                      main.TriageResult(form_kind="main"))
+
+    assert "Fixed typo" in edits[0] and "Typo\n" not in edits[0]
+
+
+def test_a_report_without_an_analysis_is_not_edited(monkeypatch, fake_gh):
+    body = "### What happened?\n\nNo sound"
+    edits = []
+    monkeypatch.setattr(type(fake_gh), "get_issue",
+                        lambda self, n: {"body": body}, raising=False)
+    monkeypatch.setattr(type(fake_gh), "set_issue_body",
+                        lambda self, n, b: edits.append(b), raising=False)
+    monkeypatch.setattr(main, "_resolve_labels", lambda gh, r: [])
+    main.apply_triage(fake_gh, 1, {"labels": [], "body": body},
+                      main.TriageResult(form_kind="main"))
+    assert edits == []

--- a/.github/scripts/tests/test_template.py
+++ b/.github/scripts/tests/test_template.py
@@ -258,3 +258,87 @@ def test_a_log_quoted_in_the_ai_analysis_is_not_a_log_wall():
     )
     assert template.detect_log_wall(f"### AI analysis\n\n{log}") is False
     assert template.detect_log_wall(f"### What happened?\n\n{log}") is True
+
+
+# --- folding the AI analysis behind a disclosure ------------------------------- #
+_WITH_ANALYSIS = (
+    "### What happened?\n\nNo sound\n\n"
+    "### AI analysis\n\nRace in the bridge manager.\n\n"
+    "### Anything else?\n\nNightly"
+)
+
+
+def test_wrap_ai_analysis_folds_only_that_section():
+    out = template.wrap_ai_analysis(_WITH_ANALYSIS)
+    assert "<details>" in out and template.AI_ANALYSIS_SUMMARY in out
+    assert "Race in the bridge manager." in out
+    # Everything around it is left exactly as the reporter wrote it.
+    assert "### What happened?\n\nNo sound" in out
+    assert out.count("<details>") == 1
+
+
+def test_wrap_ai_analysis_is_idempotent():
+    """The rewrite re-triggers triage, so the next pass has to change nothing."""
+    once = template.wrap_ai_analysis(_WITH_ANALYSIS)
+    assert template.wrap_ai_analysis(once) is None
+
+
+def test_wrap_ai_analysis_leaves_a_report_without_one_alone():
+    assert template.wrap_ai_analysis("### What happened?\n\nNo sound") is None
+    assert template.wrap_ai_analysis("### AI analysis\n\n_No response_") is None
+    assert template.wrap_ai_analysis("") is None
+    assert template.wrap_ai_analysis(None) is None
+
+
+def test_wrap_ai_analysis_handles_a_trailing_section():
+    """The field is last on the form, so end-of-body is the common case."""
+    out = template.wrap_ai_analysis("### What happened?\n\nNo sound\n\n### AI analysis\n\nA cause.")
+    assert out.rstrip().endswith("</details>")
+    assert "A cause." in out
+
+
+def test_a_folded_analysis_still_leaves_the_ranked_text_alone():
+    """Folding must not smuggle the section back into what we rank on."""
+    out = template.wrap_ai_analysis(_WITH_ANALYSIS)
+    stripped = template.strip_boilerplate(out)
+    assert "Race in the bridge manager." not in stripped
+    assert "No sound" in stripped and "Nightly" in stripped
+
+
+# Realistic generated output: it brings headings of its own.
+_WITH_SUBHEADINGS = (
+    "### What happened?\n\nSound cuts out after 30 seconds\n\n"
+    "### AI analysis\n\n"
+    "## Summary\nThe Sonos provider fails to renew its subscription.\n\n"
+    "### Root cause\nA race in `_handle_player_update`.\n\n"
+    "### Anything else?\n\nNightly"
+)
+
+
+def test_the_fold_covers_an_analysis_with_its_own_headings():
+    """Stopping at any heading folded the first paragraph and promoted the rest."""
+    out = template.wrap_ai_analysis(_WITH_SUBHEADINGS)
+    assert "## Summary" in out and "### Root cause" in out
+    assert out.index("<details>") < out.index("### Root cause")
+    assert out.index("### Root cause") < out.index("</details>")
+    # The form's own next section stays outside the disclosure.
+    assert out.index("</details>") < out.index("### Anything else?")
+
+
+def test_sub_headed_analysis_stays_out_of_the_ranked_text():
+    """The leak this closes: the section's own headings ended the drop early."""
+    stripped = template.strip_boilerplate(_WITH_SUBHEADINGS)
+    assert "Root cause" not in stripped
+    assert "_handle_player_update" not in stripped
+    assert "Sound cuts out after 30 seconds" in stripped and "Nightly" in stripped
+
+
+def test_the_fold_is_idempotent_with_sub_headings():
+    once = template.wrap_ai_analysis(_WITH_SUBHEADINGS)
+    assert template.wrap_ai_analysis(once) is None
+
+
+def test_a_half_broken_disclosure_is_left_alone():
+    """A hand-edit that mangles the markup must not be re-folded around."""
+    body = "### AI analysis\n\n</details>\n\nleftover text"
+    assert template.wrap_ai_analysis(body) is None

--- a/.github/scripts/tests/test_template.py
+++ b/.github/scripts/tests/test_template.py
@@ -207,3 +207,54 @@ def test_form_replaced_threshold_is_tunable(monkeypatch):
     """The floor is the knob to reach for during rollout, so it has to work."""
     monkeypatch.setattr(config, "FORM_REPLACED_MIN_CHARS", 10_000)
     assert template.form_replaced(_NO_FORM, "main") is False
+
+
+def test_ai_analysis_is_kept_out_of_the_ranked_text():
+    """Kept out of the lexical query and the stored excerpt.
+
+    It is unique per report but speculative about causes, so two unrelated
+    reports theorising about the same subsystem look alike to a retriever in a
+    way their actual symptoms do not. The embedded text is a separate decision,
+    documented on `embeddings.post_excerpt`, and is deliberately left whole.
+    """
+    body = (
+        "### What happened?\n\nAirPlay drops out mid-track\n\n"
+        "### AI analysis\n\nLikely a race condition in the provider's event "
+        "handling around _on_providers_updated and the bridge manager.\n\n"
+        "### Anything else?\n\nHappens nightly"
+    )
+    stripped = template.strip_boilerplate(body)
+    assert "AirPlay drops out mid-track" in stripped
+    assert "Happens nightly" in stripped
+    assert "race condition" not in stripped
+    assert "AI analysis" not in stripped
+
+
+def test_ai_analysis_is_not_scanned_for_providers():
+    """The deterministic provider scan reads only what the reporter answered.
+
+    A provider named in a generated analysis therefore carries no weight *here*.
+    The assessment model is still handed the raw body and may pick one up; this
+    covers the scan, not that path.
+    """
+    body = (
+        "### What happened?\n\nPlayback stops\n\n"
+        "### AI analysis\n\nThe Sonos provider is almost certainly at fault."
+    )
+    assert "Sonos" not in template.provider_scan_text(body)
+
+
+def test_optional_form_fields_do_not_enter_the_required_set():
+    """Adding an optional field must not make it something we demand."""
+    assert template.SECTION_AI_ANALYSIS not in template.REQUIRED_SECTIONS_MAIN
+    assert template.SECTION_AI_ANALYSIS not in template.REQUIRED_SECTIONS_FRONTEND
+
+
+def test_a_log_quoted_in_the_ai_analysis_is_not_a_log_wall():
+    """The field asks for log interpretation, so quoting a log there follows it."""
+    log = "\n".join(
+        f"2026-09-09 12:00:{i:02d} ERROR (MainThread) [ma] something failed"
+        for i in range(40)
+    )
+    assert template.detect_log_wall(f"### AI analysis\n\n{log}") is False
+    assert template.detect_log_wall(f"### What happened?\n\n{log}") is True

--- a/.github/scripts/tests/test_template.py
+++ b/.github/scripts/tests/test_template.py
@@ -1,6 +1,8 @@
 import re
 from pathlib import Path
 
+import pytest
+
 from ma_triage import config, template
 
 
@@ -189,18 +191,26 @@ def test_form_replaced_only_applies_to_the_main_form():
     assert template.form_replaced(_NO_FORM, "translation") is False
 
 
-def test_required_sections_match_the_form_that_ships():
-    """The constants claim to be kept in sync with the issue form by hand.
+@pytest.mark.parametrize(
+    ("required", "form_name"),
+    [
+        (template.REQUIRED_SECTIONS_MAIN, "1_bug_report.yml"),
+        (template.REQUIRED_SECTIONS_FRONTEND, "2_frontend_bug_report.yml"),
+    ],
+)
+def test_required_sections_match_the_form_that_ships(required, form_name):
+    """The constants claim to be kept in sync with the issue forms by hand.
 
     Nothing enforced that, and the risk changed with `form_replaced`: a stale
     heading used to mean a redundant "please fill this in", and now means every
-    correctly-filed report is told it bypassed the form. A one-word label edit
-    should fail here rather than in production.
+    correctly-filed report is told it bypassed the form and is chased for
+    answers it already gave. A one-word label edit should fail here rather than
+    in production — on either form.
     """
-    form = Path(__file__).resolve().parents[2] / "ISSUE_TEMPLATE" / "1_bug_report.yml"
+    form = Path(__file__).resolve().parents[2] / "ISSUE_TEMPLATE" / form_name
     labels = set(re.findall(r"^\s*label:\s*(.+?)\s*$", form.read_text(), re.M))
-    missing = [s for s in template.REQUIRED_SECTIONS_MAIN if s not in labels]
-    assert not missing, f"not in {form.name}: {missing}"
+    missing = [s for s in required if s not in labels]
+    assert not missing, f"not in {form_name}: {missing}"
 
 
 def test_form_replaced_threshold_is_tunable(monkeypatch):

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -44,9 +44,15 @@ jobs:
     # Gated at the job, not only in the script: with tracing off there is no
     # consumer for a traced path, and an ungated job would still pay for two
     # checkouts and a CLI install on every issue while `analyze` waited on it.
+    # The bot folds the AI analysis section into a `<details>` after triage,
+    # which is an `edited` event. Re-running on our own formatting change would
+    # double the most expensive pipeline here for no new information.
     if: >-
       ${{ vars.TRIAGE_CODE_TRACE_ENABLED == 'true'
       && vars.TRIAGE_AI_ENABLED == 'true'
+      && !(github.event_name == 'issues'
+      && github.event.action == 'edited'
+      && github.event.sender.type == 'Bot')
       && ((github.event_name == 'issues' && !github.event.issue.pull_request)
       || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
@@ -148,8 +154,13 @@ jobs:
     # cancelled mid-download, having applied no labels and left no comment.
     # This is a backstop against a hung job, not a target.
     timeout-minutes: 10
+    # See `trace`: our own fold arrives as an `edited` event and carries no new
+    # information to triage.
     if: >-
       ${{ !cancelled()
+      && !(github.event_name == 'issues'
+      && github.event.action == 'edited'
+      && github.event.sender.type == 'Bot')
       && ((github.event_name == 'issues' && !github.event.issue.pull_request)
       || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Reports written with an AI assistant paste its analysis into "What happened?", which buries the symptom that field exists to capture. There was nowhere else for it to go, so it went there.

Both forms now end with an optional **AI analysis** field. The description is written for two readers: the person filing, and the assistant they pasted the form into, which is how a good many of these are produced. Telling that assistant where its output belongs is the part most likely to change what arrives.

## Three parts

**The field.** Last on both forms, optional. Links the AI policy, but not as the closing sentence — that page is contributor-facing and ends on enforcement, and a first-time bug reporter should not land there as the last thing they read.

**It stays out of what we rank on.** `CONSENT_SECTION_PREFIXES` becomes `UNRANKED_SECTION_PREFIXES` and gains the new heading. The consent block is dropped from that text because it is identical across every report; this is dropped for the opposite reason — unique per report, but speculative about causes, and two unrelated reports that both theorise about a race in a provider's event handling look far more alike to a retriever than their symptoms do. The summariser reads the report without it too: the gist fires on long reports, which is what this field makes them, and a confident "the root cause is a race in the bridge manager" would outrank "sound cuts out after 30 seconds" in the three lines a maintainer reads first. Log-wall detection also reads it stripped — the field asks for log interpretation in as many words, so quoting a log there is the form being followed, not a wall to nudge about.

**The bot folds it.** An issue form cannot collapse a field: a pre-filled `<details>` in the field's default is submitted even when the field is left alone, so every report would carry an empty one. So the bot folds it after triage instead.

## Where the section ends

At the next heading that names a *form* section, not at any heading. Generated analyses bring headings of their own, and `### Root cause` is the same answer continuing rather than the next field. Stopping at the first of them folded one paragraph, promoted the rest to form-section level in the rendered issue, and left it in the ranked text. The fold and the strip share one span so the two cannot disagree about it.

## On the bot editing an issue body

This is the first time it does. Worth stating plainly:

- Only the markup around that one section moves. Nothing is inserted, removed or reworded, and the change is visible in the issue's edit history.
- The body is re-read immediately before the rewrite. Triage takes minutes, and writing back the copy the run started with would silently revert an edit the reporter made while it was in flight.
- `trace` and `analyze` skip an `edited` event raised by a bot. Without that, every fold re-ran the whole pipeline including the code trace, which is the most expensive job here and is budgeted at fifteen minutes.
- The fold runs last, because it is cosmetic and a failed request must not cost the labels and the sticky comment that are the bot's actual output.
- `update_issue(**fields)` — a generic issue PATCH reachable by `state`, `title` and `labels`, with one caller that only ever set the body — narrows to `set_issue_body`.
- `README.md` gains a line for it: body edits are a new class of mutation, and that file is what a maintainer reads to decide whether to leave this enabled.

## Also here

The form-sync guard now covers **both** forms. It read `1_bug_report.yml` by name, so `REQUIRED_SECTIONS_FRONTEND` was checked against nothing: renaming "Browser and operating system" to "Browser and OS" left every test passing while every correctly-filed frontend report started reporting a missing section — asking reporters for answers they had already given, applying `waiting-for-user`, and letting the sweep close them a fortnight later.

## Known gap, carried deliberately

Renaming the `AI analysis` label in either form silently disables both the fold and the stripping, and no test fails: the disclosure stops appearing and the analysis flows back into duplicate retrieval. Guarding it means asserting every `SECTION_*` the code depends on exists in some shipped form, which cannot be a strict two-way equality — `SECTION_DIAGNOSTICS` and `SECTION_SCREENSHOT` are validated in `attachments.py`, and the two forms carry different field sets. Not built here. The constants that matter are `SECTION_AI_ANALYSIS` in `template.py` and the `label:` in both form files.

## Test plan

`python -m pytest tests/` — 410 pass. New coverage for the fold (including an analysis carrying its own sub-headings, idempotence, trailing-section, and broken markup left alone), the section staying out of the ranked text, the re-read before rewriting, provider scanning skipping it, and the sync guard across both forms.
