### PR TITLE
Fold the whole analysis, not a fragment of it

### DIFF
--- a/.github/scripts/ma_triage/template.py
+++ b/.github/scripts/ma_triage/template.py
@@ -81,23 +81,6 @@ UNRANKED_SECTION_PREFIXES = (
     "have you reviewed the",
 )
 
-# Every heading the current forms emit. The AI analysis section ends at one of
-# these and not at any heading, because generated prose brings headings of its
-# own — "### Root cause" is the reporter's answer continuing, not a new field.
-FORM_SECTIONS = frozenset(
-    {
-        SECTION_WHAT_HAPPENED,
-        SECTION_HOW_TO_REPRODUCE,
-        SECTION_VERSION,
-        SECTION_INSTALL_METHOD,
-        SECTION_DIAGNOSTICS,
-        SECTION_ANYTHING_ELSE,
-        SECTION_BROWSER_OS,
-        SECTION_SCREENSHOT,
-        SECTION_AI_ANALYSIS,
-    }
-)
-
 _RE_SECTION = re.compile(r"^###\s+(.*?)\s*$")
 _RE_CHECKBOX = re.compile(r"^\s*[-*]\s*\[[ xX]\].*$", re.MULTILINE)
 # A line that looks like a log line: has a level keyword or an ISO-ish timestamp.
@@ -146,27 +129,25 @@ def parse_sections(body: str | None) -> dict[str, str]:
 def _ai_analysis_span(lines: list[str]) -> tuple[int, int] | None:
     """``(start, end)`` line range of the AI analysis section, heading included.
 
-    The end is the next heading that names a *form* section. Stopping at any
-    heading would cut the section short, because generated analyses carry their
-    own — "### Root cause" is the same answer continuing, not the next field.
-    Getting that wrong leaves half the analysis outside the fold and, worse,
-    inside the text a report is ranked on.
+    It runs to the end of the body, because the field is last on both forms and
+    everything after its heading is therefore its content. No heading ends it.
 
-    Shared by the fold and the strip so the two cannot disagree about where the
-    section ends.
+    Any heading-based boundary can be fed a heading. Ending at the next *form*
+    section skipped a pasted "### Before you begin" — a real form heading, but
+    not one of the fields — and cut the section off at the "### What happened?"
+    below it, so half a reporter's pasted form was folded and the rest was
+    promoted back to top level. Reporters do paste whole filled-in forms into
+    this box; the boundary has to hold when they do.
+
+    `test_the_ai_analysis_field_is_last_on_every_form` enforces the assumption.
+
+    Shared by the fold and the strip so the two cannot disagree about it.
     """
-    start = None
     for i, line in enumerate(lines):
         heading = _RE_SECTION.match(line)
-        if heading is None:
-            continue
-        name = heading.group(1).strip()
-        if start is None:
-            if name == SECTION_AI_ANALYSIS:
-                start = i
-        elif name in FORM_SECTIONS:
-            return start, i
-    return (start, len(lines)) if start is not None else None
+        if heading is not None and heading.group(1).strip() == SECTION_AI_ANALYSIS:
+            return i, len(lines)
+    return None
 
 
 def _is_unranked_heading(name: str | None) -> bool:

--- a/.github/scripts/tests/test_template.py
+++ b/.github/scripts/tests/test_template.py
@@ -229,9 +229,9 @@ def test_ai_analysis_is_kept_out_of_the_ranked_text():
     """
     body = (
         "### What happened?\n\nAirPlay drops out mid-track\n\n"
+        "### Anything else?\n\nHappens nightly\n\n"
         "### AI analysis\n\nLikely a race condition in the provider's event "
-        "handling around _on_providers_updated and the bridge manager.\n\n"
-        "### Anything else?\n\nHappens nightly"
+        "handling around _on_providers_updated and the bridge manager."
     )
     stripped = template.strip_boilerplate(body)
     assert "AirPlay drops out mid-track" in stripped
@@ -273,8 +273,8 @@ def test_a_log_quoted_in_the_ai_analysis_is_not_a_log_wall():
 # --- folding the AI analysis behind a disclosure ------------------------------- #
 _WITH_ANALYSIS = (
     "### What happened?\n\nNo sound\n\n"
-    "### AI analysis\n\nRace in the bridge manager.\n\n"
-    "### Anything else?\n\nNightly"
+    "### Anything else?\n\nNightly\n\n"
+    "### AI analysis\n\nRace in the bridge manager."
 )
 
 
@@ -285,6 +285,7 @@ def test_wrap_ai_analysis_folds_only_that_section():
     # Everything around it is left exactly as the reporter wrote it.
     assert "### What happened?\n\nNo sound" in out
     assert out.count("<details>") == 1
+    assert out.index("### What happened?") < out.index("<details>")
 
 
 def test_wrap_ai_analysis_is_idempotent():
@@ -318,10 +319,10 @@ def test_a_folded_analysis_still_leaves_the_ranked_text_alone():
 # Realistic generated output: it brings headings of its own.
 _WITH_SUBHEADINGS = (
     "### What happened?\n\nSound cuts out after 30 seconds\n\n"
+    "### Anything else?\n\nNightly\n\n"
     "### AI analysis\n\n"
     "## Summary\nThe Sonos provider fails to renew its subscription.\n\n"
-    "### Root cause\nA race in `_handle_player_update`.\n\n"
-    "### Anything else?\n\nNightly"
+    "### Root cause\nA race in `_handle_player_update`."
 )
 
 
@@ -331,8 +332,8 @@ def test_the_fold_covers_an_analysis_with_its_own_headings():
     assert "## Summary" in out and "### Root cause" in out
     assert out.index("<details>") < out.index("### Root cause")
     assert out.index("### Root cause") < out.index("</details>")
-    # The form's own next section stays outside the disclosure.
-    assert out.index("</details>") < out.index("### Anything else?")
+    # The sections the reporter actually answered stay outside it.
+    assert out.index("### Anything else?") < out.index("<details>")
 
 
 def test_sub_headed_analysis_stays_out_of_the_ranked_text():
@@ -352,3 +353,50 @@ def test_a_half_broken_disclosure_is_left_alone():
     """A hand-edit that mangles the markup must not be re-folded around."""
     body = "### AI analysis\n\n</details>\n\nleftover text"
     assert template.wrap_ai_analysis(body) is None
+
+
+# Reporters do paste a whole filled-in form into the AI analysis box — asking an
+# assistant to fill the form, then pasting all of it into one field. #6392.
+_PASTED_WHOLE_FORM = (
+    "### Before you begin\n\n- [x] I have searched the issues.\n\n"
+    "### What happened?\n\nMilkdrop crashes\n\n"
+    "### How to reproduce\n\nOpen it\n\n"
+    "### Music Assistant version\n\n2.10.1\n\n"
+    "### AI analysis\n\n"
+    "### Before you begin\n\n- [x] I have searched the issues.\n\n"
+    "### What happened?\n\nMilkdrop crashes\n\n"
+    "### How to reproduce\n\nOpen it\n"
+)
+
+
+def test_a_pasted_form_inside_the_analysis_folds_whole():
+    """Ending the span at a heading let a pasted form escape the disclosure.
+
+    Half of it was folded and the rest promoted back to top level, so the report
+    read as though it contained the form twice.
+    """
+    out = template.wrap_ai_analysis(_PASTED_WHOLE_FORM)
+    assert out.count("<details>") == 1 and out.count("</details>") == 1
+    # Nothing from the pasted copy escapes the disclosure.
+    tail = out[out.index("</details>") :]
+    assert "### What happened?" not in tail
+    assert "### Before you begin" not in tail
+    # And nothing is lost.
+    assert out.count("Milkdrop crashes") == _PASTED_WHOLE_FORM.count("Milkdrop crashes")
+
+
+def test_a_pasted_form_inside_the_analysis_stays_unranked():
+    stripped = template.strip_boilerplate(_PASTED_WHOLE_FORM)
+    assert stripped.count("Milkdrop crashes") == 1, "only the real answer is ranked"
+
+
+def test_the_ai_analysis_field_is_last_on_every_form():
+    """The span runs to the end of the body, which only holds while it is last."""
+    forms = (Path(__file__).resolve().parents[2] / "ISSUE_TEMPLATE").glob("*_*.yml")
+    for form in forms:
+        labels = re.findall(r"^\s*label:\s*(.+?)\s*$", form.read_text(), re.M)
+        if template.SECTION_AI_ANALYSIS in labels:
+            assert labels[-1] == template.SECTION_AI_ANALYSIS, (
+                f"{form.name}: '{template.SECTION_AI_ANALYSIS}' must stay the last "
+                "field — `_ai_analysis_span` folds everything after it"
+            )


### PR DESCRIPTION
Fixes the fold on #6392.

## What happened

The reporter asked an assistant to fill in the bug form, then pasted the whole filled-in form into the **AI analysis** box. The fold wrapped the first few lines of that paste and left the rest outside the disclosure, where its headings sat at form-section level — so the report read as though it contained the form twice.

**Nothing was duplicated or lost.** Both copies were in the body before the bot touched it; the edit history shows the reporter at 22:13:16 and the bot at 22:15:10, and the content is byte-identical either side. What the fold did was make a reporter's own paste look like our restructuring of their report, which is the one thing an edit to someone's issue body must never do.

## Cause

`_ai_analysis_span` ended at the next heading naming a form *field*. `### Before you begin` is a real form heading but not one of the fields, so the scan stepped straight over it and stopped at the `### What happened?` below it — partway through the pasted copy.

Any heading-based boundary can be handed a heading, and this box is precisely where reporters paste them.

## Fix

The span runs to the end of the body. The field is last on both forms, so everything after its heading is its content, and there is no boundary left to fool.

`test_the_ai_analysis_field_is_last_on_every_form` fails if a later change puts a field after it, since that is the assumption the rule rests on.

Replayed against the real #6392 body: the whole pasted form folds inside the disclosure, no heading escapes it, and the content is preserved exactly.

## Note on the tests

Three fixtures placed `### Anything else?` after the analysis, which no shipped form does. That ordering is what let the old boundary look correct in tests while failing on a real report. Reordered to match the forms.

## Test plan

`python -m pytest tests/` — 413 pass, including a fixture reproducing #6392's shape: a whole form pasted inside the field, asserted to fold entire, leave nothing at top level, lose nothing, and contribute only the real answer to the ranked text.

## After merge

#6392's body is still in the half-folded state. A `workflow_dispatch` re-triage on that issue number will re-fold it correctly.
